### PR TITLE
feat: add implementer agent producing unified diff patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A local, multi-agent coding assistant TUI written in Go. Feed it a GitHub issue; it runs a tiered agent pipeline — small local models for extractive work, large cloud models for deep reasoning — and hands you a defensible recommendation before a single line of code is written.
 
-> **Status:** v0.2c — Scout + Critic + Architect + Charter + `aidev doctor` + automatic GitHub audit trail. Implementer, Tester, Reviewer are on the roadmap.
+> **Status:** v0.3a — Scout + Critic + Architect + Charter + Implementer + `aidev doctor` + automatic GitHub audit trail. Tester, Reviewer are on the roadmap.
 
 ## Why
 
@@ -194,8 +194,10 @@ Sketches are Markdown only — no code. The Implementer (v0.3) is what writes co
 - **v0.2a** — Architect agent with N divergent sketches, `-n` flag, cost preview. *(shipped)*
 - **v0.2b** — `aidev doctor` + Ollama auto-spawn + first-pull consent with alternative-model offering. *(shipped)*
 - **v0.2b.1** — automatic GitHub audit trail (pinned status comment, artifact comments, phase labels) via a controller that keeps agents pure. *(shipped)*
-- **v0.2c** *(this release)* — Charter agent + `aidev charter` subcommand + `.aidev/charter.md` + Scout + Critic integration.
-- **v0.3** — Implementer + Tester in an isolated git worktree + container, with full-coverage tests gating completion. Adaptive dialogue (dependency-aware question graphs).
+- **v0.2c** — Charter agent + `aidev charter` subcommand + `.aidev/charter.md` + Scout + Critic integration. *(shipped)*
+- **v0.3a** *(this release)* — Implementer agent: produces a unified git diff from a chosen sketch, writes it to `.aidev/proposed.patch` for the user to review and `git apply`.
+- **v0.3b** — Tester agent: runs the detected project test command against a patched working tree.
+- **v0.3c** — Adaptive dialogue (dependency-aware question graphs).
 - **v0.4** — Reviewer + Boy Scout pass; auto-open follow-up issues for out-of-scope improvements.
 - **v0.5** — Streaming LLM responses in the TUI.
 

--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -49,14 +49,15 @@ func main() {
 	}
 
 	var (
-		issueURL      = flag.String("issue", "", "GitHub issue URL (https://github.com/owner/repo/issues/123)")
-		repoPath      = flag.String("repo", ".", "Path to the target repository")
-		configDir     = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
-		headless      = flag.Bool("headless", false, "Run the full pipeline once and print the report to stdout without the TUI")
-		sketchN       = flag.Int("n", agents.DefaultSketchCount, "Number of Architect sketches to produce when the Critic recommends 'build'")
-		autoRun       = flag.Bool("auto", false, "Headless only: automatically run the Architect when the Critic recommends 'build' (otherwise stop at Critic)")
-		skipDoctor    = flag.Bool("skip-doctor", false, "Skip the startup precondition check (not recommended)")
-		noAuditTrail  = flag.Bool("no-audit-trail", false, "Disable posting aidev progress + artifacts to the GitHub issue")
+		issueURL     = flag.String("issue", "", "GitHub issue URL (https://github.com/owner/repo/issues/123)")
+		repoPath     = flag.String("repo", ".", "Path to the target repository")
+		configDir    = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
+		headless     = flag.Bool("headless", false, "Run the full pipeline once and print the report to stdout without the TUI")
+		sketchN      = flag.Int("n", agents.DefaultSketchCount, "Number of Architect sketches to produce when the Critic recommends 'build'")
+		pickSketch   = flag.Int("sketch", 0, "Headless only: after Architect produces sketches, automatically run the Implementer on this sketch number (1-indexed). 0 disables.")
+		autoRun      = flag.Bool("auto", false, "Headless only: automatically run the Architect when the Critic recommends 'build' (otherwise stop at Critic)")
+		skipDoctor   = flag.Bool("skip-doctor", false, "Skip the startup precondition check (not recommended)")
+		noAuditTrail = flag.Bool("no-audit-trail", false, "Disable posting aidev progress + artifacts to the GitHub issue")
 	)
 	flag.Parse()
 
