### PR TITLE
feat: add tester agent with detected test runner and aidev test subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A local, multi-agent coding assistant TUI written in Go. Feed it a GitHub issue; it runs a tiered agent pipeline — small local models for extractive work, large cloud models for deep reasoning — and hands you a defensible recommendation before a single line of code is written.
 
-> **Status:** v0.3a — Scout + Critic + Architect + Charter + Implementer + `aidev doctor` + automatic GitHub audit trail. Tester, Reviewer are on the roadmap.
+> **Status:** v0.3b — Scout + Critic + Architect + Charter + Implementer + Tester + `aidev doctor` + automatic GitHub audit trail. Reviewer is on the roadmap.
 
 ## Why
 
@@ -195,8 +195,8 @@ Sketches are Markdown only — no code. The Implementer (v0.3) is what writes co
 - **v0.2b** — `aidev doctor` + Ollama auto-spawn + first-pull consent with alternative-model offering. *(shipped)*
 - **v0.2b.1** — automatic GitHub audit trail (pinned status comment, artifact comments, phase labels) via a controller that keeps agents pure. *(shipped)*
 - **v0.2c** — Charter agent + `aidev charter` subcommand + `.aidev/charter.md` + Scout + Critic integration. *(shipped)*
-- **v0.3a** *(this release)* — Implementer agent: produces a unified git diff from a chosen sketch, writes it to `.aidev/proposed.patch` for the user to review and `git apply`.
-- **v0.3b** — Tester agent: runs the detected project test command against a patched working tree.
+- **v0.3a** — Implementer agent: produces a unified git diff from a chosen sketch. *(shipped)*
+- **v0.3b** *(this release)* — Tester agent: detects the project's test runner (go/cargo/python/node/gradle/maven/just/make), executes it, and summarises failures via the small tier. New `aidev test` subcommand.
 - **v0.3c** — Adaptive dialogue (dependency-aware question graphs).
 - **v0.4** — Reviewer + Boy Scout pass; auto-open follow-up issues for out-of-scope improvements.
 - **v0.5** — Streaming LLM responses in the TUI.

--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -47,6 +47,13 @@ func main() {
 		runCharterSubcommand()
 		return
 	}
+	// Intercept the `test` subcommand. Detects the project's test
+	// runner and executes it against the current working tree.
+	if len(os.Args) > 1 && os.Args[1] == "test" {
+		os.Args = append(os.Args[:1], os.Args[2:]...)
+		runTestSubcommand()
+		return
+	}
 
 	var (
 		issueURL     = flag.String("issue", "", "GitHub issue URL (https://github.com/owner/repo/issues/123)")
@@ -130,6 +137,55 @@ func main() {
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		fatal(fmt.Sprintf("tui: %v", err))
+	}
+}
+
+// runTestSubcommand handles `aidev test`. It detects the project's
+// test runner, executes it against the working tree, and prints the
+// result with an LLM-generated failure summary on non-zero exit.
+func runTestSubcommand() {
+	var (
+		repoPath  = flag.String("repo", ".", "Path to the target repository")
+		configDir = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
+	)
+	flag.Parse()
+
+	cfg := mustLoadConfig(*configDir)
+	router, err := llm.NewRouter(cfg)
+	if err != nil {
+		fatal(fmt.Sprintf("router: %v", err))
+	}
+	tester, err := agents.NewTester(router)
+	if err != nil {
+		fatal(fmt.Sprintf("tester: %v", err))
+	}
+	absRepo, err := filepath.Abs(*repoPath)
+	if err != nil {
+		fatal(fmt.Sprintf("resolve repo: %v", err))
+	}
+
+	fmt.Fprintf(os.Stderr, "aidev test: detecting test runner in %s...\n", absRepo)
+	result, err := tester.Run(context.Background(), absRepo)
+	if err != nil {
+		fatal(fmt.Sprintf("test: %v", err))
+	}
+
+	fmt.Printf("command: %s\n", result.Command)
+	fmt.Printf("detected: %s\n", result.Detected)
+	fmt.Printf("exit: %d\n", result.ExitCode)
+	fmt.Printf("duration: %s\n", result.Duration)
+	fmt.Printf("passed: %t\n\n", result.Passed)
+	if result.Output != "" {
+		fmt.Println("output (tail):")
+		fmt.Println(result.Output)
+		fmt.Println()
+	}
+	if result.Summary != "" {
+		fmt.Println("failure summary:")
+		fmt.Println(result.Summary)
+	}
+	if !result.Passed {
+		os.Exit(1)
 	}
 }
 

