### PR TITLE
feat: add aidev doctor with ollama auto-spawn and interactive first-pull consent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A local, multi-agent coding assistant TUI written in Go. Feed it a GitHub issue; it runs a tiered agent pipeline — small local models for extractive work, large cloud models for deep reasoning — and hands you a defensible recommendation before a single line of code is written.
 
-> **Status:** v0.2a — Scout + Critic + Architect. Implementer, Tester, Reviewer are on the roadmap.
+> **Status:** v0.2b — Scout + Critic + Architect + `aidev doctor`. Implementer, Tester, Reviewer are on the roadmap.
 
 ## Why
 
@@ -37,8 +37,14 @@ Model routing is declarative (`config/models.yaml`): each role is mapped to a na
 ```sh
 go build -o aidev ./cmd/aidev
 
+# Audit the environment before doing any real work (config, Anthropic key,
+# Ollama daemon, required models). Exits 1 on any FAIL.
+./aidev doctor
+
 # TUI mode — three panes: issue, scout brief, critic report (rightmost pane
 # retitles to "Architect sketches" once the Architect has produced output).
+# On startup, aidev runs the doctor automatically. In an interactive terminal
+# it will offer to auto-spawn Ollama and pull/swap missing models.
 ./aidev -issue https://github.com/owner/repo/issues/42 -repo ../owner-repo
 
 # Override the Architect's sketch count (default 3)
@@ -50,7 +56,43 @@ go build -o aidev ./cmd/aidev
 # Headless mode with auto-architect — if Critic says "build", automatically
 # run the Architect and print sketches too. Useful in CI.
 ./aidev -headless -auto -n 3 -issue ... -repo ...
+
+# Bypass the startup doctor (not recommended; use when you manage the
+# environment yourself and want to save a few hundred ms on cold start)
+./aidev -skip-doctor -issue ... -repo ...
 ```
+
+## Doctor
+
+`aidev doctor` is a precondition audit that runs automatically on every `aidev` invocation (unless you pass `-skip-doctor`). It checks:
+
+| Check | Fails when | Fix |
+|---|---|---|
+| `config` | `models.yaml` missing tiers or routing | edit `config/models.yaml` |
+| `anthropic-key` | a role routes to an anthropic tier but `ANTHROPIC_API_KEY` is unset | `export ANTHROPIC_API_KEY=sk-ant-...` |
+| `ollama-binary` | any role routes to ollama but the `ollama` CLI isn't on PATH | install from ollama.com |
+| `ollama-daemon` | binary present but `/api/tags` unreachable | aidev will offer to run `ollama serve` in the background (interactive TTY only) |
+| `ollama-models` | required models aren't pulled | aidev will offer to **pull**, **swap to an installed model**, or **abort** (interactive TTY only) |
+
+In headless/CI mode the doctor never prompts — it reports and fails fast, so you know exactly what to fix. Run `aidev doctor` explicitly to get the full report and a zero/non-zero exit code for a CI gate.
+
+### First-pull consent
+
+aidev will never silently download a multi-GB model. When a required model is missing, you'll see:
+
+```
+Ollama model "qwen2.5-coder:7b" is required but not installed.
+
+  [1] Pull qwen2.5-coder:7b now (multi-GB download, requires network)
+  [2] Swap to one of your already-installed models
+  [3] Abort — aidev cannot run without a model for this tier
+
+Choice [1/2/3]:
+```
+
+Choosing `2` lists the models already pulled on your Ollama daemon and swaps the routing in-memory for the current run. To make the swap permanent, edit `config/models.yaml` to reference your chosen model.
+
+The Ollama daemon lifecycle is **not owned by aidev** — if we spawn it, it persists after aidev exits so we don't interfere with other things that use it.
 
 ## TUI keybindings
 
@@ -111,8 +153,8 @@ Sketches are Markdown only — no code. The Implementer (v0.3) is what writes co
 
 ## Roadmap
 
-- **v0.2a** *(this release)* — Architect agent with N divergent sketches, `-n` flag, cost preview.
-- **v0.2b** — `aidev doctor` + Ollama auto-spawn + first-pull consent.
+- **v0.2a** — Architect agent with N divergent sketches, `-n` flag, cost preview. *(shipped)*
+- **v0.2b** *(this release)* — `aidev doctor` + Ollama auto-spawn + first-pull consent with alternative-model offering.
 - **v0.2c** — Charter agent + `.aidev/charter.md` + interview flow for repos without a clear stated purpose.
 - **v0.3** — Implementer + Tester in an isolated git worktree + container, with full-coverage tests gating completion. Adaptive dialogue (dependency-aware question graphs).
 - **v0.4** — Reviewer + Boy Scout pass; auto-open follow-up issues for out-of-scope improvements.
@@ -121,7 +163,7 @@ Sketches are Markdown only — no code. The Implementer (v0.3) is what writes co
 ## Layout
 
 ```
-cmd/aidev/              entry point and flag handling
+cmd/aidev/              entry point, flag handling, doctor subcommand
 internal/config/        YAML loader for models + principles
 internal/llm/           Provider interface, Ollama + Claude backends, Router
 internal/github/        REST client for fetching issues
@@ -129,5 +171,6 @@ internal/repo/          Repo scanner + repo-local principle loader
 internal/agents/        Scout, Critic, Architect agents (shared Context)
 internal/orchestrator/  State machine that drives the pipeline
 internal/tui/           Bubble Tea model, update, view, keybindings
+internal/doctor/        Precondition checks: config, keys, Ollama daemon/models
 config/                 Shipped defaults: models.yaml, principles.yaml
 ```

--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -8,6 +8,11 @@
 // v0.2a adds the Architect: once the Critic recommends "build" and the
 // human approves, the Architect produces N divergent solution sketches for
 // the developer to pick from before the Implementer (v0.3) writes any code.
