### PR TITLE
feat: add controller for automatic github issue audit trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A local, multi-agent coding assistant TUI written in Go. Feed it a GitHub issue; it runs a tiered agent pipeline — small local models for extractive work, large cloud models for deep reasoning — and hands you a defensible recommendation before a single line of code is written.
 
-> **Status:** v0.2b — Scout + Critic + Architect + `aidev doctor`. Implementer, Tester, Reviewer are on the roadmap.
+> **Status:** v0.2b.1 — Scout + Critic + Architect + `aidev doctor` + automatic GitHub audit trail. Implementer, Tester, Reviewer are on the roadmap.
 
 ## Why
 
@@ -94,6 +94,20 @@ Choosing `2` lists the models already pulled on your Ollama daemon and swaps the
 
 The Ollama daemon lifecycle is **not owned by aidev** — if we spawn it, it persists after aidev exits so we don't interfere with other things that use it.
 
+## Audit trail (controller)
+
+Every significant state transition — Scout started, Critic report ready, user approved, Architect produced sketches, run killed, error — is posted to the GitHub issue that seeded the run. A single **pinned status comment** is updated in place for every transition, and **one-shot artifact comments** contain the full Scout brief, Critic report, and Architect sketches.
+
+A single `aidev:<phase>` label on the issue gives you a kanban-style view of every run at a glance on the repo's Issues page. Labels are swapped (not stacked) so there's always exactly one `aidev:*` label on an issue.
+
+**Agents stay pure.** The controller pattern puts all GitHub I/O in the orchestrator — agents receive a `Context`, call an LLM, return markdown. They never touch the network. This keeps unit tests deterministic and keeps the failure modes of the pipeline contained to one place.
+
+**Idempotent across re-runs.** The pinned status comment carries a hidden HTML fingerprint (`<!-- aidev:status -->`). On startup, aidev scans existing comments for that fingerprint and updates the existing one instead of posting a duplicate — so re-running aidev on the same issue doesn't spam the thread.
+
+**Disable with `-no-audit-trail`.** The controller is on by default when the run has a GitHub issue. Pass `-no-audit-trail` to run silently.
+
+**Credential.** The audit trail writes require `GITHUB_TOKEN` in the environment, with Issues: read and write permission. The same token aidev already uses for issue fetching.
+
 ## TUI keybindings
 
 | Key | Action |
@@ -154,7 +168,8 @@ Sketches are Markdown only — no code. The Implementer (v0.3) is what writes co
 ## Roadmap
 
 - **v0.2a** — Architect agent with N divergent sketches, `-n` flag, cost preview. *(shipped)*
-- **v0.2b** *(this release)* — `aidev doctor` + Ollama auto-spawn + first-pull consent with alternative-model offering.
+- **v0.2b** — `aidev doctor` + Ollama auto-spawn + first-pull consent with alternative-model offering. *(shipped)*
+- **v0.2b.1** *(this release)* — automatic GitHub audit trail (pinned status comment, artifact comments, phase labels) via a controller that keeps agents pure.
 - **v0.2c** — Charter agent + `.aidev/charter.md` + interview flow for repos without a clear stated purpose.
 - **v0.3** — Implementer + Tester in an isolated git worktree + container, with full-coverage tests gating completion. Adaptive dialogue (dependency-aware question graphs).
 - **v0.4** — Reviewer + Boy Scout pass; auto-open follow-up issues for out-of-scope improvements.
@@ -168,8 +183,8 @@ internal/config/        YAML loader for models + principles
 internal/llm/           Provider interface, Ollama + Claude backends, Router
 internal/github/        REST client for fetching issues
 internal/repo/          Repo scanner + repo-local principle loader
-internal/agents/        Scout, Critic, Architect agents (shared Context)
-internal/orchestrator/  State machine that drives the pipeline
+internal/agents/        Scout, Critic, Architect agents (shared Context, pure)
+internal/orchestrator/  State machine + Reporter interface + GitHubReporter (controller)
 internal/tui/           Bubble Tea model, update, view, keybindings
 internal/doctor/        Precondition checks: config, keys, Ollama daemon/models
 config/                 Shipped defaults: models.yaml, principles.yaml

--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -41,13 +41,14 @@ func main() {
 	}
 
 	var (
-		issueURL    = flag.String("issue", "", "GitHub issue URL (https://github.com/owner/repo/issues/123)")
-		repoPath    = flag.String("repo", ".", "Path to the target repository")
-		configDir   = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
-		headless    = flag.Bool("headless", false, "Run the full pipeline once and print the report to stdout without the TUI")
-		sketchN     = flag.Int("n", agents.DefaultSketchCount, "Number of Architect sketches to produce when the Critic recommends 'build'")
-		autoRun     = flag.Bool("auto", false, "Headless only: automatically run the Architect when the Critic recommends 'build' (otherwise stop at Critic)")
-		skipDoctor  = flag.Bool("skip-doctor", false, "Skip the startup precondition check (not recommended)")
+		issueURL      = flag.String("issue", "", "GitHub issue URL (https://github.com/owner/repo/issues/123)")
+		repoPath      = flag.String("repo", ".", "Path to the target repository")
+		configDir     = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
+		headless      = flag.Bool("headless", false, "Run the full pipeline once and print the report to stdout without the TUI")
+		sketchN       = flag.Int("n", agents.DefaultSketchCount, "Number of Architect sketches to produce when the Critic recommends 'build'")
+		autoRun       = flag.Bool("auto", false, "Headless only: automatically run the Architect when the Critic recommends 'build' (otherwise stop at Critic)")
+		skipDoctor    = flag.Bool("skip-doctor", false, "Skip the startup precondition check (not recommended)")
+		noAuditTrail  = flag.Bool("no-audit-trail", false, "Disable posting aidev progress + artifacts to the GitHub issue")
 	)
 	flag.Parse()
 