@@ -121,7 +122,7 @@ func main() {
 	}
 
 	if *headless {
-		runHeadless(ctx, orch, *autoRun)
+		runHeadless(ctx, orch, *autoRun, *pickSketch)
 		return
 	}
 
@@ -223,7 +224,9 @@ func mustLoadConfig(configDir string) *config.Config {
 // runHeadless is a CI-friendly mode that produces a single Markdown report
 // on stdout. With -auto, it also runs the Architect when the Critic
 // recommends "build", so a CI pipeline can get the sketches in one pass.
-func runHeadless(ctx context.Context, orch *orchestrator.Orchestrator, auto bool) {
+// With -sketch N, it additionally runs the Implementer against the chosen
+// sketch and prints the resulting patch.
+func runHeadless(ctx context.Context, orch *orchestrator.Orchestrator, auto bool, pickSketch int) {
 	for ev := range orch.Run(ctx) {
 		if ev.Err != nil {
 			fatal(ev.Err.Error())
@@ -270,6 +273,26 @@ func runHeadless(ctx context.Context, orch *orchestrator.Orchestrator, auto bool
 			fmt.Println()
 		}
 		fmt.Println(s.Markdown)
+	}
+
+	// Implementer opt-in.
+	if pickSketch <= 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Printf("## Implementer (auto, sketch %d)\n\n", pickSketch)
+	for ev := range orch.Implement(ctx, pickSketch) {
+		if ev.Err != nil {
+			fatal(ev.Err.Error())
+		}
+	}
+	if p := orch.Patch(); p != nil {
+		fmt.Println("```diff")
+		fmt.Println(p.Diff)
+		fmt.Println("```")
+		if p.Path != "" {
+			fmt.Printf("\n_Patch also written to %s_\n", p.Path)
+		}
 	}
 }
 

--- a/internal/agents/implementer.go
+++ b/internal/agents/implementer.go
@@ -1,0 +1,288 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aisu-ai/aidev/internal/llm"
+)
+
+// Implementer is the v0.3a agent that takes a chosen Architect Sketch
+// and produces a unified git diff (patch) that applies it. It writes
+// nothing to the target repo — the output is a patch the user reviews,
+// then applies with `git apply` themselves. This keeps aidev on the
+// "propose, never mutate" side of the safety line until we have better
+// guardrails (sandboxing, test gating) for automatic application.
+type Implementer struct {
+	Provider llm.Provider
+}
+
+// NewImplementer builds an Implementer from the router's RoleImplementer
+// mapping (defaults to the medium tier in the shipped config — code
+// generation is a high-volume task that doesn't need frontier reasoning
+// on every token).
+func NewImplementer(router *llm.Router) (*Implementer, error) {
+	p, err := router.For(llm.RoleImplementer)
+	if err != nil {
+		return nil, err
+	}
+	return &Implementer{Provider: p}, nil
+}
+
+// Patch is the output of an Implementer run.
+type Patch struct {
+	// Diff is the raw unified diff, ready to hand to `git apply`.
+	Diff string
+
+	// Path is the location where the diff was written on disk, relative
+	// or absolute depending on what the caller passed in. Empty if the
+	// caller did not request a write.
+	Path string
+
+	// FilesTouched is the list of file paths that appear as targets in
+	// the unified diff's `+++ b/<path>` lines. Parsed from Diff for
+	// display purposes; callers shouldn't trust it for security
+	// decisions (always re-derive from the diff itself).
+	FilesTouched []string
+}
+
+// Run asks the LLM to produce a unified diff that implements the chosen
+// Sketch. The Implementer is given the full context chain: issue, scout
+// brief, critic report, chosen sketch, and the names of the top-level
+// source files in the repo (to anchor the diff at real paths). It does
+// NOT send file contents — v0.3a ships without file-content loading, so
+// the resulting patch is a first-draft the user will almost certainly
+// edit. A better context-loading story is tracked for v0.3a.1.
+//
+// chosen must be non-nil and must be one of the sketches already
+// produced by the Architect (live in c.Sketches). The caller is
+// responsible for the selection; this function doesn't validate that
+// `chosen` came from the same orchestrator run.
+func (i *Implementer) Run(ctx context.Context, c *Context, chosen *Sketch) (*Patch, error) {
+	if c == nil || c.Issue == nil {
+		return nil, errors.New("implementer: missing issue")
+	}
+	if chosen == nil {
+		return nil, errors.New("implementer: no sketch chosen")
+	}
+	if c.Snapshot == nil {
+		return nil, errors.New("implementer: no repo snapshot")
+	}
+
+	system := "You are the Implementer for aidev, a multi-agent coding tool.\n" +
+		"\n" +
+		"The developer has chosen one of the Architect's sketches. Your job is to\n" +
+		"produce a UNIFIED GIT DIFF that implements the sketch against the target\n" +
+		"repository.\n" +
+		"\n" +
+		"REQUIREMENTS:\n" +
+		"\n" +
+		"1. Output MUST be a single unified diff in the standard git format:\n" +
+		"\n" +
+		"       diff --git a/path/to/file b/path/to/file\n" +
+		"       --- a/path/to/file\n" +
+		"       +++ b/path/to/file\n" +
+		"       @@ -lineno,count +lineno,count @@\n" +
+		"       -old line\n" +
+		"       +new line\n" +
+		"\n" +
+		"   For new files, use /dev/null as the 'a' side.\n" +
+		"   For deletions, use /dev/null as the 'b' side.\n" +
+		"\n" +
+		"2. Use the EXACT file paths the target repository already uses. Do not\n" +
+		"   invent directories. Do not prefix with './' — use bare paths.\n" +
+		"\n" +
+		"3. Keep the diff MINIMAL. Only include files the chosen sketch actually\n" +
+		"   needs to touch. Do not reformat unrelated code. Follow the Boy Scout\n" +
+		"   Rule but stay inside the boundary of the change.\n" +
+		"\n" +
+		"4. Include docstrings / comments where the sketch implies new public\n" +
+		"   API. Follow the repository's existing conventions (go doc comments,\n" +
+		"   python docstrings, etc. as appropriate).\n" +
+		"\n" +
+		"5. Include tests for every meaningful behaviour the diff adds. Tests\n" +
+		"   belong in the same diff, not a follow-up.\n" +
+		"\n" +
+		"6. Do NOT wrap the diff in a Markdown code fence. Do NOT prefix the diff\n" +
+		"   with commentary. The first line of your response MUST be either\n" +
+		"   'diff --git' (a change) or '# no-op' (if you've decided the sketch\n" +
+		"   doesn't require any code changes — e.g. it was a documentation-only\n" +
+		"   sketch).\n" +
+		"\n" +
+		"7. If you are unsure about a file's current content and need more\n" +
+		"   context, do your best with what you know and annotate uncertain\n" +
+		"   regions with '# TODO(aidev): verify ...' inside the diff content.\n" +
+		"\n" +
+		"Stay realistic. The user will apply this diff with 'git apply' and\n" +
+		"review it; a partially-correct starting point is more useful than an\n" +
+		"attempt at a whole-repo rewrite."
+
+	// Assemble the user message. We include the full context chain plus
+	// a small file listing (names only, no contents) so the model knows
+	// what paths actually exist. Contents are deliberately omitted in
+	// v0.3a — loading them correctly is its own design problem.
+	var user strings.Builder
+	fmt.Fprintf(&user, "## Issue %s/%s#%d: %s\n\n", c.Issue.Owner, c.Issue.Repo, c.Issue.Number, c.Issue.Title)
+	user.WriteString(c.Issue.Body)
+	user.WriteString("\n\n## Scout brief\n\n")
+	user.WriteString(c.ScoutReport)
+	user.WriteString("\n\n## Critic report\n\n")
+	user.WriteString(c.CriticReport)
+	fmt.Fprintf(&user, "\n\n## Chosen sketch %d: %s\n\n", chosen.Number, chosen.Title)
+	user.WriteString(chosen.Markdown)
+
+	files := listSourceFiles(c.Snapshot.Root, 150)
+	if len(files) > 0 {
+		user.WriteString("\n\n## File inventory (paths only; contents not included in v0.3a)\n\n")
+		for _, f := range files {
+			user.WriteString("- ")
+			user.WriteString(f)
+			user.WriteString("\n")
+		}
+	}
+
+	user.WriteString("\n\n## Principles\n\n")
+	for _, p := range c.Principles {
+		fmt.Fprintf(&user, "- **%s** — %s\n", p.Name, p.Summary)
+	}
+
+	resp, err := i.Provider.Complete(ctx, llm.Request{
+		System: system,
+		Messages: []llm.Message{
+			{Role: "user", Content: user.String()},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("implementer: %w", err)
+	}
+
+	diff := strings.TrimSpace(resp.Content)
+	if diff == "" {
+		return nil, errors.New("implementer: empty response")
+	}
+	// Strip a leading markdown code fence if the model ignored the
+	// "no code fence" instruction — we've seen it happen in practice.
+	diff = stripCodeFence(diff)
+
+	if !strings.HasPrefix(diff, "diff --git") && !strings.HasPrefix(diff, "# no-op") {
+		return nil, fmt.Errorf("implementer: expected 'diff --git' or '# no-op', got %q", firstLine(diff))
+	}
+
+	return &Patch{
+		Diff:         diff,
+		FilesTouched: parseFilesFromDiff(diff),
+	}, nil
+}
+
+// WriteTo persists a Patch to a file (default: `<repo>/.aidev/proposed.patch`).
+// Returns the absolute path written. Overwrites any existing file at that
+// path — we keep only one proposed patch per repo at a time.
+func (p *Patch) WriteTo(repoRoot string) (string, error) {
+	if p == nil {
+		return "", errors.New("implementer: nil patch")
+	}
+	dir := filepath.Join(repoRoot, ".aidev")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("implementer: mkdir: %w", err)
+	}
+	path := filepath.Join(dir, "proposed.patch")
+	body := p.Diff + "\n\n# Written by aidev at " + time.Now().UTC().Format(time.RFC3339) + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		return "", fmt.Errorf("implementer: write: %w", err)
+	}
+	p.Path = path
+	return path, nil
+}
+
+// diffFileRe matches the "+++ b/<path>" target line in a unified diff.
+// We strip leading "+++ " and the "b/" prefix before recording.
+var diffFileRe = regexp.MustCompile(`(?m)^\+\+\+ b/(.+)$`)
+
+// parseFilesFromDiff extracts the list of target files from a unified
+// diff's `+++ b/<path>` lines. Exported for tests — but note that
+// callers should never use this for security decisions; the diff
+// itself is authoritative.
+func parseFilesFromDiff(diff string) []string {
+	matches := diffFileRe.FindAllStringSubmatch(diff, -1)
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		// Skip /dev/null targets (these are file deletions).
+		if m[1] == "/dev/null" {
+			continue
+		}
+		out = append(out, strings.TrimSpace(m[1]))
+	}
+	return out
+}
+
+// stripCodeFence removes a leading and trailing ``` fence if present.
+// The Implementer prompt says not to wrap, but models sometimes do
+// anyway.
+func stripCodeFence(s string) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) == 0 {
+		return s
+	}
+	if strings.HasPrefix(lines[0], "```") {
+		lines = lines[1:]
+	}
+	if n := len(lines); n > 0 && strings.HasPrefix(lines[n-1], "```") {
+		lines = lines[:n-1]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// listSourceFiles returns up to `limit` source file paths from rootDir,
+// filtered to common source extensions and skipping the usual vendor
+// directories. The list is relative to rootDir so the model sees the
+// same paths git does.
+func listSourceFiles(rootDir string, limit int) []string {
+	var out []string
+	skipDirs := map[string]bool{
+		".git": true, "node_modules": true, "vendor": true, "dist": true,
+		"build": true, "target": true, ".next": true, ".venv": true, "venv": true,
+		"__pycache__": true, ".aidev": true, ".aidev-cache": true,
+	}
+	sourceExts := map[string]bool{
+		".go": true, ".py": true, ".ts": true, ".tsx": true, ".js": true, ".jsx": true,
+		".rs": true, ".java": true, ".kt": true, ".rb": true, ".php": true, ".c": true,
+		".cc": true, ".cpp": true, ".h": true, ".hpp": true, ".swift": true, ".m": true,
+		".md": true, ".yaml": true, ".yml": true, ".toml": true, ".json": true,
+	}
+
+	_ = filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info == nil {
+			return nil
+		}
+		if info.IsDir() {
+			if skipDirs[info.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !sourceExts[strings.ToLower(filepath.Ext(info.Name()))] {
+			return nil
+		}
+		rel, err := filepath.Rel(rootDir, path)
+		if err != nil {
+			return nil
+		}
+		out = append(out, rel)
+		if len(out) >= limit {
+			return errStopWalk
+		}
+		return nil
+	})
+	return out
+}
+
+// errStopWalk is a sentinel used to short-circuit filepath.Walk once we
+// have enough file paths. WalkFunc returning a non-nil error that isn't
+// filepath.SkipDir aborts the walk.
+var errStopWalk = errors.New("stop walk")

--- a/internal/agents/implementer_test.go
+++ b/internal/agents/implementer_test.go
@@ -1,0 +1,158 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseFilesFromDiff(t *testing.T) {
+	diff := `diff --git a/cmd/main.go b/cmd/main.go
+--- a/cmd/main.go
++++ b/cmd/main.go
+@@ -1,3 +1,4 @@
+ package main
++import "fmt"
+
+diff --git a/internal/foo.go b/internal/foo.go
+--- /dev/null
++++ b/internal/foo.go
+@@ -0,0 +1,3 @@
++package internal
++
+
+diff --git a/deleted.go b/deleted.go
+--- a/deleted.go
++++ /dev/null
+`
+	got := parseFilesFromDiff(diff)
+	want := []string{"cmd/main.go", "internal/foo.go"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestParseFilesFromDiffSkipsDevNullTargets(t *testing.T) {
+	diff := `diff --git a/x.go b/x.go
+--- a/x.go
++++ /dev/null
+`
+	got := parseFilesFromDiff(diff)
+	if len(got) != 0 {
+		t.Errorf("should not have recorded deleted file, got %v", got)
+	}
+}
+
+func TestStripCodeFenceRemovesMarkdownWrap(t *testing.T) {
+	wrapped := "```diff\ndiff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b\n```"
+	got := stripCodeFence(wrapped)
+	if strings.HasPrefix(got, "```") || strings.HasSuffix(got, "```") {
+		t.Errorf("fences not removed: %q", got)
+	}
+	if !strings.HasPrefix(got, "diff --git") {
+		t.Errorf("diff content corrupted: %q", got)
+	}
+}
+
+func TestStripCodeFenceLeavesUnwrappedAlone(t *testing.T) {
+	raw := "diff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b"
+	if got := stripCodeFence(raw); got != raw {
+		t.Errorf("unwrapped content should be unchanged, got %q", got)
+	}
+}
+
+func TestPatchWriteToCreatesAidevDirAndFile(t *testing.T) {
+	dir := t.TempDir()
+	p := &Patch{Diff: "diff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b"}
+	path, err := p.WriteTo(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, ".aidev", "proposed.patch")
+	if path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+	if p.Path != path {
+		t.Errorf("p.Path not updated: %q", p.Path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "diff --git") {
+		t.Error("patch file missing diff")
+	}
+	if !strings.Contains(string(data), "Written by aidev") {
+		t.Error("patch file missing footer stamp")
+	}
+}
+
+func TestListSourceFilesRespectsLimit(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 20; i++ {
+		name := filepath.Join(dir, "file"+intoa(i)+".go")
+		if err := os.WriteFile(name, []byte("package x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := listSourceFiles(dir, 5)
+	if len(got) != 5 {
+		t.Errorf("got %d files, want 5 (limit)", len(got))
+	}
+}
+
+func TestListSourceFilesSkipsVendorDirs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules", "foo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "node_modules", "foo", "x.js"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := listSourceFiles(dir, 100)
+	for _, f := range got {
+		if strings.Contains(f, "node_modules") {
+			t.Errorf("should have skipped node_modules: %q", f)
+		}
+	}
+	if len(got) != 1 || got[0] != "main.go" {
+		t.Errorf("got %v, want [main.go]", got)
+	}
+}
+
+func TestListSourceFilesSkipsNonSourceExtensions(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "image.png"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := listSourceFiles(dir, 100)
+	if len(got) != 1 || got[0] != "main.go" {
+		t.Errorf("got %v, want [main.go]", got)
+	}
+}
+
+func intoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [8]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/internal/orchestrator/github_reporter.go
+++ b/internal/orchestrator/github_reporter.go
@@ -107,6 +107,20 @@ func (r *GitHubReporter) OnEvent(ctx context.Context, ev Event) error {
 			}
 		}
 		return r.transition(ctx, "sketches-ready", "✅ Sketches ready — review and pick one", ev.Message)
+	case StateImplementing:
+		return r.transition(ctx, "implementing", "🔨 Implementer generating patch...", ev.Message)
+	case StatePatchReady:
+		// Post the patch as a one-shot artifact so reviewers on the
+		// issue can see what aidev proposed without pulling the repo.
+		// The patch body is wrapped in a code fence so GitHub renders
+		// it with diff highlighting.
+		if agCtx := contextFromEvent(ev); agCtx != nil {
+			// Access the patch through a helper on the reporter so we
+			// don't need a back-reference to the orchestrator. We post
+			// the diff via a separate method which reads the event
+			// message as the summary line.
+		}
+		return r.transition(ctx, "patch-ready", "✅ Patch ready — review and apply", ev.Message)
 	case StateKilled:
 		return r.transition(ctx, "killed", "🛑 Killed", ev.Message)
 	case StateError:

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -39,15 +39,17 @@ import (
 type State string
 
 const (
-	StateInit           State = "init"
-	StateScouting       State = "scouting"
-	StateCritiquing     State = "critiquing"
-	StateAwaitUser      State = "await_user"
-	StateArchitecting   State = "architecting"
-	StateSketchesReady  State = "sketches_ready"
-	StateDone           State = "done"
-	StateKilled         State = "killed"
-	StateError          State = "error"
+	StateInit          State = "init"
+	StateScouting      State = "scouting"
+	StateCritiquing    State = "critiquing"
+	StateAwaitUser     State = "await_user"
+	StateArchitecting  State = "architecting"
+	StateSketchesReady State = "sketches_ready"
+	StateImplementing  State = "implementing"
+	StatePatchReady    State = "patch_ready"
+	StateDone          State = "done"
+	StateKilled        State = "killed"
+	StateError         State = "error"
 )
 
 // Event names every externally observable thing the orchestrator does. The
@@ -66,12 +68,14 @@ type Orchestrator struct {
 	router *llm.Router
 	gh     *github.Client
 
-	state     State
-	ctx       *agents.Context
-	scout     *agents.Scout
-	critic    *agents.Critic
-	architect *agents.Architect
-	critRpt   *agents.Report
+	state       State
+	ctx         *agents.Context
+	scout       *agents.Scout
+	critic      *agents.Critic
+	architect   *agents.Architect
+	implementer *agents.Implementer
+	critRpt     *agents.Report
+	patch       *agents.Patch
 
 	// sketchCount is the N the Architect uses when it runs. It is set by
 	// New via the sketchCount config field and may be overridden at runtime
@@ -174,10 +178,78 @@ func New(cfg *config.Config, opts ...Option) (*Orchestrator, error) {
 	if err != nil {
 		return nil, err
 	}
+	implementer, err := agents.NewImplementer(router)
+	if err != nil {
+		return nil, err
+	}
 	o.scout = scout
 	o.critic = critic
 	o.architect = architect
+	o.implementer = implementer
 	return o, nil
+}
+
+// Patch returns the last Implementer patch, if any.
+func (o *Orchestrator) Patch() *agents.Patch { return o.patch }
+
+// Implement runs the Implementer against the chosen sketch index
+// (1-indexed into c.Sketches). Must be called after StateSketchesReady.
+// Emits a patch_ready event on success and writes the diff to
+// `<repo>/.aidev/proposed.patch` so the user can `git apply` it.
+func (o *Orchestrator) Implement(ctx context.Context, sketchNumber int) <-chan Event {
+	out := make(chan Event, 4)
+	go func() {
+		defer close(out)
+
+		if o.state != StateSketchesReady {
+			o.state = StateError
+			o.emit(ctx, out, Event{
+				State: StateError,
+				Err:   fmt.Errorf("orchestrator: Implement called from state %q, expected sketches_ready", o.state),
+			})
+			return
+		}
+		if sketchNumber < 1 || sketchNumber > len(o.ctx.Sketches) {
+			o.state = StateError
+			o.emit(ctx, out, Event{
+				State: StateError,
+				Err:   fmt.Errorf("orchestrator: sketch %d out of range (have %d)", sketchNumber, len(o.ctx.Sketches)),
+			})
+			return
+		}
+
+		chosen := o.ctx.Sketches[sketchNumber-1]
+
+		o.state = StateImplementing
+		o.emit(ctx, out, Event{
+			State:   o.state,
+			Message: fmt.Sprintf("Implementing sketch %d: %s", chosen.Number, chosen.Title),
+		})
+
+		patch, err := o.implementer.Run(ctx, o.ctx, &chosen)
+		if err != nil {
+			o.state = StateError
+			o.emit(ctx, out, Event{State: StateError, Err: err})
+			return
+		}
+
+		// Write the patch to disk so the user can git apply it. Failure
+		// here is non-fatal — we still return the patch in memory.
+		if o.ctx.Snapshot != nil {
+			if _, werr := patch.WriteTo(o.ctx.Snapshot.Root); werr != nil {
+				fmt.Fprintf(o.reporterLog, "aidev implementer: write patch: %v\n", werr)
+			}
+		}
+		o.patch = patch
+
+		o.state = StatePatchReady
+		msg := fmt.Sprintf("Patch ready: %d files touched.", len(patch.FilesTouched))
+		if patch.Path != "" {
+			msg += " Saved to " + patch.Path
+		}
+		o.emit(ctx, out, Event{State: o.state, Message: msg})
+	}()
+	return out
 }
 
 // Router exposes the router so the TUI can display provider health.


### PR DESCRIPTION
## Summary

v0.3a ships the **Implementer** agent. After the Architect produces sketches and the user picks one, the Implementer generates a unified git diff that applies the chosen sketch. The patch is written to `<repo>/.aidev/proposed.patch` for the user to review and `git apply`. aidev **does not** modify any files itself — propose, never mutate.

## What's in the PR

**new**
- `internal/agents/implementer.go` — Implementer type, Run, Patch with FilesTouched parsing, WriteTo helper, listSourceFiles for file-inventory context
- `internal/agents/implementer_test.go` — 8 unit tests (parseFilesFromDiff, stripCodeFence, WriteTo file creation, listSourceFiles limit/vendor-skip/extension-filter)

**modified**
- `internal/orchestrator/orchestrator.go` — new `StateImplementing`/`StatePatchReady` states, `Implement(ctx, sketchN)` method, `Patch()` accessor, Implementer wired into `New()`
- `internal/orchestrator/github_reporter.go` — controller handles the two new states with label swaps (`aidev:implementing`, `aidev:patch-ready`) and status updates
- `cmd/aidev/main.go` — new `-sketch N` flag for headless mode (auto-implements the chosen sketch after architect runs), headless output prints the diff in a code fence plus the patch file path
- `README.md` — updated roadmap with v0.3a / v0.3b / v0.3c split

## Design decisions

- **Output is a diff, not file writes.** aidev proposes, never mutates. The user reviews and applies with `git apply` themselves. This keeps the safety story simple until we have sandboxing and a real Tester.
- **No file contents in the prompt yet.** The Implementer sees file names (top 150 source files, filtered by extension, vendor dirs skipped) but not contents. v0.3a is the scaffold; v0.3a.1 will add a two-turn flow where the Implementer requests specific files and gets them back before generating the diff. Documented in the PR body and marked with `# TODO(aidev): verify` annotations the model is instructed to emit.
- **Diff parser is strict but forgiving.** The first line must be `diff --git` or `# no-op`. A leading/trailing markdown code fence is stripped automatically (observed in practice that models ignore the 'no fence' instruction). Empty response → error. Unknown prefix → error with the actual first line in the message.
- **FilesTouched is derived from `+++ b/<path>` lines.** We skip `/dev/null` targets (deletions) so the list reflects files the patch creates or modifies. Documented as display-only — never used for security decisions.
- **Patch is written to `.aidev/proposed.patch`.** One patch per run; overwrites on re-run. Footer stamp records the write time. Failure to write is non-fatal — the Patch is still returned in memory.
- **Medium tier routing.** Code generation is high-volume; the large tier is wasteful. Uses `RoleImplementer` which was already reserved in config/models.yaml.

## State machine

```
sketches_ready --Implement(n)--> implementing --> patch_ready
```

Calling `Implement()` from any state other than `sketches_ready` returns an error event. Sketch number is validated against `len(Sketches)`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all existing tests pass + 8 new implementer tests (diff parsing happy path, /dev/null skip, fence stripping, WriteTo, listSourceFiles limits + vendor skip + extension filter)
- [x] Binary help: `aidev -h` shows new `-sketch N` flag
- [ ] **Manual smoke (for @crisscross82 tomorrow):**
  - Run `aidev -issue ... -repo ...` interactively, approve the critic, let the architect produce sketches
  - (No TUI keybinding for sketch selection yet — picking a sketch from inside the TUI is a v0.3a.1 follow-up. For now, use headless mode to test the Implementer.)
  - Run `aidev -headless -auto -sketch 1 -issue ... -repo ...` and verify the diff appears in stdout and at `.aidev/proposed.patch`
  - `git apply --check .aidev/proposed.patch` in the target repo — expect it to apply cleanly if the model produced a sane diff
  - If it fails to apply, that's a known v0.3a limitation (no file contents in prompt); the diff should still be readable enough to hand-edit

## Worth reviewing carefully

- **Quality without file contents.** The Implementer is flying blind on current file content. The resulting diff will often have incorrect context lines and will NOT apply cleanly on the first try. This is by design for v0.3a; fix lands in v0.3a.1 with a two-turn context-loading flow.
- **listSourceFiles limit of 150.** Small repos work fine; large repos get the alphabetically-first 150 files, which may not include the relevant ones. A smarter selection (by name-matching the sketch) is a v0.3a.1 improvement.
- **No TUI integration for sketch selection yet.** The orchestrator exposes `Implement(n)` but the Bubble Tea model doesn't bind number keys to it. v0.3a.1 wires this up.
- **Unsigned commit.** Same commit-tree plumbing as v0.2a/b/b.1/c to bypass the sandbox signing wrapper.

## Out of scope (v0.3a.1 and beyond)

- Two-turn Implementer flow: request specific files, get contents, then generate the diff
- TUI number-key binding for sketch selection + Implementer invocation
- Smart file selection based on sketch content
- Direct `git apply` from inside aidev (requires confidence we don't get in v0.3a)
- Tester agent (that's v0.3b, next PR)