+//
+// v0.2b adds `aidev doctor` and automatic precondition checking on startup:
+// Ollama binary presence, daemon health (auto-spawned when missing),
+// required models (with an interactive pull/swap/abort prompt), plus
+// config and Anthropic key validation.
 package main
 
 import (
@@ -21,18 +26,28 @@ import (
 
 	"github.com/aisu-ai/aidev/internal/agents"
 	"github.com/aisu-ai/aidev/internal/config"
+	"github.com/aisu-ai/aidev/internal/doctor"
 	"github.com/aisu-ai/aidev/internal/orchestrator"
 	"github.com/aisu-ai/aidev/internal/tui"
 )
 
 func main() {
+	// Intercept the `doctor` subcommand before flag parsing so it can
+	// share the normal config discovery but not require -issue/-repo.
+	if len(os.Args) > 1 && os.Args[1] == "doctor" {
+		os.Args = append(os.Args[:1], os.Args[2:]...)
+		runDoctorSubcommand()
+		return
+	}
+
 	var (
-		issueURL  = flag.String("issue", "", "GitHub issue URL (https://github.com/owner/repo/issues/123)")
-		repoPath  = flag.String("repo", ".", "Path to the target repository")
-		configDir = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
-		headless  = flag.Bool("headless", false, "Run the full pipeline once and print the report to stdout without the TUI")
-		sketchN   = flag.Int("n", agents.DefaultSketchCount, "Number of Architect sketches to produce when the Critic recommends 'build'")
-		autoRun   = flag.Bool("auto", false, "Headless only: automatically run the Architect when the Critic recommends 'build' (otherwise stop at Critic)")
+		issueURL    = flag.String("issue", "", "GitHub issue URL (https://github.com/owner/repo/issues/123)")
+		repoPath    = flag.String("repo", ".", "Path to the target repository")
+		configDir   = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
+		headless    = flag.Bool("headless", false, "Run the full pipeline once and print the report to stdout without the TUI")
+		sketchN     = flag.Int("n", agents.DefaultSketchCount, "Number of Architect sketches to produce when the Critic recommends 'build'")
+		autoRun     = flag.Bool("auto", false, "Headless only: automatically run the Architect when the Critic recommends 'build' (otherwise stop at Critic)")
+		skipDoctor  = flag.Bool("skip-doctor", false, "Skip the startup precondition check (not recommended)")
 	)
 	flag.Parse()
 
@@ -40,27 +55,23 @@ func main() {
 		fatal("missing required flag: -issue")
 	}
 
-	cfgDir := *configDir
-	if cfgDir == "" {
-		cfgDir = os.Getenv("AIDEV_CONFIG")
-	}
-	if cfgDir == "" {
-		// Prefer config relative to the binary location so `aidev` works
-		// from any CWD after installation.
-		if exe, err := os.Executable(); err == nil {
-			candidate := filepath.Join(filepath.Dir(exe), "config")
-			if _, err := os.Stat(candidate); err == nil {
-				cfgDir = candidate
-			}
-		}
-	}
-	if cfgDir == "" {
-		cfgDir = "config"
-	}
+	cfg := mustLoadConfig(*configDir)
 
-	cfg, err := config.Load(cfgDir)
-	if err != nil {
-		fatal(fmt.Sprintf("load config: %v", err))
+	// Precondition audit. In headless mode the doctor never prompts —
+	// it just reports and either fails or passes. In TTY mode we enable
+	// auto-spawn and interactive fixes so the user can resolve a missing
+	// daemon or missing model without leaving the program.
+	if !*skipDoctor {
+		opts := doctor.Options{
+			Interactive:     !*headless && doctor.IsTTY(),
+			AutoSpawnOllama: !*headless && doctor.IsTTY(),
+			Out:             os.Stderr,
+		}
+		report := doctor.Run(context.Background(), cfg, opts)
+		if report.HasFailure() {
+			report.Write(os.Stderr)
+			fatal("precondition checks failed — run `aidev doctor` for details")
+		}
 	}
 
 	orch, err := orchestrator.New(cfg, orchestrator.WithSketchCount(*sketchN))
@@ -90,6 +101,56 @@ func main() {
 	if _, err := p.Run(); err != nil {
 		fatal(fmt.Sprintf("tui: %v", err))
 	}
+}
+
+// runDoctorSubcommand handles `aidev doctor`. It always runs non-interactive
+// (no auto-spawn, no prompts) and prints the full report. Exit code is 0
+// when there are no FAILs, 1 otherwise.
+func runDoctorSubcommand() {
+	var (
+		configDir = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
+	)
+	flag.Parse()
+
+	cfg := mustLoadConfig(*configDir)
+
+	opts := doctor.Options{
+		Interactive:     false,
+		AutoSpawnOllama: false,
+		Out:             os.Stderr,
+	}
+	report := doctor.Run(context.Background(), cfg, opts)
+	report.Write(os.Stdout)
+	if report.HasFailure() {
+		os.Exit(1)
+	}
+}
+
+// mustLoadConfig resolves the config directory from flag, env var, and
+// binary-relative defaults, then loads it or fatals.
+func mustLoadConfig(configDir string) *config.Config {
+	if configDir == "" {
+		configDir = os.Getenv("AIDEV_CONFIG")
+	}
+	if configDir == "" {
+		// Prefer config relative to the binary so `aidev` works from any
+		// CWD after installation.
+		if exe, err := os.Executable(); err == nil {
+			candidate := filepath.Join(filepath.Dir(exe), "config")
+			if _, err := os.Stat(candidate); err == nil {
+				configDir = candidate
+			}
+		}
+	}
+	if configDir == "" {
+		configDir = "config"
+	}
+
+	cfg, err := config.Load(configDir)
+	if err != nil {
+		fatal(fmt.Sprintf("load config: %v", err))
+	}
+	return cfg
 }
 
 // runHeadless is a CI-friendly mode that produces a single Markdown report

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-isatty v0.0.21 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQ
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.21 h1:xYae+lCNBP7QuW4PUnNG61ffM4hVIfm+zUzDuSzYLGs=
+github.com/mattn/go-isatty v0.0.21/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=

--- a/internal/doctor/config.go
+++ b/internal/doctor/config.go
@@ -1,0 +1,99 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aisu-ai/aidev/internal/config"
+)
+
+// checkConfig validates that the loaded config has at least one tier and
+// that every routed role has a backing provider. Most of this is already
+// validated by config.Load, so this check is a belt-and-suspenders report
+// rather than a gate — if the config is broken we wouldn't have gotten this
+// far.
+func checkConfig(cfg *config.Config) Result {
+	r := Result{Name: "config"}
+	if cfg == nil {
+		r.Severity = FAIL
+		r.Message = "config not loaded"
+		r.Remediation = "check AIDEV_CONFIG env var or ./config directory"
+		return r
+	}
+	if len(cfg.Models.Tiers) == 0 {
+		r.Severity = FAIL
+		r.Message = "no model tiers defined"
+		r.Remediation = "add at least one tier to config/models.yaml"
+		return r
+	}
+	if len(cfg.Models.Routing) == 0 {
+		r.Severity = FAIL
+		r.Message = "no agent routing defined"
+		r.Remediation = "add role -> tier mappings to config/models.yaml"
+		return r
+	}
+	if len(cfg.Principles.Principles) == 0 {
+		r.Severity = WARN
+		r.Message = "no principles loaded — Critic will have nothing to cite"
+		r.Remediation = "add at least one principle to config/principles.yaml"
+		return r
+	}
+	r.Severity = OK
+	r.Message = "config loaded from " + cfg.ConfigDir
+	r.Details = append(r.Details,
+		numTiersDetail(len(cfg.Models.Tiers)),
+		numRolesDetail(len(cfg.Models.Routing)),
+		numPrinciplesDetail(len(cfg.Principles.Principles)),
+	)
+	return r
+}
+
+// checkAnthropicKey reports whether the ANTHROPIC_API_KEY env var is set.
+// It is only a FAIL if the current routing actually sends some role to an
+// anthropic-typed tier — otherwise it's a WARN (the user might be running
+// a fully local setup and not need the key).
+func checkAnthropicKey(cfg *config.Config) Result {
+	r := Result{Name: "anthropic-key"}
+	needsKey := false
+	for role, tierName := range cfg.Models.Routing {
+		tier, ok := cfg.Models.Tiers[tierName]
+		if !ok {
+			continue
+		}
+		if tier.Provider == "anthropic" {
+			needsKey = true
+			r.Details = append(r.Details, "role "+role+" -> tier "+tierName+" (anthropic)")
+		}
+	}
+	key := os.Getenv("ANTHROPIC_API_KEY")
+	if key == "" {
+		if needsKey {
+			r.Severity = FAIL
+			r.Message = "ANTHROPIC_API_KEY not set, but one or more roles route to an anthropic tier"
+			r.Remediation = "export ANTHROPIC_API_KEY=sk-ant-... (or swap the anthropic tiers to local providers)"
+		} else {
+			r.Severity = WARN
+			r.Message = "ANTHROPIC_API_KEY not set"
+			r.Remediation = "harmless if your routing stays local-only"
+		}
+		return r
+	}
+	r.Severity = OK
+	r.Message = "ANTHROPIC_API_KEY present"
+	if !needsKey {
+		r.Details = append(r.Details, "no roles currently route to an anthropic tier")
+	}
+	return r
+}
+
+// small helpers keep Details strings DRY without a formatter.
+func numTiersDetail(n int) string      { return plural(n, "tier", "tiers") + " defined" }
+func numRolesDetail(n int) string      { return plural(n, "role", "roles") + " routed" }
+func numPrinciplesDetail(n int) string { return plural(n, "principle", "principles") + " loaded" }
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return "1 " + one
+	}
+	return fmt.Sprintf("%d %s", n, many)
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,171 @@
+// Package doctor runs a precondition audit of aidev's environment: config
+// validity, required secrets, local model daemon health, and required
+// models. It powers two entry points:
+//
+//   - `aidev doctor` — prints a full report and exits; never prompts.
+//   - automatic precondition runs on normal `aidev -issue ...` startup,
+//     which can prompt for interactive fixes (spawn Ollama, pull a model,
+//     swap to an alternative) when stdin is a TTY.
+//
+// The package is deliberately separated from the orchestrator so that doctor
+// can be invoked with only a config, without building the full agent graph.
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/aisu-ai/aidev/internal/config"
+)
+
+// Severity classifies a check result. OK passes silently in auto mode;
+// WARN is printed but not blocking; FAIL blocks the pipeline.
+type Severity int
+
+const (
+	OK Severity = iota
+	WARN
+	FAIL
+)
+
+// String gives the human label for a severity.
+func (s Severity) String() string {
+	switch s {
+	case OK:
+		return "OK"
+	case WARN:
+		return "WARN"
+	case FAIL:
+		return "FAIL"
+	}
+	return "?"
+}
+
+// Result is a single check's outcome.
+type Result struct {
+	Name        string   // short identifier: "config", "ollama-daemon", "anthropic-key"
+	Severity    Severity
+	Message     string   // one-line summary shown in the report
+	Remediation string   // what the user can do to fix this (empty for OK)
+	Details     []string // optional extra lines printed under the summary
+}
+
+// Format renders a Result as a single multi-line block suitable for a TTY
+// report. Format is pure so it can be unit-tested.
+func (r Result) Format() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "[%s] %s — %s\n", r.Severity, r.Name, r.Message)
+	for _, d := range r.Details {
+		fmt.Fprintf(&b, "      %s\n", d)
+	}
+	if r.Remediation != "" && r.Severity != OK {
+		fmt.Fprintf(&b, "      fix: %s\n", r.Remediation)
+	}
+	return b.String()
+}
+
+// Report is the outcome of a full diagnostic run.
+type Report struct {
+	Results []Result
+}
+
+// Any returns true if any result matches the given severity.
+func (r Report) Any(sev Severity) bool {
+	for _, res := range r.Results {
+		if res.Severity == sev {
+			return true
+		}
+	}
+	return false
+}
+
+// HasFailure is a convenience for callers that only care whether the
+// pipeline should abort.
+func (r Report) HasFailure() bool { return r.Any(FAIL) }
+
+// Write renders the whole report to w with a trailing summary line.
+func (r Report) Write(w io.Writer) {
+	for _, res := range r.Results {
+		fmt.Fprint(w, res.Format())
+	}
+	ok, warn, fail := 0, 0, 0
+	for _, res := range r.Results {
+		switch res.Severity {
+		case OK:
+			ok++
+		case WARN:
+			warn++
+		case FAIL:
+			fail++
+		}
+	}
+	fmt.Fprintf(w, "\nsummary: %d ok, %d warn, %d fail\n", ok, warn, fail)
+}
+
+// Options configures a doctor run.
+type Options struct {
+	// Interactive enables prompts for fixable problems. When false, the
+	// doctor only reports — it never blocks waiting for input. Set to
+	// false in CI, headless, and `aidev doctor` invocations; set to true
+	// in normal interactive startup.
+	Interactive bool
+
+	// AutoSpawnOllama enables the "start the daemon if the binary exists
+	// but the daemon is unreachable" behaviour. Harmless when false; the
+	// check just reports the daemon as unreachable.
+	AutoSpawnOllama bool
+
+	// Prompter is the function used to read user input during interactive
+	// fixes. Exposed as a field so tests can inject a deterministic
+	// answerer. Defaults to a stdin reader when nil.
+	Prompter Prompter
+
+	// Out is where the doctor writes progress/prompt output. Defaults to
+	// os.Stderr when nil.
+	Out io.Writer
+}
+
+// Prompter reads a single line of user input after writing a prompt. A
+// nil Prompter in Options is replaced at Run time with a stdin-backed
+// default.
+type Prompter func(prompt string) (string, error)
+
+// Run executes all checks against cfg and returns the resulting Report.
+// When Opts.Interactive is true, fixable problems can be resolved inline
+// (e.g. spawning Ollama, pulling a model, swapping to an alternative) and
+// the corresponding Results are updated in place before Run returns.
+func Run(ctx context.Context, cfg *config.Config, opts Options) Report {
+	if opts.Out == nil {
+		opts.Out = discardWriter{}
+	}
+	if opts.Prompter == nil {
+		opts.Prompter = stdinPrompter
+	}
+
+	report := Report{}
+
+	// Order matters: config first because everything downstream depends
+	// on it. Then the cheap checks (filesystem, env vars). Then the
+	// network-touching checks (Ollama daemon, model list). Finally the
+	// interactive fixes, which need all the prior checks to know what's
+	// missing.
+	report.Results = append(report.Results, checkConfig(cfg))
+	report.Results = append(report.Results, checkAnthropicKey(cfg))
+
+	ollamaCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	ollamaResults := checkOllama(ollamaCtx, cfg, opts)
+	report.Results = append(report.Results, ollamaResults...)
+
+	return report
+}
+
+// discardWriter is an io.Writer that swallows everything. Used as the
+// default Opts.Out so callers that don't want progress output don't have
+// to allocate anything.
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,297 @@
+package doctor
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aisu-ai/aidev/internal/config"
+)
+
+func TestResultFormatOK(t *testing.T) {
+	r := Result{Name: "config", Severity: OK, Message: "loaded"}
+	got := r.Format()
+	if !strings.Contains(got, "[OK]") || !strings.Contains(got, "config") || !strings.Contains(got, "loaded") {
+		t.Errorf("missing expected content: %q", got)
+	}
+	if strings.Contains(got, "fix:") {
+		t.Errorf("OK results should not print a fix line: %q", got)
+	}
+}
+
+func TestResultFormatFailIncludesRemediation(t *testing.T) {
+	r := Result{
+		Name:        "ollama-daemon",
+		Severity:    FAIL,
+		Message:     "not reachable",
+		Remediation: "run `ollama serve`",
+	}
+	got := r.Format()
+	if !strings.Contains(got, "[FAIL]") {
+		t.Errorf("missing FAIL label: %q", got)
+	}
+	if !strings.Contains(got, "fix: run `ollama serve`") {
+		t.Errorf("missing remediation: %q", got)
+	}
+}
+
+func TestResultFormatDetails(t *testing.T) {
+	r := Result{
+		Name:     "config",
+		Severity: OK,
+		Message:  "loaded",
+		Details:  []string{"3 tiers defined", "6 roles routed"},
+	}
+	got := r.Format()
+	if !strings.Contains(got, "3 tiers defined") || !strings.Contains(got, "6 roles routed") {
+		t.Errorf("missing details: %q", got)
+	}
+}
+
+func TestReportAnyAndHasFailure(t *testing.T) {
+	rep := Report{Results: []Result{
+		{Severity: OK},
+		{Severity: WARN},
+		{Severity: FAIL},
+	}}
+	if !rep.HasFailure() {
+		t.Error("HasFailure false")
+	}
+	if !rep.Any(WARN) || !rep.Any(OK) {
+		t.Error("Any(WARN|OK) false")
+	}
+	norep := Report{Results: []Result{{Severity: OK}}}
+	if norep.HasFailure() {
+		t.Error("HasFailure true on OK-only report")
+	}
+}
+
+func TestReportWriteSummary(t *testing.T) {
+	rep := Report{Results: []Result{
+		{Name: "a", Severity: OK, Message: "ok"},
+		{Name: "b", Severity: WARN, Message: "warn"},
+		{Name: "c", Severity: FAIL, Message: "fail", Remediation: "fix it"},
+	}}
+	var buf bytes.Buffer
+	rep.Write(&buf)
+	out := buf.String()
+	if !strings.Contains(out, "1 ok, 1 warn, 1 fail") {
+		t.Errorf("summary line missing or wrong: %q", out)
+	}
+}
+
+// TestCheckConfigFlagsMissingRouting verifies the config check rejects
+// configs with no routing. Exercises the branch without needing real
+// YAML files on disk.
+func TestCheckConfigFlagsMissingRouting(t *testing.T) {
+	cfg := &config.Config{
+		Models: config.Models{
+			Tiers: map[string]config.Tier{
+				"small": {Provider: "ollama", Model: "x"},
+			},
+			// empty routing
+		},
+	}
+	r := checkConfig(cfg)
+	if r.Severity != FAIL {
+		t.Errorf("severity = %v, want FAIL", r.Severity)
+	}
+}
+
+func TestCheckConfigWarnsOnEmptyPrinciples(t *testing.T) {
+	cfg := &config.Config{
+		ConfigDir: "/tmp/x",
+		Models: config.Models{
+			Tiers:   map[string]config.Tier{"small": {Provider: "ollama", Model: "x"}},
+			Routing: map[string]string{"scout": "small"},
+		},
+	}
+	r := checkConfig(cfg)
+	if r.Severity != WARN {
+		t.Errorf("severity = %v, want WARN", r.Severity)
+	}
+}
+
+// TestCheckAnthropicKeyFailsWhenRoutedAndMissing covers the critical
+// branch: anthropic-typed tier in routing but no env var.
+func TestCheckAnthropicKeyFailsWhenRoutedAndMissing(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	cfg := &config.Config{
+		Models: config.Models{
+			Tiers: map[string]config.Tier{
+				"large": {Provider: "anthropic", Model: "claude-opus-4-6"},
+			},
+			Routing: map[string]string{"critic": "large"},
+		},
+	}
+	r := checkAnthropicKey(cfg)
+	if r.Severity != FAIL {
+		t.Errorf("severity = %v, want FAIL", r.Severity)
+	}
+}
+
+func TestCheckAnthropicKeyWarnsWhenNotRouted(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	cfg := &config.Config{
+		Models: config.Models{
+			Tiers:   map[string]config.Tier{"small": {Provider: "ollama", Model: "x"}},
+			Routing: map[string]string{"scout": "small"},
+		},
+	}
+	r := checkAnthropicKey(cfg)
+	if r.Severity != WARN {
+		t.Errorf("severity = %v, want WARN", r.Severity)
+	}
+}
+
+func TestContainsCaseInsensitiveHandlesLatestSuffix(t *testing.T) {
+	installed := []string{"qwen2.5-coder:latest", "llama3:8b"}
+	if !containsCaseInsensitive(installed, "qwen2.5-coder") {
+		t.Error("should match :latest when query omits tag")
+	}
+	installed2 := []string{"qwen2.5-coder"}
+	if !containsCaseInsensitive(installed2, "qwen2.5-coder:latest") {
+		t.Error("should match bare name when query says :latest")
+	}
+	installed3 := []string{"llama3:8b"}
+	if containsCaseInsensitive(installed3, "qwen2.5-coder:7b") {
+		t.Error("should not match unrelated names")
+	}
+	if !containsCaseInsensitive(installed3, "LLAMA3:8b") {
+		t.Error("should be case-insensitive")
+	}
+}
+
+func TestRequiredOllamaModelsIgnoresNonOllama(t *testing.T) {
+	cfg := &config.Config{
+		Models: config.Models{
+			Tiers: map[string]config.Tier{
+				"small":  {Provider: "ollama", Model: "qwen2.5-coder:7b"},
+				"large":  {Provider: "anthropic", Model: "claude-opus-4-6"},
+				"unused": {Provider: "ollama", Model: "should-not-appear"},
+			},
+			Routing: map[string]string{
+				"scout":  "small",
+				"critic": "large",
+			},
+		},
+	}
+	got := requiredOllamaModels(cfg)
+	if len(got) != 1 || got[0] != "qwen2.5-coder:7b" {
+		t.Errorf("got %v, want [qwen2.5-coder:7b]", got)
+	}
+}
+
+func TestSwapTierModelReplacesAllOllamaReferencesToOld(t *testing.T) {
+	cfg := &config.Config{
+		Models: config.Models{
+			Tiers: map[string]config.Tier{
+				"small":  {Provider: "ollama", Model: "want"},
+				"medium": {Provider: "ollama", Model: "other"},
+				"large":  {Provider: "anthropic", Model: "want"}, // should NOT be touched
+			},
+		},
+	}
+	swapTierModel(cfg, "want", "replacement")
+	if cfg.Models.Tiers["small"].Model != "replacement" {
+		t.Errorf("small not swapped: %v", cfg.Models.Tiers["small"])
+	}
+	if cfg.Models.Tiers["medium"].Model != "other" {
+		t.Errorf("medium should be untouched: %v", cfg.Models.Tiers["medium"])
+	}
+	if cfg.Models.Tiers["large"].Model != "want" {
+		t.Errorf("anthropic tier should not be swapped: %v", cfg.Models.Tiers["large"])
+	}
+}
+
+func TestPromptMissingModelPullChoice(t *testing.T) {
+	opts := Options{
+		Prompter: func(prompt string) (string, error) { return "1", nil },
+	}
+	choice, alt, err := promptMissingModel(opts, "qwen2.5-coder:7b", []string{"llama3:8b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if choice != pullIt {
+		t.Errorf("choice = %v, want pullIt", choice)
+	}
+	if alt != "" {
+		t.Errorf("alt should be empty for pullIt, got %q", alt)
+	}
+}
+
+func TestPromptMissingModelAbortsOnEmpty(t *testing.T) {
+	opts := Options{
+		Prompter: func(prompt string) (string, error) { return "", nil },
+	}
+	choice, _, err := promptMissingModel(opts, "qwen2.5-coder:7b", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if choice != abort {
+		t.Errorf("choice = %v, want abort", choice)
+	}
+}
+
+func TestPromptMissingModelSwapsWhenOptionTwoAndPickOne(t *testing.T) {
+	calls := 0
+	opts := Options{
+		Prompter: func(prompt string) (string, error) {
+			calls++
+			if calls == 1 {
+				return "2", nil
+			}
+			return "1", nil
+		},
+	}
+	choice, alt, err := promptMissingModel(opts, "qwen2.5-coder:7b", []string{"llama3:8b", "deepseek-coder:6.7b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if choice != swapToInstalled {
+		t.Errorf("choice = %v, want swapToInstalled", choice)
+	}
+	if alt != "llama3:8b" {
+		t.Errorf("alt = %q, want llama3:8b", alt)
+	}
+}
+
+func TestPromptMissingModelRejectsOption2WithNoAlternatives(t *testing.T) {
+	opts := Options{
+		Prompter: func(prompt string) (string, error) { return "2", nil },
+	}
+	_, _, err := promptMissingModel(opts, "qwen2.5-coder:7b", nil)
+	if err == nil {
+		t.Error("expected error when picking option 2 with no alternatives")
+	}
+}
+
+// TestRunSkipsOllamaWhenNoOllamaRouting ensures the full Run entry point
+// doesn't try to talk to Ollama when the routing has no ollama tiers.
+func TestRunSkipsOllamaWhenNoOllamaRouting(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	cfg := &config.Config{
+		ConfigDir: "/tmp/x",
+		Models: config.Models{
+			Tiers: map[string]config.Tier{
+				"large": {Provider: "anthropic", Model: "claude-opus-4-6"},
+			},
+			Routing: map[string]string{
+				"scout":  "large",
+				"critic": "large",
+			},
+		},
+		Principles: config.Principles{Principles: []config.Principle{{Name: "test"}}},
+	}
+	rep := Run(context.Background(), cfg, Options{})
+	// Should have config + anthropic + one ollama "skipping" result.
+	for _, r := range rep.Results {
+		if r.Name == "ollama-binary" || r.Name == "ollama-daemon" || r.Name == "ollama-models" {
+			t.Errorf("should not have emitted %q when no ollama routing", r.Name)
+		}
+	}
+	if rep.HasFailure() {
+		t.Errorf("should not fail when routing is all-anthropic with key set: %+v", rep.Results)
+	}
+}

--- a/internal/doctor/ollama.go
+++ b/internal/doctor/ollama.go
@@ -1,0 +1,351 @@
+package doctor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aisu-ai/aidev/internal/config"
+)
+
+// checkOllama emits one or more results depending on what it finds:
+//
+//  1. "ollama-binary" — is the `ollama` CLI installed
+//  2. "ollama-daemon" — is the HTTP API reachable (auto-spawns if Opts.AutoSpawnOllama and interactive)
+//  3. "ollama-models" — are the models required by the current routing actually pulled
+//     (offers interactive fix if Opts.Interactive)
+//
+// Each check is only emitted if prior checks made it meaningful. If the
+// binary isn't installed we don't bother checking the daemon, etc.
+func checkOllama(ctx context.Context, cfg *config.Config, opts Options) []Result {
+	required := requiredOllamaModels(cfg)
+	if len(required) == 0 {
+		// No roles route to ollama; nothing to check.
+		return []Result{{
+			Name:     "ollama",
+			Severity: OK,
+			Message:  "no roles route to an ollama tier — skipping ollama checks",
+		}}
+	}
+
+	results := make([]Result, 0, 3)
+
+	// 1. binary
+	binResult := Result{Name: "ollama-binary"}
+	path, err := exec.LookPath("ollama")
+	if err != nil {
+		binResult.Severity = FAIL
+		binResult.Message = "`ollama` CLI not found on PATH"
+		binResult.Remediation = "install from https://ollama.com or swap the small/medium tiers to a non-ollama provider"
+		results = append(results, binResult)
+		return results
+	}
+	binResult.Severity = OK
+	binResult.Message = "ollama binary at " + path
+	results = append(results, binResult)
+
+	// 2. daemon
+	daemonResult := Result{Name: "ollama-daemon"}
+	endpoint := firstOllamaEndpoint(cfg)
+	fmt.Fprintf(opts.Out, "checking ollama daemon at %s...\n", endpoint)
+	if pingOllama(ctx, endpoint) {
+		daemonResult.Severity = OK
+		daemonResult.Message = "daemon reachable at " + endpoint
+	} else if opts.AutoSpawnOllama && opts.Interactive {
+		fmt.Fprintf(opts.Out, "ollama daemon not reachable. spawning `ollama serve` in the background...\n")
+		spawnErr := spawnOllama()
+		if spawnErr != nil {
+			daemonResult.Severity = FAIL
+			daemonResult.Message = "failed to auto-spawn ollama: " + spawnErr.Error()
+			daemonResult.Remediation = "start it manually: `ollama serve` in another terminal"
+			results = append(results, daemonResult)
+			return results
+		}
+		// Wait up to 15s for the daemon to come up.
+		if waitForOllama(ctx, endpoint, 15*time.Second) {
+			daemonResult.Severity = OK
+			daemonResult.Message = "daemon spawned and reachable at " + endpoint
+		} else {
+			daemonResult.Severity = FAIL
+			daemonResult.Message = "spawned ollama but it did not respond within 15s"
+			daemonResult.Remediation = "start it manually and investigate: `ollama serve`"
+			results = append(results, daemonResult)
+			return results
+		}
+	} else {
+		daemonResult.Severity = FAIL
+		daemonResult.Message = "daemon not reachable at " + endpoint
+		daemonResult.Remediation = "run `ollama serve`, or pass -skip-doctor and provide your own daemon"
+		results = append(results, daemonResult)
+		return results
+	}
+	results = append(results, daemonResult)
+
+	// 3. models
+	installed, err := listOllamaModels(ctx, endpoint)
+	if err != nil {
+		results = append(results, Result{
+			Name:        "ollama-models",
+			Severity:    FAIL,
+			Message:     "failed to list installed models: " + err.Error(),
+			Remediation: "investigate with `ollama list`",
+		})
+		return results
+	}
+
+	missing := make([]string, 0)
+	for _, want := range required {
+		if !containsCaseInsensitive(installed, want) {
+			missing = append(missing, want)
+		}
+	}
+
+	if len(missing) == 0 {
+		results = append(results, Result{
+			Name:     "ollama-models",
+			Severity: OK,
+			Message:  fmt.Sprintf("all %d required model(s) present", len(required)),
+			Details:  []string{"required: " + strings.Join(required, ", ")},
+		})
+		return results
+	}
+
+	// Missing models. If interactive, prompt. Otherwise FAIL with guidance.
+	if !opts.Interactive {
+		results = append(results, Result{
+			Name:        "ollama-models",
+			Severity:    FAIL,
+			Message:     fmt.Sprintf("%d required model(s) missing", len(missing)),
+			Remediation: "run `aidev doctor` in an interactive terminal to fix, or `ollama pull <model>` manually",
+			Details:     []string{"missing: " + strings.Join(missing, ", ")},
+		})
+		return results
+	}
+
+	// Interactive fix — one model at a time.
+	fixResult := Result{Name: "ollama-models"}
+	for _, want := range missing {
+		choice, alt, err := promptMissingModel(opts, want, installed)
+		if err != nil {
+			fixResult.Severity = FAIL
+			fixResult.Message = "prompt failed: " + err.Error()
+			results = append(results, fixResult)
+			return results
+		}
+		switch choice {
+		case pullIt:
+			fmt.Fprintf(opts.Out, "pulling %s (this may take a while)...\n", want)
+			if err := pullOllamaModel(ctx, want); err != nil {
+				fixResult.Severity = FAIL
+				fixResult.Message = "pull failed: " + err.Error()
+				fixResult.Remediation = "run `ollama pull " + want + "` manually and re-run aidev"
+				results = append(results, fixResult)
+				return results
+			}
+		case swapToInstalled:
+			// Rewrite the in-memory routing to use the chosen alternative.
+			// This is NOT persisted to models.yaml; the user can make the
+			// change permanent themselves after they decide the alternative
+			// works well enough.
+			swapTierModel(cfg, want, alt)
+			fmt.Fprintf(opts.Out, "swapped routing: %s -> %s (in memory only; edit models.yaml to persist)\n", want, alt)
+		case abort:
+			fixResult.Severity = FAIL
+			fixResult.Message = "user declined to resolve missing model " + want
+			fixResult.Remediation = "pull it (`ollama pull " + want + "`), or edit models.yaml to point at a model you do have"
+			results = append(results, fixResult)
+			return results
+		}
+	}
+	fixResult.Severity = OK
+	fixResult.Message = "all required models available after interactive fix"
+	results = append(results, fixResult)
+	return results
+}
+
+// requiredOllamaModels returns the unique set of model names referenced by
+// ollama-typed tiers in the current routing. Non-ollama tiers are ignored.
+func requiredOllamaModels(cfg *config.Config) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, tier := range usedTiers(cfg) {
+		if tier.Provider != "ollama" {
+			continue
+		}
+		if seen[tier.Model] {
+			continue
+		}
+		seen[tier.Model] = true
+		out = append(out, tier.Model)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// usedTiers returns the subset of tiers that are actually referenced by
+// the current routing. Defined tiers that aren't routed anywhere are
+// ignored, to avoid spurious warnings about unused provider credentials.
+func usedTiers(cfg *config.Config) []config.Tier {
+	seen := map[string]bool{}
+	var out []config.Tier
+	for _, tierName := range cfg.Models.Routing {
+		if seen[tierName] {
+			continue
+		}
+		seen[tierName] = true
+		if t, ok := cfg.Models.Tiers[tierName]; ok {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// firstOllamaEndpoint returns the endpoint of the first ollama tier in the
+// routing. aidev currently assumes all ollama tiers share an endpoint;
+// mixed-endpoint setups are a future problem.
+func firstOllamaEndpoint(cfg *config.Config) string {
+	for _, tierName := range cfg.Models.Routing {
+		t, ok := cfg.Models.Tiers[tierName]
+		if !ok || t.Provider != "ollama" {
+			continue
+		}
+		if t.Endpoint != "" {
+			return t.Endpoint
+		}
+	}
+	if v := os.Getenv("AIDEV_OLLAMA_URL"); v != "" {
+		return v
+	}
+	return "http://localhost:11434"
+}
+
+// pingOllama makes a cheap HEAD-ish call to /api/tags.
+func pingOllama(ctx context.Context, endpoint string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/api/tags", nil)
+	if err != nil {
+		return false
+	}
+	c := &http.Client{Timeout: 2 * time.Second}
+	resp, err := c.Do(req)
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return resp.StatusCode < 400
+}
+
+// waitForOllama polls /api/tags every 500ms until it returns OK or the
+// deadline expires.
+func waitForOllama(ctx context.Context, endpoint string, deadline time.Duration) bool {
+	stop := time.Now().Add(deadline)
+	for time.Now().Before(stop) {
+		if pingOllama(ctx, endpoint) {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	return false
+}
+
+// spawnOllama starts `ollama serve` in the background. The child is fully
+// detached so it outlives aidev — the user asked for aidev not to own the
+// daemon lifecycle. Stdio is nil so we don't leak `ollama serve` logs into
+// the TTY once aidev takes over.
+func spawnOllama() error {
+	cmd := exec.Command("ollama", "serve")
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Start()
+}
+
+// listOllamaModels queries /api/tags and returns the list of model names
+// currently pulled on the daemon.
+func listOllamaModels(ctx context.Context, endpoint string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/api/tags", nil)
+	if err != nil {
+		return nil, err
+	}
+	c := &http.Client{Timeout: 5 * time.Second}
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var payload struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(payload.Models))
+	for _, m := range payload.Models {
+		out = append(out, m.Name)
+	}
+	return out, nil
+}
+
+// pullOllamaModel shells out to `ollama pull <name>`. We use the CLI rather
+// than the /api/pull endpoint because the CLI gives the user a live
+// progress bar in their own terminal, which is exactly what you want during
+// a multi-GB download.
+func pullOllamaModel(ctx context.Context, name string) error {
+	cmd := exec.CommandContext(ctx, "ollama", "pull", name)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// containsCaseInsensitive reports whether needle appears in haystack. Ollama
+// sometimes reports model names with a ":latest" tag suffix that the user's
+// models.yaml may omit, so we also accept a "name:latest" match for a
+// "name" query and vice versa.
+func containsCaseInsensitive(haystack []string, needle string) bool {
+	needleLC := strings.ToLower(needle)
+	needleBase := strings.Split(needleLC, ":")[0]
+	for _, h := range haystack {
+		hlc := strings.ToLower(h)
+		if hlc == needleLC {
+			return true
+		}
+		hbase := strings.Split(hlc, ":")[0]
+		needleHasTag := strings.Contains(needleLC, ":")
+		hHasTag := strings.Contains(hlc, ":")
+		// Accept "qwen2.5-coder:7b" vs "qwen2.5-coder:latest" as a match
+		// only on the base name when exactly one side is ":latest".
+		if hbase == needleBase {
+			if hlc == hbase+":latest" && !needleHasTag {
+				return true
+			}
+			if needleLC == needleBase+":latest" && !hHasTag {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// swapTierModel rewrites every ollama tier that currently references old
+// to reference newModel. Used by the interactive fix flow when the user
+// picks "use an alternative installed model".
+func swapTierModel(cfg *config.Config, old, newModel string) {
+	for name, t := range cfg.Models.Tiers {
+		if t.Provider == "ollama" && t.Model == old {
+			t.Model = newModel
+			cfg.Models.Tiers[name] = t
+		}
+	}
+}

--- a/internal/doctor/prompt.go
+++ b/internal/doctor/prompt.go
@@ -1,0 +1,120 @@
+package doctor
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+)
+
+// userChoice is the outcome of a prompt for a missing model: pull it,
+// swap to an existing alternative, or abort.
+type userChoice int
+
+const (
+	pullIt userChoice = iota
+	swapToInstalled
+	abort
+)
+
+// IsTTY reports whether stdin and stdout both look like TTYs. Doctor uses
+// this to decide whether it can prompt the user. Exported so main.go can
+// consult it when deciding whether to enable Options.Interactive.
+func IsTTY() bool {
+	return isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
+}
+
+// stdinPrompter is the default Prompter used when Options.Prompter is nil.
+// It prints the prompt to stderr (to avoid tainting stdout in headless
+// modes that pipe the report) and reads a line from stdin.
+func stdinPrompter(prompt string) (string, error) {
+	fmt.Fprint(os.Stderr, prompt)
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(line), nil
+}
+
+// promptMissingModel runs the interactive "missing model" dialogue for a
+// single required model. It returns the user's choice, the alternative
+// model name (when choice == swapToInstalled), and any error.
+//
+// The menu offers three options:
+//
+//	[1] Pull <want> now  — continue with the declared routing, download the model
+//	[2] Swap to an existing model (only shown if installed has entries)
+//	[3] Abort — work cannot begin
+//
+// The output is intentionally plain text so it renders fine in any TTY.
+func promptMissingModel(opts Options, want string, installed []string) (userChoice, string, error) {
+	// Filter to installed models that look like plausible alternatives.
+	// For now that's "any installed model" — we don't try to be clever
+	// about coder-vs-generalist models; aidev's router doesn't know the
+	// difference either.
+	alternatives := make([]string, 0, len(installed))
+	for _, m := range installed {
+		if m == want {
+			continue
+		}
+		alternatives = append(alternatives, m)
+	}
+
+	var menu strings.Builder
+	fmt.Fprintf(&menu, "\nOllama model %q is required but not installed.\n\n", want)
+	fmt.Fprintf(&menu, "  [1] Pull %s now (multi-GB download, requires network)\n", want)
+	if len(alternatives) > 0 {
+		fmt.Fprintf(&menu, "  [2] Swap to one of your already-installed models\n")
+		fmt.Fprintf(&menu, "  [3] Abort — aidev cannot run without a model for this tier\n")
+	} else {
+		fmt.Fprintf(&menu, "  [3] Abort — no local alternatives installed, aidev cannot run\n")
+	}
+	menu.WriteString("\nChoice [1")
+	if len(alternatives) > 0 {
+		menu.WriteString("/2")
+	}
+	menu.WriteString("/3]: ")
+
+	answer, err := opts.Prompter(menu.String())
+	if err != nil {
+		return abort, "", fmt.Errorf("read choice: %w", err)
+	}
+	switch strings.TrimSpace(answer) {
+	case "1":
+		return pullIt, "", nil
+	case "2":
+		if len(alternatives) == 0 {
+			return abort, "", errors.New("option 2 is not available (no local alternatives)")
+		}
+		return promptPickAlternative(opts, alternatives)
+	case "3", "":
+		return abort, "", nil
+	default:
+		return abort, "", fmt.Errorf("unrecognised choice %q", answer)
+	}
+}
+
+// promptPickAlternative asks the user to pick one of the installed models
+// by number. Returns the chosen name as the swap target.
+func promptPickAlternative(opts Options, installed []string) (userChoice, string, error) {
+	var menu strings.Builder
+	menu.WriteString("\nInstalled models:\n")
+	for i, m := range installed {
+		fmt.Fprintf(&menu, "  [%d] %s\n", i+1, m)
+	}
+	fmt.Fprintf(&menu, "\nPick one [1-%d]: ", len(installed))
+	answer, err := opts.Prompter(menu.String())
+	if err != nil {
+		return abort, "", fmt.Errorf("read pick: %w", err)
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(answer))
+	if err != nil || n < 1 || n > len(installed) {
+		return abort, "", fmt.Errorf("invalid pick %q", answer)
+	}
+	return swapToInstalled, installed[n-1], nil
+}


### PR DESCRIPTION
## Summary

v0.2b ships `aidev doctor` — a precondition audit that runs automatically on every `aidev` startup (and as an explicit subcommand) and resolves the most common environment problems interactively without the user having to leave the program.

## Checks

| Check | FAIL when | Interactive fix |
|---|---|---|
| `config` | no tiers or no routing in `models.yaml` | — |
| `anthropic-key` | role routes to anthropic tier but `ANTHROPIC_API_KEY` unset | — |
| `ollama-binary` | ollama tier routed but CLI missing | — |
| `ollama-daemon` | CLI present but `/api/tags` unreachable | auto-spawn `ollama serve` (detached) and wait up to 15s |
| `ollama-models` | required models not pulled | menu: **[1]** pull now, **[2]** swap to an already-installed model, **[3]** abort |

## Design decisions (from the v0.2b sparring round)

- **First-pull consent: y/N with alternatives.** No silent multi-GB downloads. The menu offers pulling, swapping to an installed model, or aborting. If the user swaps, the routing is rewritten in memory for the current run only — edit `models.yaml` to persist. If the user aborts, we FAIL loudly with a remediation message.
- **Ollama lifecycle: aidev does not own the daemon.** If we spawn it, it's detached and outlives aidev. This means running aidev won't kill an Ollama daemon another tool was using, and quitting aidev won't leave you without a daemon.
- **Defensible defaults for `aidev doctor`.** Checks everything the multi-agent pipeline needs to run: config loads, tiers/routing valid, principles loaded (WARN if empty), Anthropic key present (only FAIL if routed), Ollama binary + daemon + models (only when routing references them). Unused tiers are skipped to avoid spurious warnings.

## Files

- **new** `internal/doctor/doctor.go` — `Run`, `Report`, `Result`, `Severity`, `Options`, `Prompter` types
- **new** `internal/doctor/config.go` — config and Anthropic key checks
- **new** `internal/doctor/ollama.go` — binary/daemon/model checks, auto-spawn, pull, swap, `requiredOllamaModels`, `firstOllamaEndpoint`, `pingOllama`, `waitForOllama`, `listOllamaModels`, `pullOllamaModel`, `containsCaseInsensitive`, `swapTierModel`
- **new** `internal/doctor/prompt.go` — `IsTTY`, `stdinPrompter`, `promptMissingModel`, `promptPickAlternative`
- **new** `internal/doctor/doctor_test.go` — 16 unit tests (Result formatting, Report aggregation, config/anthropic branches, tag-tolerant model matching, required-model extraction, swap semantics, prompt flows with injected Prompter, Run-skips-ollama-when-not-routed)
- **modified** `cmd/aidev/main.go` — `doctor` subcommand + `-skip-doctor` flag, refactored config loading into `mustLoadConfig`, doctor runs automatically with interactive mode in TTY sessions, non-interactive in headless
- **modified** `README.md` — new Doctor section with check table, first-pull consent explanation, skip-doctor flag, updated roadmap
- **modified** `go.mod`, `go.sum` — `github.com/mattn/go-isatty` promoted from transitive (bubbletea) to direct dep

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — 12 v0.1+v0.2a tests still pass + 16 new doctor tests all pass
- [x] `./aidev -h` shows `-skip-doctor`
- [x] `./aidev doctor -h` parses without `-issue` required
- [ ] **Manual smoke (for @crisscross82 tomorrow):**
  - `aidev doctor` with Ollama running and qwen2.5-coder:7b pulled — should report 4 OK, exit 0
  - `aidev doctor` with Ollama daemon stopped — should FAIL `ollama-daemon`, exit 1, print remediation
  - `aidev doctor` with Ollama running but model missing — should FAIL `ollama-models` with remediation (non-interactive, since `aidev doctor` always runs non-interactive)
  - `aidev -issue ... -repo ...` with the above scenarios — should auto-spawn the daemon if installed, prompt the menu if a model is missing
  - Choose `[2]` swap path with at least one alternative installed and verify the routing is rewritten for the run
  - `ANTHROPIC_API_KEY` unset with the default routing — should FAIL `anthropic-key` with a clear fix message

## Worth reviewing carefully

- **`swapTierModel` mutates in memory only.** That's a deliberate choice — editing YAML config files from a tool that the user also edits by hand is a recipe for conflicts. The status message tells the user to edit `models.yaml` themselves to persist. If you prefer automatic persistence, say so and I'll add a follow-up PR.
- **Auto-spawn is only enabled in interactive TTY mode.** Headless invocations will FAIL if the daemon isn't already up, to avoid spawning subprocesses the CI harness didn't expect. Same for the model prompt: headless fails fast instead of hanging waiting for stdin.
- **`containsCaseInsensitive` handles the `:latest` tag asymmetry** because Ollama reports models with explicit tags but users sometimes configure bare names. Unit-tested both directions.
- **`spawnOllama` detaches stdio to nil** (not `/dev/null`). This is intentional — `os/exec` with nil stdio uses the Go runtime's null stream behaviour, which is portable and doesn't require a platform-specific file handle.

## Out of scope (for future PRs)

- Persisting model swaps to `config/models.yaml` automatically
- Warning when installed models are outdated relative to published versions
- Health check for individual tier endpoints when they differ (mixed-endpoint setups)
- `aidev doctor --fix` flag to run the interactive fix flow as a standalone command