@@ -89,6 +90,17 @@ func main() {
 	}
 	if err := orch.LoadRepo(absRepo); err != nil {
 		fatal(fmt.Sprintf("scan repo: %v", err))
+	}
+
+	// Install the GitHubReporter unless the user opted out. We hand it
+	// the same github.Client the orchestrator already uses, so the
+	// credential story is "one GITHUB_TOKEN env var covers everything".
+	if !*noAuditTrail {
+		if issue := orch.AgentContext().Issue; issue != nil {
+			reporter := orchestrator.NewGitHubReporter(ctx, orch.GitHubClient(), issue, os.Stderr)
+			orch.SetReporter(reporter)
+			defer func() { _ = orch.CloseReporter() }()
+		}
 	}
 
 	if *headless {

--- a/internal/github/issue.go
+++ b/internal/github/issue.go
@@ -29,18 +29,45 @@ type Issue struct {
 	Labels []string
 }
 
-// Client is a tiny REST client for reading issues. Auth is optional — public
-// repos work without a token — but rate limits are much friendlier when
-// GITHUB_TOKEN is set.
+// defaultAPIBase is the production GitHub API endpoint. Tests inject a
+// fake one via NewClientWithEndpoint.
+const defaultAPIBase = "https://api.github.com"
+
+// Client is a REST client for reading and writing issues and their
+// comments/labels. Auth is optional for public repo reads — but rate
+// limits are much friendlier when GITHUB_TOKEN is set, and private repos
+// and all writes require it.
 type Client struct {
-	token string
-	http  *http.Client
+	token   string
+	baseURL string // no trailing slash
+	http    *http.Client
 }
 
+// NewClient constructs a Client against the real github.com API, reading
+// the token from GITHUB_TOKEN.
 func NewClient() *Client {
 	return &Client{
-		token: os.Getenv("GITHUB_TOKEN"),
-		http:  &http.Client{Timeout: 30 * time.Second},
+		token:   os.Getenv("GITHUB_TOKEN"),
+		baseURL: defaultAPIBase,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// NewClientWithEndpoint constructs a Client that talks to baseURL instead
+// of api.github.com. Used by tests with httptest servers; also usable for
+// GitHub Enterprise installations in the future. baseURL may have a
+// trailing slash or not.
+func NewClientWithEndpoint(token, baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = defaultAPIBase
+	}
+	for len(baseURL) > 0 && baseURL[len(baseURL)-1] == '/' {
+		baseURL = baseURL[:len(baseURL)-1]
+	}
+	return &Client{
+		token:   token,
+		baseURL: baseURL,
+		http:    &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
@@ -65,7 +92,7 @@ func ParseURL(url string) (owner, repo string, number int, err error) {
 
 // Fetch returns the issue identified by owner/repo/number.
 func (c *Client) Fetch(ctx context.Context, owner, repo string, number int) (*Issue, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d", owner, repo, number)
+	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d", c.baseURL, owner, repo, number)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -1,0 +1,180 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Comment is the subset of the GitHub issue-comment payload the controller
+// cares about.
+type Comment struct {
+	ID   int64
+	Body string
+	URL  string
+}
+
+// PostComment adds a new comment to an issue and returns the created
+// Comment. aidev's controller uses this for one-shot artifact comments
+// (scout brief, critic report, sketches) that should survive untouched for
+// the rest of the run.
+func (c *Client) PostComment(ctx context.Context, owner, repo string, issue int, body string) (*Comment, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments", c.baseURL, owner, repo, issue)
+	payload, err := json.Marshal(struct {
+		Body string `json:"body"`
+	}{Body: body})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("post comment: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("post comment: %s", resp.Status)
+	}
+	var raw struct {
+		ID      int64  `json:"id"`
+		Body    string `json:"body"`
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode comment: %w", err)
+	}
+	return &Comment{ID: raw.ID, Body: raw.Body, URL: raw.HTMLURL}, nil
+}
+
+// UpdateComment replaces the body of an existing comment. The controller
+// uses this for the pinned status comment that is rewritten in place at
+// every state transition.
+func (c *Client) UpdateComment(ctx context.Context, owner, repo string, commentID int64, body string) error {
+	url := fmt.Sprintf("%s/repos/%s/%s/issues/comments/%d", c.baseURL, owner, repo, commentID)
+	payload, err := json.Marshal(struct {
+		Body string `json:"body"`
+	}{Body: body})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	c.setAuth(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("update comment: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("update comment: %s", resp.Status)
+	}
+	return nil
+}
+
+// ListComments returns every comment on the issue. The controller uses
+// this on startup to find its own prior comments (via fingerprint) so that
+// re-runs update existing comments instead of duplicating them.
+func (c *Client) ListComments(ctx context.Context, owner, repo string, issue int) ([]Comment, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments?per_page=100", c.baseURL, owner, repo, issue)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list comments: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("list comments: %s", resp.Status)
+	}
+	var raw []struct {
+		ID      int64  `json:"id"`
+		Body    string `json:"body"`
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode comments: %w", err)
+	}
+	out := make([]Comment, 0, len(raw))
+	for _, r := range raw {
+		out = append(out, Comment{ID: r.ID, Body: r.Body, URL: r.HTMLURL})
+	}
+	return out, nil
+}
+
+// AddLabels adds one or more labels to an issue. Existing labels are
+// preserved. Missing labels are created on demand by GitHub (with a
+// default colour), which is fine for aidev's `aidev:<phase>` label set.
+func (c *Client) AddLabels(ctx context.Context, owner, repo string, issue int, labels ...string) error {
+	if len(labels) == 0 {
+		return nil
+	}
+	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d/labels", c.baseURL, owner, repo, issue)
+	payload, err := json.Marshal(struct {
+		Labels []string `json:"labels"`
+	}{Labels: labels})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	c.setAuth(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("add labels: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("add labels: %s", resp.Status)
+	}
+	return nil
+}
+
+// RemoveLabel removes a single label from an issue. Absent labels are a
+// no-op (we swallow the 404), so the controller can call this blindly
+// when swapping phase labels.
+func (c *Client) RemoveLabel(ctx context.Context, owner, repo string, issue int, label string) error {
+	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d/labels/%s", c.baseURL, owner, repo, issue, label)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	c.setAuth(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("remove label: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("remove label: %s", resp.Status)
+	}
+	return nil
+}
+
+// setAuth adds the standard GitHub headers to a request, including the
+// token when one is available. Factored out so every write method agrees
+// on headers without duplicating the logic.
+func (c *Client) setAuth(req *http.Request) {
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "aidev")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+}

--- a/internal/orchestrator/github_reporter.go
+++ b/internal/orchestrator/github_reporter.go
@@ -1,0 +1,221 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aisu-ai/aidev/internal/agents"
+	"github.com/aisu-ai/aidev/internal/github"
+)
+
+// GitHubReporter posts progress and artifacts to the issue that seeded
+// the current run. It maintains one pinned status comment (updated in
+// place for every transition) and one-shot artifact comments for
+// Scout/Critic/Architect output.
+//
+// The reporter also swaps a single `aidev:<phase>` label on the issue so
+// the repo's Issues page gets a kanban-style progress indicator for free.
+type GitHubReporter struct {
+	client *github.Client
+	issue  *github.Issue
+
+	// log is where non-fatal errors are written. The orchestrator never
+	// dies because of a GitHubReporter failure — if the network is down
+	// or the token is scoped wrong, we log and continue. Defaults to
+	// io.Discard when unset.
+	log io.Writer
+
+	mu              sync.Mutex
+	statusCommentID int64  // 0 until the pinned status comment is created
+	currentLabel    string // last aidev:<phase> label we added, for removal on next transition
+	closed          bool
+}
+
+// fingerprint string lives inside the HTML comment at the bottom of the
+// pinned status comment, so cross-run reuse can locate it by scanning
+// issue comments. Keep the string literal stable — it's a public contract
+// with existing comments on GitHub.
+const statusFingerprint = "<!-- aidev:status -->"
+
+// NewGitHubReporter constructs a reporter for the given issue. It
+// immediately scans the issue's existing comments looking for a prior
+// status comment (by fingerprint) so re-runs update in place instead of
+// posting a duplicate pinned comment.
+//
+// issue must be non-nil. log may be nil (a no-op discard logger is used).
+func NewGitHubReporter(ctx context.Context, client *github.Client, issue *github.Issue, log io.Writer) *GitHubReporter {
+	if log == nil {
+		log = io.Discard
+	}
+	r := &GitHubReporter{client: client, issue: issue, log: log}
+
+	// Best-effort discovery of an existing status comment from a prior
+	// run. A failure here is silently ignored — we'll just create a new
+	// one on the first OnEvent.
+	comments, err := client.ListComments(ctx, issue.Owner, issue.Repo, issue.Number)
+	if err != nil {
+		fmt.Fprintf(log, "aidev reporter: cannot list existing comments: %v\n", err)
+		return r
+	}
+	for _, c := range comments {
+		if strings.Contains(c.Body, statusFingerprint) {
+			r.statusCommentID = c.ID
+			break
+		}
+	}
+	return r
+}
+
+// OnEvent routes a state transition to the right GitHub side effects. It
+// returns nil on success and the error from GitHub on failure — the
+// orchestrator logs errors but does not abort on them.
+func (r *GitHubReporter) OnEvent(ctx context.Context, ev Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return nil
+	}
+
+	switch ev.State {
+	case StateScouting:
+		return r.transition(ctx, "scouting", "🔍 Scout running...", ev.Message)
+	case StateCritiquing:
+		// Scout just finished; post its brief as a one-shot.
+		if agCtx := contextFromEvent(ev); agCtx != nil && agCtx.ScoutReport != "" {
+			if err := r.postArtifact(ctx, "Scout brief", agCtx.ScoutReport); err != nil {
+				fmt.Fprintf(r.log, "aidev reporter: post scout artifact: %v\n", err)
+			}
+		}
+		return r.transition(ctx, "critiquing", "🔎 Critic running...", ev.Message)
+	case StateAwaitUser:
+		if agCtx := contextFromEvent(ev); agCtx != nil && agCtx.CriticReport != "" {
+			if err := r.postArtifact(ctx, "Critic report", agCtx.CriticReport); err != nil {
+				fmt.Fprintf(r.log, "aidev reporter: post critic artifact: %v\n", err)
+			}
+		}
+		return r.transition(ctx, "awaiting-decision", "⏸ Awaiting human decision", ev.Message)
+	case StateArchitecting:
+		return r.transition(ctx, "architecting", "📐 Architect running...", ev.Message)
+	case StateSketchesReady:
+		if agCtx := contextFromEvent(ev); agCtx != nil && len(agCtx.Sketches) > 0 {
+			if err := r.postSketches(ctx, agCtx.Sketches); err != nil {
+				fmt.Fprintf(r.log, "aidev reporter: post sketches: %v\n", err)
+			}
+		}
+		return r.transition(ctx, "sketches-ready", "✅ Sketches ready — review and pick one", ev.Message)
+	case StateKilled:
+		return r.transition(ctx, "killed", "🛑 Killed", ev.Message)
+	case StateError:
+		msg := ev.Message
+		if ev.Err != nil {
+			msg = "❌ Error: " + ev.Err.Error()
+		}
+		return r.transition(ctx, "errored", msg, "")
+	}
+	return nil
+}
+
+// Close stops further event processing. It does not delete the status
+// comment — the trail is meant to survive the run.
+func (r *GitHubReporter) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.closed = true
+	return nil
+}
+
+// transition is the combined "update status + swap label" operation every
+// state change runs. phase is the short word used in the label
+// (`aidev:<phase>`); headline is the visible summary; detail is an
+// optional free-form line appended after the headline.
+func (r *GitHubReporter) transition(ctx context.Context, phase, headline, detail string) error {
+	body := r.renderStatus(headline, detail)
+
+	// Upsert the pinned status comment.
+	if r.statusCommentID == 0 {
+		posted, err := r.client.PostComment(ctx, r.issue.Owner, r.issue.Repo, r.issue.Number, body)
+		if err != nil {
+			return fmt.Errorf("post status: %w", err)
+		}
+		r.statusCommentID = posted.ID
+	} else {
+		if err := r.client.UpdateComment(ctx, r.issue.Owner, r.issue.Repo, r.statusCommentID, body); err != nil {
+			return fmt.Errorf("update status: %w", err)
+		}
+	}
+
+	// Swap phase label. Remove the previous one first so there's always
+	// exactly one aidev:<phase> label on the issue at any time.
+	wantLabel := "aidev:" + phase
+	if r.currentLabel != "" && r.currentLabel != wantLabel {
+		if err := r.client.RemoveLabel(ctx, r.issue.Owner, r.issue.Repo, r.issue.Number, r.currentLabel); err != nil {
+			fmt.Fprintf(r.log, "aidev reporter: remove old label %q: %v\n", r.currentLabel, err)
+		}
+	}
+	if r.currentLabel != wantLabel {
+		if err := r.client.AddLabels(ctx, r.issue.Owner, r.issue.Repo, r.issue.Number, wantLabel); err != nil {
+			fmt.Fprintf(r.log, "aidev reporter: add label %q: %v\n", wantLabel, err)
+		}
+		r.currentLabel = wantLabel
+	}
+	return nil
+}
+
+// postArtifact posts a one-shot comment containing a single agent's
+// output, wrapped in a collapsed <details> block so the issue doesn't
+// turn into a wall of text.
+func (r *GitHubReporter) postArtifact(ctx context.Context, title, body string) error {
+	wrapped := fmt.Sprintf(`<details><summary><strong>%s</strong> <sub>(aidev, %s)</sub></summary>
+
+%s
+
+</details>
+`, title, time.Now().UTC().Format(time.RFC3339), body)
+	_, err := r.client.PostComment(ctx, r.issue.Owner, r.issue.Repo, r.issue.Number, wrapped)
+	return err
+}
+
+// postSketches posts the Architect's sketches as a single comment with
+// each sketch inside its own <details> block. Users can expand the
+// interesting ones and skim the rest.
+func (r *GitHubReporter) postSketches(ctx context.Context, sketches []agents.Sketch) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## 📐 Architect: %d sketches\n\n", len(sketches))
+	for _, s := range sketches {
+		fmt.Fprintf(&b, "<details><summary><strong>Sketch %d: %s</strong></summary>\n\n", s.Number, s.Title)
+		b.WriteString(s.Markdown)
+		b.WriteString("\n\n</details>\n\n")
+	}
+	fmt.Fprintf(&b, "_Posted by aidev at %s_\n", time.Now().UTC().Format(time.RFC3339))
+	_, err := r.client.PostComment(ctx, r.issue.Owner, r.issue.Repo, r.issue.Number, b.String())
+	return err
+}
+
+// renderStatus builds the body of the pinned status comment. The
+// fingerprint at the end makes the comment findable on startup.
+func (r *GitHubReporter) renderStatus(headline, detail string) string {
+	var b strings.Builder
+	b.WriteString("## aidev status\n\n")
+	b.WriteString("**")
+	b.WriteString(headline)
+	b.WriteString("**\n")
+	if detail != "" {
+		b.WriteString("\n")
+		b.WriteString(detail)
+		b.WriteString("\n")
+	}
+	fmt.Fprintf(&b, "\n_Updated %s_\n\n", time.Now().UTC().Format(time.RFC3339))
+	b.WriteString(statusFingerprint)
+	return b.String()
+}
+
+// contextFromEvent pulls the agents.Context pointer out of an Event. It's
+// a thin helper because the field is named Report for historical reasons
+// and we don't want to rename it on the public struct.
+func contextFromEvent(ev Event) *agents.Context {
+	return ev.Report
+}

--- a/internal/orchestrator/github_reporter_test.go
+++ b/internal/orchestrator/github_reporter_test.go
@@ -1,0 +1,305 @@
+package orchestrator
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aisu-ai/aidev/internal/agents"
+	"github.com/aisu-ai/aidev/internal/github"
+)
+
+// fakeServer is a tiny httptest harness that mimics the handful of
+// GitHub REST endpoints the GitHubReporter touches. It records every
+// request so tests can assert on sequencing.
+type fakeServer struct {
+	t      *testing.T
+	server *httptest.Server
+
+	mu             sync.Mutex
+	postComments   []string // bodies, in order
+	patchComments  []patch
+	listComments   []github.Comment
+	addLabels      [][]string
+	removeLabels   []string
+	nextCommentID  int64
+	statusFound    bool
+}
+
+type patch struct {
+	id   int64
+	body string
+}
+
+func newFakeServer(t *testing.T) *fakeServer {
+	t.Helper()
+	fs := &fakeServer{t: t, nextCommentID: 100}
+	fs.server = httptest.NewServer(http.HandlerFunc(fs.serve))
+	t.Cleanup(fs.server.Close)
+	return fs
+}
+
+func (fs *fakeServer) serve(w http.ResponseWriter, r *http.Request) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	// All routes we implement.
+	switch {
+	case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments"):
+		// ListComments for the issue.
+		if len(fs.listComments) == 0 {
+			w.Write([]byte("[]"))
+			return
+		}
+		var b strings.Builder
+		b.WriteString("[")
+		for i, c := range fs.listComments {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			// Minimal shape the client decoder expects.
+			b.WriteString(`{"id":`)
+			b.WriteString(intToString(c.ID))
+			b.WriteString(`,"body":`)
+			b.WriteString(quote(c.Body))
+			b.WriteString(`,"html_url":""}`)
+		}
+		b.WriteString("]")
+		w.Write([]byte(b.String()))
+
+	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+		// PostComment.
+		body, _ := io.ReadAll(r.Body)
+		fs.postComments = append(fs.postComments, string(body))
+		fs.nextCommentID++
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id":` + intToString(fs.nextCommentID) + `,"body":"","html_url":""}`))
+
+	case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/issues/comments/"):
+		// UpdateComment.
+		body, _ := io.ReadAll(r.Body)
+		id := parseTrailingInt(r.URL.Path)
+		fs.patchComments = append(fs.patchComments, patch{id: id, body: string(body)})
+		w.WriteHeader(http.StatusOK)
+
+	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+		// AddLabels.
+		body, _ := io.ReadAll(r.Body)
+		fs.addLabels = append(fs.addLabels, extractStrings(string(body)))
+		w.WriteHeader(http.StatusOK)
+
+	case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/labels/"):
+		// RemoveLabel. Extract the label name from the URL tail.
+		idx := strings.Index(r.URL.Path, "/labels/")
+		fs.removeLabels = append(fs.removeLabels, r.URL.Path[idx+len("/labels/"):])
+		w.WriteHeader(http.StatusOK)
+
+	default:
+		fs.t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func TestGitHubReporterStatusCommentCreatedOnFirstEvent(t *testing.T) {
+	fs := newFakeServer(t)
+	client := github.NewClientWithEndpoint("tok", fs.server.URL+"/")
+	issue := &github.Issue{Owner: "o", Repo: "r", Number: 1}
+	rep := NewGitHubReporter(context.Background(), client, issue, io.Discard)
+
+	err := rep.OnEvent(context.Background(), Event{State: StateScouting, Message: "starting scout"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fs.postComments) != 1 {
+		t.Fatalf("expected 1 post (status comment), got %d", len(fs.postComments))
+	}
+	body := fs.postComments[0]
+	if !strings.Contains(body, "Scout running") {
+		t.Errorf("status body missing headline: %q", body)
+	}
+	// The fingerprint is HTML (< and > characters); encoding/json escapes
+	// them to \u003c / \u003e in the POST body. Check for the stable
+	// "aidev:status" substring, which survives JSON escaping intact.
+	if !strings.Contains(body, "aidev:status") {
+		t.Errorf("status body missing fingerprint substring: %q", body)
+	}
+	if len(fs.addLabels) != 1 {
+		t.Errorf("expected 1 label add, got %d: %v", len(fs.addLabels), fs.addLabels)
+	}
+}
+
+func TestGitHubReporterUpdatesStatusInPlaceOnSubsequentEvents(t *testing.T) {
+	fs := newFakeServer(t)
+	client := github.NewClientWithEndpoint("tok", fs.server.URL+"/")
+	issue := &github.Issue{Owner: "o", Repo: "r", Number: 1}
+	rep := NewGitHubReporter(context.Background(), client, issue, io.Discard)
+	ctx := context.Background()
+
+	// Scouting — creates status comment
+	if err := rep.OnEvent(ctx, Event{State: StateScouting, Message: "go"}); err != nil {
+		t.Fatal(err)
+	}
+	// Critiquing — posts scout artifact + updates status + swaps label
+	if err := rep.OnEvent(ctx, Event{State: StateCritiquing, Message: "go", Report: &agents.Context{ScoutReport: "a brief"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fs.postComments) != 2 {
+		t.Errorf("expected 2 posts (status + scout artifact), got %d", len(fs.postComments))
+	}
+	if len(fs.patchComments) != 1 {
+		t.Errorf("expected 1 status update, got %d", len(fs.patchComments))
+	}
+	if len(fs.removeLabels) != 1 || fs.removeLabels[0] != "aidev:scouting" {
+		t.Errorf("expected removal of aidev:scouting label, got %v", fs.removeLabels)
+	}
+	if len(fs.addLabels) != 2 {
+		t.Errorf("expected 2 label adds, got %d", len(fs.addLabels))
+	}
+}
+
+func TestGitHubReporterFindsExistingStatusOnStartup(t *testing.T) {
+	fs := newFakeServer(t)
+	fs.listComments = []github.Comment{
+		{ID: 777, Body: "irrelevant comment"},
+		{ID: 888, Body: "## aidev status\n\n**old**\n\n" + statusFingerprint},
+	}
+	client := github.NewClientWithEndpoint("tok", fs.server.URL+"/")
+	issue := &github.Issue{Owner: "o", Repo: "r", Number: 1}
+	rep := NewGitHubReporter(context.Background(), client, issue, io.Discard)
+
+	// First event should UPDATE (PATCH) the existing comment, not POST a new one.
+	if err := rep.OnEvent(context.Background(), Event{State: StateScouting, Message: "restart"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fs.postComments) != 0 {
+		t.Errorf("should not have posted a new status comment, got %d posts", len(fs.postComments))
+	}
+	if len(fs.patchComments) != 1 || fs.patchComments[0].id != 888 {
+		t.Errorf("should have patched comment 888, got %+v", fs.patchComments)
+	}
+}
+
+func TestGitHubReporterPostsSketchesArtifact(t *testing.T) {
+	fs := newFakeServer(t)
+	client := github.NewClientWithEndpoint("tok", fs.server.URL+"/")
+	issue := &github.Issue{Owner: "o", Repo: "r", Number: 1}
+	rep := NewGitHubReporter(context.Background(), client, issue, io.Discard)
+	ctx := context.Background()
+
+	_ = rep.OnEvent(ctx, Event{State: StateScouting, Message: "x"})
+	_ = rep.OnEvent(ctx, Event{State: StateCritiquing, Message: "y", Report: &agents.Context{ScoutReport: "brief"}})
+	_ = rep.OnEvent(ctx, Event{State: StateAwaitUser, Message: "z", Report: &agents.Context{ScoutReport: "brief", CriticReport: "report"}})
+	_ = rep.OnEvent(ctx, Event{State: StateArchitecting, Message: "w"})
+	_ = rep.OnEvent(ctx, Event{
+		State:   StateSketchesReady,
+		Message: "done",
+		Report: &agents.Context{
+			ScoutReport:  "brief",
+			CriticReport: "report",
+			Sketches: []agents.Sketch{
+				{Number: 1, Title: "Postgres", Markdown: "## Sketch 1: Postgres\n\nuse pg"},
+				{Number: 2, Title: "Redis", Markdown: "## Sketch 2: Redis\n\nuse redis"},
+			},
+		},
+	})
+
+	// Count sketches artifact: it's the POST whose body contains "## 📐 Architect".
+	sketchCount := 0
+	for _, b := range fs.postComments {
+		if strings.Contains(b, "Architect") && strings.Contains(b, "sketches") {
+			sketchCount++
+			if !strings.Contains(b, "Postgres") || !strings.Contains(b, "Redis") {
+				t.Errorf("sketches comment missing titles: %q", b)
+			}
+		}
+	}
+	if sketchCount != 1 {
+		t.Errorf("expected exactly 1 sketches artifact post, got %d", sketchCount)
+	}
+}
+
+// Test helpers.
+
+func intToString(n int64) string {
+	// Avoid strconv to keep the import list compact in the test file.
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+func parseTrailingInt(s string) int64 {
+	// Parse the trailing integer of a path like ".../issues/comments/42".
+	i := len(s)
+	for i > 0 && s[i-1] >= '0' && s[i-1] <= '9' {
+		i--
+	}
+	var n int64
+	for j := i; j < len(s); j++ {
+		n = n*10 + int64(s[j]-'0')
+	}
+	return n
+}
+
+func quote(s string) string {
+	// Minimal JSON string quoting for the test harness.
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"', '\\':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		case '\n':
+			b.WriteString("\\n")
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// extractStrings is a very small JSON parser for the shape
+// `{"labels":["a","b","c"]}`. We avoid encoding/json to keep this file
+// small and focused.
+func extractStrings(body string) []string {
+	start := strings.Index(body, "[")
+	end := strings.LastIndex(body, "]")
+	if start < 0 || end < 0 || end <= start {
+		return nil
+	}
+	inner := body[start+1 : end]
+	parts := strings.Split(inner, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		p = strings.Trim(p, `"`)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -11,6 +11,10 @@
 // and a subsequent Continue() call transitions await_user -> architecting ->
 // sketches_ready. Killed and errored runs terminate from any state.
 //
+// v0.2b.1 adds the Reporter hook: every state transition is fanned out to
+// both the TUI event channel (as before) and a Reporter that owns all
+// outgoing side effects (GitHub comments, labels, etc.). Agents stay pure.
+//
 // The orchestrator never talks to LLMs directly — it owns a Router and hands
 // the right Provider to each agent via the agents package. This keeps
 // agent-specific prompting out of the state machine.
@@ -20,6 +24,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/aisu-ai/aidev/internal/agents"
 	"github.com/aisu-ai/aidev/internal/config"
@@ -71,6 +77,15 @@ type Orchestrator struct {
 	// New via the sketchCount config field and may be overridden at runtime
 	// via SetSketchCount before Continue() is called.
 	sketchCount int
+
+	// reporter is the side-effect boundary. NullReporter by default;
+	// the main entry point swaps in a GitHubReporter unless the user
+	// passes -no-audit-trail. Never nil after New() returns.
+	reporter Reporter
+
+	// reporterLog is where reporter errors are logged when the reporter
+	// itself returns an error from OnEvent. Defaults to os.Stderr.
+	reporterLog io.Writer
 }
 
 // Option configures the orchestrator at construction time.
@@ -85,6 +100,44 @@ func WithSketchCount(n int) Option {
 		}
 		o.sketchCount = n
 	}
+}
+
+// WithReporter installs a custom Reporter. When omitted, the orchestrator
+// uses a NullReporter (no side effects). Passing nil is treated the same
+// as omitting the option.
+func WithReporter(r Reporter) Option {
+	return func(o *Orchestrator) {
+		if r != nil {
+			o.reporter = r
+		}
+	}
+}
+
+// WithReporterLog sets the io.Writer that reporter errors are logged to.
+// Defaults to os.Stderr when unset.
+func WithReporterLog(w io.Writer) Option {
+	return func(o *Orchestrator) {
+		if w != nil {
+			o.reporterLog = w
+		}
+	}
+}
+
+// GitHubClient exposes the orchestrator's github client so callers (like
+// main.go) can build a GitHubReporter against the same client without
+// duplicating credential handling.
+func (o *Orchestrator) GitHubClient() *github.Client { return o.gh }
+
+// SetReporter installs a Reporter after construction. Most callers should
+// use WithReporter(...) at New time, but main.go needs to build the
+// GitHubReporter *after* the issue is loaded, so we expose a post-hoc
+// setter as well. Passing nil resets to NullReporter.
+func (o *Orchestrator) SetReporter(r Reporter) {
+	if r == nil {
+		o.reporter = NullReporter{}
+		return
+	}
+	o.reporter = r
 }
 
 // New builds an Orchestrator from loaded config. It constructs the Router
@@ -102,6 +155,8 @@ func New(cfg *config.Config, opts ...Option) (*Orchestrator, error) {
 		state:       StateInit,
 		ctx:         &agents.Context{},
 		sketchCount: agents.DefaultSketchCount,
+		reporter:    NullReporter{},
+		reporterLog: os.Stderr,
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -204,54 +259,71 @@ func (o *Orchestrator) LoadRepo(root string) error {
 // Run executes the first pass of the pipeline: scout -> critic -> await user.
 // It emits one Event per state transition on the returned channel and closes
 // the channel when the first pass terminates (at await_user, killed, or
-// error). Call Continue() to drive the second pass (architect -> sketches).
+// error). Every emitted event is also fanned out to the Reporter. Call
+// Continue() to drive the second pass (architect -> sketches).
 func (o *Orchestrator) Run(ctx context.Context) <-chan Event {
 	out := make(chan Event, 8)
 	go func() {
 		defer close(out)
 
 		if o.ctx.Issue == nil {
-			o.state = StateError
-			out <- Event{State: o.state, Err: errors.New("orchestrator: no issue loaded")}
+			o.emit(ctx, out, Event{State: StateError, Err: errors.New("orchestrator: no issue loaded")})
 			return
 		}
 		if o.ctx.Snapshot == nil {
-			o.state = StateError
-			out <- Event{State: o.state, Err: errors.New("orchestrator: no repo loaded")}
+			o.emit(ctx, out, Event{State: StateError, Err: errors.New("orchestrator: no repo loaded")})
 			return
 		}
 
 		// Scout.
 		o.state = StateScouting
-		out <- Event{State: o.state, Message: "Scouting repository..."}
+		o.emit(ctx, out, Event{State: o.state, Message: "Scouting repository..."})
 		if _, err := o.scout.Run(ctx, o.ctx); err != nil {
 			o.state = StateError
-			out <- Event{State: o.state, Err: err}
+			o.emit(ctx, out, Event{State: o.state, Err: err})
 			return
 		}
 
 		// Critic.
 		o.state = StateCritiquing
-		out <- Event{State: o.state, Message: "Critic evaluating proposal..."}
+		o.emit(ctx, out, Event{State: o.state, Message: "Critic evaluating proposal..."})
 		rpt, err := o.critic.Run(ctx, o.ctx)
 		if err != nil {
 			o.state = StateError
-			out <- Event{State: o.state, Err: err}
+			o.emit(ctx, out, Event{State: o.state, Err: err})
 			return
 		}
 		o.critRpt = rpt
 
 		// First pass terminates here and awaits the human's verdict.
 		o.state = StateAwaitUser
-		out <- Event{State: o.state, Message: "Critic recommends: " + rpt.Recommendation}
+		o.emit(ctx, out, Event{State: o.state, Message: "Critic recommends: " + rpt.Recommendation})
 	}()
 	return out
+}
+
+// emit fans an event out to both the TUI channel and the Reporter. It
+// stamps the event with a pointer to the current agents.Context so the
+// Reporter can read downstream artifacts (ScoutReport, CriticReport,
+// Sketches) from the one place that holds them. Reporter errors are
+// logged to o.reporterLog and never propagated — the audit trail is a
+// best-effort facility, not a gate.
+func (o *Orchestrator) emit(ctx context.Context, out chan<- Event, ev Event) {
+	ev.Report = o.ctx
+	out <- ev
+	if o.reporter == nil {
+		return
+	}
+	if err := o.reporter.OnEvent(ctx, ev); err != nil {
+		fmt.Fprintf(o.reporterLog, "aidev reporter: %v\n", err)
+	}
 }
 
 // Continue runs the Architect stage. Must be called after Run() has
 // transitioned to StateAwaitUser; the TUI typically calls it when the user
 // presses the approve key. The returned channel emits architecting events
-// and closes when sketches are ready (or the run errors).
+// and closes when sketches are ready (or the run errors). Events are also
+// fanned to the Reporter.
 //
 // Calling Continue from any state other than StateAwaitUser returns a
 // channel that immediately emits an error event and closes.
@@ -261,44 +333,63 @@ func (o *Orchestrator) Continue(ctx context.Context) <-chan Event {
 		defer close(out)
 
 		if o.state != StateAwaitUser {
+			o.emit(ctx, out, Event{
+				State: StateError,
+				Err:   fmt.Errorf("orchestrator: Continue called from state %q, expected await_user", o.state),
+			})
 			o.state = StateError
-			out <- Event{
-				State: o.state,
-				Err: fmt.Errorf("orchestrator: Continue called from state %q, expected await_user", o.state),
-			}
 			return
 		}
 
 		o.state = StateArchitecting
 		preview := agents.EstimateCost(o.sketchCount)
-		out <- Event{
+		o.emit(ctx, out, Event{
 			State: o.state,
 			Message: fmt.Sprintf("Architect generating %d sketches (~%d tokens, ~%ds)...",
 				preview.N, preview.TotalOutputTokens, preview.EstimatedSeconds),
-		}
+		})
 
 		sketches, err := o.architect.Run(ctx, o.ctx)
 		if err != nil {
 			o.state = StateError
-			out <- Event{State: o.state, Err: err}
+			o.emit(ctx, out, Event{State: o.state, Err: err})
 			return
 		}
 		o.ctx.Sketches = sketches
 
 		o.state = StateSketchesReady
-		out <- Event{
-			State: o.state,
+		o.emit(ctx, out, Event{
+			State:   o.state,
 			Message: fmt.Sprintf("Architect produced %d sketches. Review them and pick one.", len(sketches)),
-		}
+		})
 	}()
 	return out
 }
 
-// Kill transitions the orchestrator to StateKilled. It is safe to call from
+// Kill transitions the orchestrator to StateKilled and fires a terminal
+// event to both the TUI channel and the Reporter. It is safe to call from
 // any non-terminal state and idempotent once terminal.
 func (o *Orchestrator) Kill() {
 	if o.state == StateDone || o.state == StateKilled || o.state == StateError {
 		return
 	}
 	o.state = StateKilled
+	// Fire a synthetic terminal event so the Reporter can finalise its
+	// audit trail. We use a one-shot channel the caller drops.
+	ctx := context.Background()
+	if o.reporter != nil {
+		ev := Event{State: StateKilled, Message: "Killed by user", Report: o.ctx}
+		if err := o.reporter.OnEvent(ctx, ev); err != nil {
+			fmt.Fprintf(o.reporterLog, "aidev reporter: %v\n", err)
+		}
+	}
+}
+
+// CloseReporter releases the reporter. Safe to call after the
+// orchestrator is done; main.go uses this from a defer.
+func (o *Orchestrator) CloseReporter() error {
+	if o.reporter == nil {
+		return nil
+	}
+	return o.reporter.Close()
 }

--- a/internal/orchestrator/reporter.go
+++ b/internal/orchestrator/reporter.go
@@ -1,0 +1,40 @@
+// Package orchestrator's Reporter is the single side-effect boundary
+// for the pipeline. Agents stay pure; the orchestrator drives the state
+// machine and fans every transition into both the TUI (via a channel) and
+// the Reporter (via a method call). Implementations of Reporter decide
+// whether those events become GitHub comments, Slack messages, log lines,
+// or nothing at all.
+package orchestrator
+
+import "context"
+
+// Reporter is the side-effect boundary. The orchestrator calls OnEvent
+// synchronously for every state transition. Implementations that perform
+// network I/O should time-box their work and never return errors that
+// would abort the pipeline — audit trail is a nice-to-have, not a gate.
+// Errors from OnEvent are logged by the orchestrator and pipeline
+// execution continues.
+type Reporter interface {
+	// OnEvent is called synchronously from the orchestrator's run
+	// goroutine after the event has been sent to the TUI channel. The
+	// Event's Report field is a live pointer to the agents.Context at
+	// emission time; implementations must read it synchronously because
+	// the orchestrator may mutate the context on the next transition.
+	OnEvent(ctx context.Context, ev Event) error
+
+	// Close is called when the orchestrator is done with the reporter.
+	// Implementations should flush any pending work here; errors are
+	// logged but not propagated.
+	Close() error
+}
+
+// NullReporter is a Reporter that does nothing. It is the default when
+// the user passes -no-audit-trail, when the run has no GitHub issue to
+// report against (e.g. the `aidev doctor` subcommand), or in tests.
+type NullReporter struct{}
+
+// OnEvent is a no-op.
+func (NullReporter) OnEvent(context.Context, Event) error { return nil }
+
+// Close is a no-op.
+func (NullReporter) Close() error { return nil }

--- a/internal/orchestrator/reporter_test.go
+++ b/internal/orchestrator/reporter_test.go
@@ -1,0 +1,127 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aisu-ai/aidev/internal/agents"
+)
+
+// recordingReporter captures every event the orchestrator fires at it,
+// so tests can assert the fan-out without reaching into private state.
+type recordingReporter struct {
+	events []Event
+	fail   error
+}
+
+func (r *recordingReporter) OnEvent(_ context.Context, ev Event) error {
+	r.events = append(r.events, ev)
+	return r.fail
+}
+func (r *recordingReporter) Close() error { return nil }
+
+func TestNullReporterIsZeroCost(t *testing.T) {
+	var n NullReporter
+	if err := n.OnEvent(context.Background(), Event{State: StateScouting}); err != nil {
+		t.Errorf("OnEvent should be nil: %v", err)
+	}
+	if err := n.Close(); err != nil {
+		t.Errorf("Close should be nil: %v", err)
+	}
+}
+
+func TestWithReporterOptionReplacesDefault(t *testing.T) {
+	rec := &recordingReporter{}
+	o := &Orchestrator{}
+	WithReporter(rec)(o)
+	if o.reporter == nil {
+		t.Fatal("reporter not set")
+	}
+	if _, ok := o.reporter.(*recordingReporter); !ok {
+		t.Errorf("reporter type = %T, want *recordingReporter", o.reporter)
+	}
+}
+
+func TestWithReporterNilIgnored(t *testing.T) {
+	o := &Orchestrator{reporter: NullReporter{}}
+	WithReporter(nil)(o)
+	if _, ok := o.reporter.(NullReporter); !ok {
+		t.Errorf("nil reporter should be ignored, got %T", o.reporter)
+	}
+}
+
+func TestSetReporterReplacesInPlace(t *testing.T) {
+	o := &Orchestrator{reporter: NullReporter{}}
+	rec := &recordingReporter{}
+	o.SetReporter(rec)
+	if _, ok := o.reporter.(*recordingReporter); !ok {
+		t.Errorf("SetReporter did not replace: %T", o.reporter)
+	}
+	o.SetReporter(nil)
+	if _, ok := o.reporter.(NullReporter); !ok {
+		t.Errorf("SetReporter(nil) should reset to NullReporter, got %T", o.reporter)
+	}
+}
+
+// TestEmitFansOutToChannelAndReporter verifies the core contract: every
+// event emitted by the orchestrator goes to BOTH the TUI channel and the
+// Reporter, in that order, with the agent context attached.
+func TestEmitFansOutToChannelAndReporter(t *testing.T) {
+	rec := &recordingReporter{}
+	o := &Orchestrator{
+		ctx:         &agents.Context{ScoutReport: "brief"},
+		reporter:    rec,
+		reporterLog: discardWriter{},
+	}
+	out := make(chan Event, 2)
+	o.emit(context.Background(), out, Event{State: StateScouting, Message: "go"})
+	close(out)
+
+	received := <-out
+	if received.State != StateScouting || received.Message != "go" {
+		t.Errorf("channel got wrong event: %+v", received)
+	}
+	if received.Report == nil || received.Report.ScoutReport != "brief" {
+		t.Errorf("context not stamped on event: %+v", received.Report)
+	}
+
+	if len(rec.events) != 1 {
+		t.Fatalf("reporter got %d events, want 1", len(rec.events))
+	}
+	if rec.events[0].State != StateScouting {
+		t.Errorf("reporter state = %q, want scouting", rec.events[0].State)
+	}
+	if rec.events[0].Report == nil || rec.events[0].Report.ScoutReport != "brief" {
+		t.Errorf("reporter did not see context: %+v", rec.events[0].Report)
+	}
+}
+
+// TestEmitSwallowsReporterErrors verifies that a reporter returning an
+// error does not block the channel send and does not propagate.
+func TestEmitSwallowsReporterErrors(t *testing.T) {
+	rec := &recordingReporter{fail: errors.New("network down")}
+	var logBuf strings.Builder
+	o := &Orchestrator{
+		ctx:         &agents.Context{},
+		reporter:    rec,
+		reporterLog: &logBuf,
+	}
+	out := make(chan Event, 1)
+	o.emit(context.Background(), out, Event{State: StateError, Err: errors.New("x")})
+	close(out)
+
+	if _, ok := <-out; !ok {
+		t.Fatal("channel did not receive event despite reporter error")
+	}
+	if !strings.Contains(logBuf.String(), "network down") {
+		t.Errorf("reporter error not logged: %q", logBuf.String())
+	}
+}
+
+// discardWriter is a tiny helper to give the orchestrator a bit-bucket
+// log sink in tests without pulling in io/ioutil.
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }


### PR DESCRIPTION
## Summary

v0.2b.1 ships the **controller pattern**: all GitHub side effects live in the orchestrator behind a `Reporter` interface. Agents stay pure — they receive a `Context`, call an LLM, return markdown, and never touch the network. Every state transition is fanned out to both the TUI event channel and the Reporter, and a `GitHubReporter` implementation posts a pinned status comment + one-shot artifact comments + `aidev:<phase>` labels to the issue that seeded the run.

This closes the 'automatic documentation' loop you asked for: every significant decision aidev makes is on the record on the originating issue, without me touching agent code.

## Architecture

- `Reporter` interface in `internal/orchestrator/reporter.go` with `OnEvent(ctx, ev) error` and `Close() error`. Default implementation is `NullReporter` — the orchestrator uses it when -no-audit-trail is set or when no issue is loaded.
- `GitHubReporter` in `internal/orchestrator/github_reporter.go` translates each state transition into: (a) upsert the pinned status comment, (b) post a one-shot artifact comment if the phase just produced one, (c) swap the `aidev:<phase>` label. On startup it scans existing comments for the fingerprint `<!-- aidev:status -->` so re-runs update in place instead of duplicating.
- `Orchestrator.emit()` is the single emission helper used by every state transition. It stamps the event with a pointer to the current `agents.Context`, sends to the TUI channel, then calls `reporter.OnEvent` synchronously. Reporter errors are logged and swallowed — the audit trail is never a gate.
- New github client write methods in `internal/github/issues.go`: `PostComment`, `UpdateComment`, `ListComments`, `AddLabels`, `RemoveLabel`, plus a shared `setAuth` helper.
- New `NewClientWithEndpoint(token, baseURL)` constructor on the github client so tests (and future GH Enterprise users) can redirect away from `api.github.com`. All URL construction now uses `c.baseURL`.

## What gets posted

| Event | Effect |
|---|---|
| `StateScouting` | create pinned status, label `aidev:scouting` |
| `StateCritiquing` | post Scout brief artifact, update status, swap to `aidev:critiquing` |
| `StateAwaitUser` | post Critic report artifact, update status, swap to `aidev:awaiting-decision` |
| `StateArchitecting` | update status, swap to `aidev:architecting` |
| `StateSketchesReady` | post sketches artifact (all N in collapsed `<details>` blocks), swap to `aidev:sketches-ready` |
| `StateKilled` | update status, swap to `aidev:killed` |
| `StateError` | update status with error message, swap to `aidev:errored` |

Artifact comments are wrapped in `<details>` blocks so the issue thread doesn't turn into a wall of text.

## Design decisions

- **Controller sits in the orchestrator, not in a new package.** The orchestrator is already the only component with the full state-machine view, so it's the natural place to own side effects. A new package would have needed a back-reference to the orchestrator to know what happened.
- **Agents unchanged.** Zero lines touched in `internal/agents`. The controller reads artifacts from `Context` via the pointer attached to `Event.Report`. This preserves all existing agent tests and all existing agent purity invariants.
- **Synchronous calls, errors swallowed.** Reporter runs inline in the orchestrator goroutine, not in a separate goroutine. Simpler, avoids ordering races. Reporter errors are logged but never abort the pipeline — if GitHub is down, aidev still works, you just lose the audit trail for that run.
- **Fingerprint-based idempotency for the status comment only.** Artifact comments are one-shot and per-run; duplicating them across re-runs is actually useful (you see what each run produced). Only the pinned status comment deduplicates across runs, via `<!-- aidev:status -->`.
- **On by default, `-no-audit-trail` to disable.** aidev operates on issues you explicitly give it — posting back to those issues is inside the consent boundary. If you need silent runs for a private repo or a dry run, the flag disables the controller entirely.

## Files changed

**new**
- `internal/orchestrator/reporter.go` — Reporter interface + NullReporter
- `internal/orchestrator/github_reporter.go` — GitHubReporter with transition/artifact/sketches mapping
- `internal/orchestrator/reporter_test.go` — recordingReporter + fan-out + error-swallowing tests
- `internal/orchestrator/github_reporter_test.go` — fakeServer httptest harness + status/artifact/label/idempotency tests
- `internal/github/issues.go` — PostComment, UpdateComment, ListComments, AddLabels, RemoveLabel, setAuth

**modified**
- `internal/github/issue.go` — add `baseURL` field, `NewClientWithEndpoint` constructor, parameterise `Fetch` URL
- `internal/orchestrator/orchestrator.go` — add `reporter`/`reporterLog` fields, `WithReporter`/`WithReporterLog` options, `SetReporter` post-hoc setter, `GitHubClient` accessor, `CloseReporter`; route every Run/Continue/Kill emission through the new `emit()` helper that fans out to the Reporter
- `cmd/aidev/main.go` — `-no-audit-trail` flag, install `GitHubReporter` after issue load
- `README.md` — new Audit trail section, updated roadmap, updated layout

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all existing tests pass + 10 new reporter/controller tests (fan-out, null no-op, option + setter replacement, error swallowing, status comment creation, in-place update on subsequent events, existing-comment discovery on startup, sketches artifact)
- [ ] **Manual smoke (for @crisscross82 tomorrow):**
  - Run aidev against a test issue, verify the pinned status comment appears
  - Press `a` after Critic, verify labels swap from `aidev:awaiting-decision` to `aidev:architecting`
  - Verify Scout brief and Critic report land as separate one-shot comments, each in a collapsed `<details>` block
  - Re-run aidev against the same issue; verify the pinned status is updated in place, not duplicated
  - Run with `-no-audit-trail` and verify no comments are posted