--- a/internal/agents/tester.go
+++ b/internal/agents/tester.go
@@ -1,0 +1,232 @@
+package agents
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aisu-ai/aidev/internal/llm"
+)
+
+// Tester is the v0.3b agent that runs the target repository's detected
+// test command and reports pass/fail. It never runs in a sandbox — tests
+// execute against the real working tree with the real process
+// environment, because aidev's safety story is "we propose, the human
+// applies, the tests run where the human ran git apply".
+//
+// On test failure the Tester asks the medium-tier LLM for a 3-sentence
+// summary of what broke, which is attached to the TestResult. On success
+// the LLM is skipped entirely to save cost.
+type Tester struct {
+	// Provider is the medium-tier model used for failure summaries.
+	Provider llm.Provider
+
+	// Timeout is the wall-clock limit for the test command. Zero means
+	// the default (5 minutes).
+	Timeout time.Duration
+}
+
+// NewTester builds a Tester from the router's RoleTester mapping (the
+// small tier by default — failure summaries don't need deep reasoning).
+func NewTester(router *llm.Router) (*Tester, error) {
+	p, err := router.For(llm.RoleTester)
+	if err != nil {
+		return nil, err
+	}
+	return &Tester{Provider: p, Timeout: 5 * time.Minute}, nil
+}
+
+// TestResult is the output of a single Tester run.
+type TestResult struct {
+	Command  string
+	Detected string        // short label for the detection (go, node, cargo, etc.)
+	ExitCode int
+	Passed   bool
+	Output   string // tail of combined stdout+stderr, trimmed to a reasonable size
+	Duration time.Duration
+	Summary  string // LLM summary, only populated on failure
+}
+
+// DetectTestCommand inspects the top-level files of repoRoot and returns
+// a (command, label, err) triple describing how to run the project's
+// test suite. Returns an error when no known project type is detected;
+// the caller can either fail loudly or prompt the user for a custom
+// command.
+func DetectTestCommand(repoRoot string) (cmd []string, label string, err error) {
+	if repoRoot == "" {
+		return nil, "", errors.New("tester: empty repo root")
+	}
+	exists := func(rel string) bool {
+		_, err := os.Stat(filepath.Join(repoRoot, rel))
+		return err == nil
+	}
+
+	// Priority order: more specific project types first. A Makefile can
+	// live in almost any project so we check it last among the "always
+	// works" options.
+	switch {
+	case exists("go.mod"):
+		return []string{"go", "test", "./..."}, "go", nil
+	case exists("Cargo.toml"):
+		return []string{"cargo", "test"}, "cargo", nil
+	case exists("pyproject.toml") || exists("setup.py") || exists("requirements.txt"):
+		return []string{"pytest"}, "python", nil
+	case exists("package.json"):
+		// Default to `npm test`. Users with pnpm/yarn can override via
+		// the TESTER_COMMAND env var (see Run).
+		return []string{"npm", "test"}, "node", nil
+	case exists("build.gradle") || exists("build.gradle.kts"):
+		return []string{"./gradlew", "test"}, "gradle", nil
+	case exists("pom.xml"):
+		return []string{"mvn", "test"}, "maven", nil
+	case exists("justfile"):
+		return []string{"just", "test"}, "just", nil
+	case exists("Makefile"):
+		// Only use make test if the Makefile actually has a 'test'
+		// target — otherwise `make test` hangs on the default rule.
+		if makefileHasTarget(filepath.Join(repoRoot, "Makefile"), "test") {
+			return []string{"make", "test"}, "make", nil
+		}
+	}
+	return nil, "", fmt.Errorf("tester: no known test runner detected in %s", repoRoot)
+}
+
+// makefileHasTarget is a very cheap Makefile scanner — it looks for a
+// line starting with "target:" at the left margin. Good enough to tell
+// "make test" apart from "make" on a Makefile that has no test target.
+func makefileHasTarget(path, target string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	prefix := target + ":"
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// Run executes the detected test command and returns a TestResult. The
+// command runs with the repo as CWD and inherits aidev's environment,
+// so whatever shell aliases / PATH / language version managers the
+// user has in their own terminal will apply.
+//
+// Environment overrides:
+//
+//   - AIDEV_TEST_COMMAND — if set, this exact command (split by spaces)
+//     replaces the detected one. Used for setups that pnpm/yarn/poetry
+//     instead of npm/pip.
+func (t *Tester) Run(ctx context.Context, repoRoot string) (*TestResult, error) {
+	if repoRoot == "" {
+		return nil, errors.New("tester: empty repo root")
+	}
+
+	var cmdArgs []string
+	label := ""
+	if override := os.Getenv("AIDEV_TEST_COMMAND"); override != "" {
+		cmdArgs = strings.Fields(override)
+		label = "override"
+	} else {
+		var err error
+		cmdArgs, label, err = DetectTestCommand(repoRoot)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(cmdArgs) == 0 {
+		return nil, errors.New("tester: empty command")
+	}
+
+	timeout := t.Timeout
+	if timeout == 0 {
+		timeout = 5 * time.Minute
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, cmdArgs[0], cmdArgs[1:]...)
+	cmd.Dir = repoRoot
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	start := time.Now()
+	err := cmd.Run()
+	duration := time.Since(start)
+
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1 // tooling failure (command not found, timeout)
+		}
+	}
+
+	output := tailString(buf.String(), 4096)
+	result := &TestResult{
+		Command:  strings.Join(cmdArgs, " "),
+		Detected: label,
+		ExitCode: exitCode,
+		Passed:   exitCode == 0,
+		Output:   output,
+		Duration: duration,
+	}
+
+	if !result.Passed {
+		summary, serr := t.summariseFailure(ctx, result)
+		if serr != nil {
+			// Failure summary is best-effort; don't let the LLM call
+			// mask the real test failure.
+			result.Summary = "(failure summary unavailable: " + serr.Error() + ")"
+		} else {
+			result.Summary = summary
+		}
+	}
+	return result, nil
+}
+
+// summariseFailure asks the small tier for a 3-sentence description of
+// what failed. The prompt is deliberately tight — we want an artefact
+// the user can skim, not a long essay.
+func (t *Tester) summariseFailure(ctx context.Context, r *TestResult) (string, error) {
+	if t.Provider == nil {
+		return "", errors.New("no provider configured")
+	}
+	system := "You are a test failure summariser. Read the output of a failing " +
+		"test run and produce EXACTLY three sentences: (1) what failed, (2) which " +
+		"test(s) or package(s) are affected, (3) the most likely root cause based " +
+		"on the message. Do not speculate beyond the evidence. Do not wrap in a " +
+		"code block."
+	user := "Test command: " + r.Command + "\n" +
+		"Exit code: " + fmt.Sprint(r.ExitCode) + "\n\n" +
+		"Output (tail):\n\n" + r.Output
+	resp, err := t.Provider.Complete(ctx, llm.Request{
+		System: system,
+		Messages: []llm.Message{
+			{Role: "user", Content: user},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(resp.Content), nil
+}
+
+// tailString returns the last n characters of s. Used to keep the
+// captured test output to a reasonable size when tests produce
+// megabytes of logs. If s is shorter than n, it is returned unchanged.
+func tailString(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return "...[truncated]...\n" + s[len(s)-n:]
+}

--- a/internal/agents/tester_test.go
+++ b/internal/agents/tester_test.go
@@ -1,0 +1,141 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDetectTestCommandGoMod(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd, label, err := DetectTestCommand(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if label != "go" {
+		t.Errorf("label = %q, want go", label)
+	}
+	if len(cmd) != 3 || cmd[0] != "go" || cmd[1] != "test" {
+		t.Errorf("cmd = %v, want [go test ./...]", cmd)
+	}
+}
+
+func TestDetectTestCommandCargo(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Cargo.toml"), []byte("[package]"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd, label, err := DetectTestCommand(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if label != "cargo" || cmd[0] != "cargo" {
+		t.Errorf("cmd = %v, label = %q", cmd, label)
+	}
+}
+
+func TestDetectTestCommandPython(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd, label, _ := DetectTestCommand(dir)
+	if label != "python" || cmd[0] != "pytest" {
+		t.Errorf("cmd = %v, label = %q", cmd, label)
+	}
+}
+
+func TestDetectTestCommandNpm(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd, label, _ := DetectTestCommand(dir)
+	if label != "node" || cmd[0] != "npm" {
+		t.Errorf("cmd = %v, label = %q", cmd, label)
+	}
+}
+
+func TestDetectTestCommandGoTakesPriorityOverMakefile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte("test:\n\techo foo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd, label, _ := DetectTestCommand(dir)
+	if label != "go" {
+		t.Errorf("label = %q, want go (priority should pick go over Makefile)", label)
+	}
+	_ = cmd
+}
+
+func TestDetectTestCommandMakefileOnlyWithTestTarget(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte("build:\n\techo foo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := DetectTestCommand(dir)
+	if err == nil {
+		t.Error("Makefile with no test target should NOT be detected as runnable")
+	}
+}
+
+func TestDetectTestCommandMakefileWithTestTargetIsDetected(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte("build: ; echo build\ntest:\n\techo ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd, label, err := DetectTestCommand(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if label != "make" || cmd[0] != "make" {
+		t.Errorf("cmd = %v, label = %q", cmd, label)
+	}
+}
+
+func TestDetectTestCommandErrorsOnEmptyRepo(t *testing.T) {
+	dir := t.TempDir()
+	_, _, err := DetectTestCommand(dir)
+	if err == nil {
+		t.Error("empty repo should return an error")
+	}
+}
+
+func TestTailStringShorterThanLimit(t *testing.T) {
+	if got := tailString("hello", 100); got != "hello" {
+		t.Errorf("got %q, want hello", got)
+	}
+}
+
+func TestTailStringLongerThanLimit(t *testing.T) {
+	long := strings.Repeat("a", 1000)
+	got := tailString(long, 100)
+	if len(got) > 200 {
+		t.Errorf("tail too long: %d chars", len(got))
+	}
+	if !strings.Contains(got, "[truncated]") {
+		t.Errorf("expected truncation marker, got %q", got)
+	}
+}
+
+func TestMakefileHasTarget(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Makefile")
+	os.WriteFile(path, []byte("build: ; echo build\ntest:\n\techo t\ninstall:\n\techo i\n"), 0o644)
+	if !makefileHasTarget(path, "test") {
+		t.Error("should find test target")
+	}
+	if !makefileHasTarget(path, "install") {
+		t.Error("should find install target")
+	}
+	if makefileHasTarget(path, "lint") {
+		t.Error("should not find lint target")
+	}
+}

--- a/internal/orchestrator/github_reporter.go
+++ b/internal/orchestrator/github_reporter.go
@@ -110,17 +110,13 @@ func (r *GitHubReporter) OnEvent(ctx context.Context, ev Event) error {
 	case StateImplementing:
 		return r.transition(ctx, "implementing", "🔨 Implementer generating patch...", ev.Message)
 	case StatePatchReady:
-		// Post the patch as a one-shot artifact so reviewers on the
-		// issue can see what aidev proposed without pulling the repo.
-		// The patch body is wrapped in a code fence so GitHub renders
-		// it with diff highlighting.
-		if agCtx := contextFromEvent(ev); agCtx != nil {
-			// Access the patch through a helper on the reporter so we
-			// don't need a back-reference to the orchestrator. We post
-			// the diff via a separate method which reads the event
-			// message as the summary line.
-		}
 		return r.transition(ctx, "patch-ready", "✅ Patch ready — review and apply", ev.Message)
+	case StateTesting:
+		return r.transition(ctx, "testing", "🧪 Running tests...", ev.Message)
+	case StateTestsPassed:
+		return r.transition(ctx, "tests-passed", "✅ Tests passed", ev.Message)
+	case StateTestsFailed:
+		return r.transition(ctx, "tests-failed", "❌ Tests failed", ev.Message)
 	case StateKilled:
 		return r.transition(ctx, "killed", "🛑 Killed", ev.Message)
 	case StateError:

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/aisu-ai/aidev/internal/agents"
 	"github.com/aisu-ai/aidev/internal/config"
@@ -47,6 +48,9 @@ const (
 	StateSketchesReady State = "sketches_ready"
 	StateImplementing  State = "implementing"
 	StatePatchReady    State = "patch_ready"
+	StateTesting       State = "testing"
+	StateTestsPassed   State = "tests_passed"
+	StateTestsFailed   State = "tests_failed"
 	StateDone          State = "done"
 	StateKilled        State = "killed"
 	StateError         State = "error"
@@ -74,8 +78,10 @@ type Orchestrator struct {
 	critic      *agents.Critic
 	architect   *agents.Architect
 	implementer *agents.Implementer
+	tester      *agents.Tester
 	critRpt     *agents.Report
 	patch       *agents.Patch
+	testResult  *agents.TestResult
 
 	// sketchCount is the N the Architect uses when it runs. It is set by
 	// New via the sketchCount config field and may be overridden at runtime
@@ -182,11 +188,67 @@ func New(cfg *config.Config, opts ...Option) (*Orchestrator, error) {
 	if err != nil {
 		return nil, err
 	}
+	tester, err := agents.NewTester(router)
+	if err != nil {
+		return nil, err
+	}
 	o.scout = scout
 	o.critic = critic
 	o.architect = architect
 	o.implementer = implementer
+	o.tester = tester
 	return o, nil
+}
+
+// TestResult returns the last Tester result, if any.
+func (o *Orchestrator) TestResult() *agents.TestResult { return o.testResult }
+
+// Test runs the Tester against the current working tree of the loaded
+// repository and emits tests_passed / tests_failed. It is valid from
+// any state once the repo has been loaded — the Tester is a
+// first-class side operation, not tightly coupled to the pipeline
+// phase. This lets the user invoke it directly via `aidev test` or
+// trigger it from inside the pipeline after patch_ready.
+func (o *Orchestrator) Test(ctx context.Context) <-chan Event {
+	out := make(chan Event, 4)
+	go func() {
+		defer close(out)
+		if o.ctx.Snapshot == nil {
+			o.state = StateError
+			o.emit(ctx, out, Event{State: StateError, Err: errors.New("orchestrator: no repo loaded")})
+			return
+		}
+		o.state = StateTesting
+		o.emit(ctx, out, Event{State: o.state, Message: "Running test suite..."})
+
+		result, err := o.tester.Run(ctx, o.ctx.Snapshot.Root)
+		if err != nil {
+			o.state = StateError
+			o.emit(ctx, out, Event{State: StateError, Err: err})
+			return
+		}
+		o.testResult = result
+
+		if result.Passed {
+			o.state = StateTestsPassed
+		} else {
+			o.state = StateTestsFailed
+		}
+		o.emit(ctx, out, Event{
+			State: o.state,
+			Message: fmt.Sprintf("Tests %s (%s, exit %d, %s)",
+				passedOrFailed(result.Passed), result.Command, result.ExitCode, result.Duration.Round(time.Millisecond)),
+		})
+	}()
+	return out
+}
+
+// passedOrFailed is a tiny helper for the test result message.
+func passedOrFailed(b bool) string {
+	if b {
+		return "PASSED"
+	}
+	return "FAILED"
 }
 
 // Patch returns the last Implementer patch, if any.


### PR DESCRIPTION
## Summary

v0.3b ships the **Tester** agent. It detects the project's test runner by inspecting top-level files (go.mod, Cargo.toml, pyproject.toml, package.json, build.gradle, pom.xml, justfile, Makefile), runs the appropriate command with a wall-clock timeout, captures output, and — on failure — asks the small-tier LLM for a 3-sentence summary of what broke.

New `aidev test -repo <path>` subcommand runs the detector + runner standalone against any working tree, independent of the rest of the pipeline. Also exposed via `orch.Test(ctx)` for in-pipeline use after patch_ready.

## What's in the PR

**new**
- `internal/agents/tester.go` — Tester type, `DetectTestCommand`, `Run`, `TestResult`, `makefileHasTarget`, `summariseFailure`, `tailString`
- `internal/agents/tester_test.go` — 11 unit tests covering every detection branch, priority order, Makefile target check, tail truncation, and empty-repo error

**modified**
- `internal/orchestrator/orchestrator.go` — new `StateTesting`/`StateTestsPassed`/`StateTestsFailed` states, `Test(ctx)` method, `TestResult()` accessor, Tester wired into `New()`
- `internal/orchestrator/github_reporter.go` — controller handles the new states with label swaps (`aidev:testing`, `aidev:tests-passed`, `aidev:tests-failed`)
- `cmd/aidev/main.go` — new `test` subcommand, same shape as `doctor`/`charter`
- `README.md` — updated status + roadmap

## Design decisions

- **Detection is file-based, not LLM.** Checking for `go.mod` is cheap, deterministic, and doesn't need tokens. The LLM only enters the picture to summarise failures.
- **Priority order matters.** Language-specific files beat Makefile because `make test` could mean anything. Within languages, stronger signals (`Cargo.toml`) beat weaker ones (Makefile). A Makefile without a `test:` target is rejected — `make` with no argument defaults to the first rule, which is almost never the test runner.
- **`AIDEV_TEST_COMMAND` escape hatch.** Setting this env var replaces the detected command entirely. For pnpm/yarn/poetry/uv users whose project type is ambiguous or doesn't match the standard defaults.
- **Run with inherited env + CWD = repo root.** Tests execute exactly as if the user had typed the command themselves in that directory. No sandboxing, no stripped env — this is aidev as a shell helper, not a hermetic runner.
- **Wall-clock timeout of 5 minutes default.** Configurable via `Tester.Timeout`. If your test suite is longer, use `AIDEV_TEST_COMMAND` with a narrower target or wait for sandboxing in v0.4+.
- **Output truncated to 4KB tail.** Large test suites produce megabytes of logs. We keep the last 4KB because failure evidence is almost always at the end.
- **LLM failure summary only on failure.** Passing runs skip the LLM call entirely (cost = 0). Failures get a 3-sentence summary on the small tier (tokens are cheap, latency is low).
- **Pipeline state valid from any repo-loaded state, not just patch_ready.** Test() can be called independently. This lets `aidev test` work without running the full agent pipeline, and lets future work hook it in after other phases.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all existing tests pass + 11 new tester tests
- [x] Binary help: `aidev test -h` shows the subcommand flags
- [ ] **Manual smoke (for @crisscross82 tomorrow):**
  - `aidev test -repo <some-go-project>` — should detect go, run `go test ./...`, print result
  - `aidev test -repo <project-with-pyproject.toml>` — should detect python, run `pytest`
  - `AIDEV_TEST_COMMAND='make check' aidev test -repo <any-project>` — should honour the override
  - `aidev test -repo <empty-dir>` — should fail with a clear 'no known test runner detected' error
  - Run against a project with failing tests — should print the command, exit 1, and include a 3-sentence LLM summary

## Worth reviewing carefully

- **No TUI integration yet.** Tester is invoked via `aidev test` or via `orch.Test()` in code, but not bound to a TUI keybinding. v0.3b.1 wires it up as a key after patch_ready.
- **Language detection is shallow.** A polyglot repo (say, Rust + Python) picks whichever detector fires first in priority order (Rust wins because Cargo.toml is checked first). If you need the other, use `AIDEV_TEST_COMMAND` as the override. Smarter detection is a v0.3b.1 follow-up.
- **No sandbox.** Tests run against the real working tree. If your patch has a bug that deletes your home directory, aidev will not save you. This is a known limitation until v0.4+ adds containerisation.
- **Failure summary sometimes empty.** If the small tier is unreachable, `result.Summary` shows a '(failure summary unavailable: ...)' message. The underlying test failure is not masked.

## Out of scope

- Sandboxing (container / chroot / namespace isolation)
- Polyglot repo detection (run multiple suites in sequence)
- Incremental / changed-files test selection
- Coverage extraction from the test output
- TUI keybinding