### PR TITLE
feat: add reviewer agent with boy scout pass and follow-up issue proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A local, multi-agent coding assistant TUI written in Go. Feed it a GitHub issue; it runs a tiered agent pipeline — small local models for extractive work, large cloud models for deep reasoning — and hands you a defensible recommendation before a single line of code is written.
 
-> **Status:** v0.3b — Scout + Critic + Architect + Charter + Implementer + Tester + `aidev doctor` + automatic GitHub audit trail. Reviewer is on the roadmap.
+> **Status:** v0.4 — Scout + Critic + Architect + Charter + Implementer + Tester + Reviewer + `aidev doctor` + automatic GitHub audit trail. Full agent pipeline shipped.
 
 ## Why
 
@@ -196,8 +196,9 @@ Sketches are Markdown only — no code. The Implementer (v0.3) is what writes co
 - **v0.2b.1** — automatic GitHub audit trail (pinned status comment, artifact comments, phase labels) via a controller that keeps agents pure. *(shipped)*
 - **v0.2c** — Charter agent + `aidev charter` subcommand + `.aidev/charter.md` + Scout + Critic integration. *(shipped)*
 - **v0.3a** — Implementer agent: produces a unified git diff from a chosen sketch. *(shipped)*
-- **v0.3b** *(this release)* — Tester agent: detects the project's test runner (go/cargo/python/node/gradle/maven/just/make), executes it, and summarises failures via the small tier. New `aidev test` subcommand.
-- **v0.3c** — Adaptive dialogue (dependency-aware question graphs).
+- **v0.3b** — Tester agent: detects the project's test runner, executes it, and summarises failures. *(shipped)*
+- **v0.4** *(this release)* — Reviewer agent: Boy Scout pass on a patch with blockers/suggestions/follow-up issue proposals. New `aidev review` subcommand. Full agent pipeline is now complete.
+- **v0.5+** — Adaptive dialogue (dependency-aware question graphs), auto-filing of follow-up issues via `aidev followups --file-issues`, sandboxing for the Tester, streaming LLM responses in the TUI, two-turn Implementer file-content loading.
 - **v0.4** — Reviewer + Boy Scout pass; auto-open follow-up issues for out-of-scope improvements.
 - **v0.5** — Streaming LLM responses in the TUI.
 

--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -54,6 +54,14 @@ func main() {
 		runTestSubcommand()
 		return
 	}
+	// Intercept the `review` subcommand. Runs the Reviewer against a
+	// patch file (default: .aidev/proposed.patch in the target repo)
+	// and prints the review plus any follow-up proposals.
+	if len(os.Args) > 1 && os.Args[1] == "review" {
+		os.Args = append(os.Args[:1], os.Args[2:]...)
+		runReviewSubcommand()
+		return
+	}
 
 	var (
 		issueURL     = flag.String("issue", "", "GitHub issue URL (https://github.com/owner/repo/issues/123)")
@@ -137,6 +145,59 @@ func main() {
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		fatal(fmt.Sprintf("tui: %v", err))
+	}
+}
+
+// runReviewSubcommand handles `aidev review`. It loads a patch file
+// (default `<repo>/.aidev/proposed.patch`), fetches the issue context,
+// runs the Reviewer, and prints the structured review to stdout. If the
+// review contains follow-up proposals they're also written to
+// `<repo>/.aidev/followups.md` for manual triage.
+func runReviewSubcommand() {
+	var (
+		issueURL  = flag.String("issue", "", "GitHub issue URL (required for context)")
+		repoPath  = flag.String("repo", ".", "Path to the target repository")
+		patchPath = flag.String("patch", "", "Path to the patch file to review (default: <repo>/.aidev/proposed.patch)")
+		configDir = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
+	)
+	flag.Parse()
+	if *issueURL == "" {
+		fatal("missing required flag: -issue")
+	}
+
+	cfg := mustLoadConfig(*configDir)
+	orch, err := orchestrator.New(cfg)
+	if err != nil {
+		fatal(fmt.Sprintf("orchestrator: %v", err))
+	}
+	ctx := context.Background()
+	if err := orch.LoadIssue(ctx, *issueURL); err != nil {
+		fatal(fmt.Sprintf("load issue: %v", err))
+	}
+	absRepo, err := filepath.Abs(*repoPath)
+	if err != nil {
+		fatal(fmt.Sprintf("resolve repo: %v", err))
+	}
+	if err := orch.LoadRepo(absRepo); err != nil {
+		fatal(fmt.Sprintf("scan repo: %v", err))
+	}
+
+	pp := *patchPath
+	if pp == "" {
+		pp = filepath.Join(absRepo, ".aidev", "proposed.patch")
+	}
+	data, err := os.ReadFile(pp)
+	if err != nil {
+		fatal(fmt.Sprintf("read patch %s: %v", pp, err))
+	}
+
+	for ev := range orch.ReviewPatch(ctx, string(data)) {
+		if ev.Err != nil {
+			fatal(ev.Err.Error())
+		}
+	}
+	if rev := orch.Review(); rev != nil {
+		fmt.Println(rev.Markdown)
 	}
 }
 

--- a/internal/agents/reviewer.go
+++ b/internal/agents/reviewer.go
@@ -1,0 +1,289 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aisu-ai/aidev/internal/llm"
+)
+
+// Reviewer is the v0.4 agent that performs a Boy Scout pass on a patch
+// before the user merges it. Given a unified diff, it produces a
+// structured review with three sections:
+//
+//	BLOCKERS  — things that would prevent merge (correctness, safety,
+//	            principle violations)
+//	SUGGESTIONS — non-blocking improvements inside the diff's scope
+//	FOLLOW-UPS — out-of-scope improvements worth filing as separate
+//	            issues (Boy Scout: "this dirty thing I noticed nearby")
+//
+// Reviewer does NOT auto-file the follow-ups. It writes them to
+// `<repo>/.aidev/followups.md` for the user to review and either file
+// manually or with a future `aidev followups --file-issues` command.
+// This keeps the safety story "propose, never mutate" consistent with
+// the Implementer.
+type Reviewer struct {
+	Provider llm.Provider
+}
+
+// NewReviewer builds a Reviewer from the router's RoleReviewer mapping
+// (defaults to medium tier in the shipped config).
+func NewReviewer(router *llm.Router) (*Reviewer, error) {
+	p, err := router.For(llm.RoleReviewer)
+	if err != nil {
+		return nil, err
+	}
+	return &Reviewer{Provider: p}, nil
+}
+
+// Review is a complete Reviewer output.
+type Review struct {
+	Markdown  string         // full markdown report, ready to post to a PR
+	Blockers  []ReviewNote   // parsed blockers
+	Suggests  []ReviewNote   // parsed suggestions
+	FollowUps []FollowUpIssue // parsed proposed follow-up issues
+	Verdict   string         // "approve" | "changes_requested" | "comment"
+}
+
+// ReviewNote is a single blocker or suggestion line from the report.
+type ReviewNote struct {
+	Severity string // "blocker" | "suggestion"
+	Text     string
+}
+
+// FollowUpIssue is a proposed out-of-scope improvement. The user can
+// review these in `.aidev/followups.md` and decide which to file.
+type FollowUpIssue struct {
+	Title  string
+	Body   string
+	Labels []string
+}
+
+// Run produces a Review for the given patch and repo context. The patch
+// must be a non-empty unified diff (or the `# no-op` sentinel the
+// Implementer uses for documentation-only sketches — in that case the
+// reviewer returns an empty review quickly).
+func (r *Reviewer) Run(ctx context.Context, c *Context, patch string) (*Review, error) {
+	if c == nil || c.Issue == nil {
+		return nil, errors.New("reviewer: missing issue")
+	}
+	patch = strings.TrimSpace(patch)
+	if patch == "" {
+		return nil, errors.New("reviewer: empty patch")
+	}
+	if strings.HasPrefix(patch, "# no-op") {
+		return &Review{
+			Markdown: "# Review\n\nNo-op patch — nothing to review.\n\nVERDICT: approve\n",
+			Verdict:  "approve",
+		}, nil
+	}
+
+	system := "You are the Reviewer for aidev, a multi-agent coding tool. A " +
+		"diff has just been produced by the Implementer and the user is about " +
+		"to apply it. Your job is a Boy Scout pass on that diff: identify " +
+		"anything that should block merge, anything the author could still " +
+		"improve inside the scope of the change, and anything nearby that " +
+		"deserves a follow-up issue.\n\n" +
+		"Produce EXACTLY these sections in Markdown:\n\n" +
+		"# Review\n\n" +
+		"## Blockers\n" +
+		"Bullet list. Cite the principle violated and the specific line/file. " +
+		"Be willing to find zero blockers — do not invent them.\n\n" +
+		"## Suggestions\n" +
+		"Bullet list. Non-blocking improvements the author could still make " +
+		"INSIDE the scope of this diff. Name the file and approximate region.\n\n" +
+		"## Follow-up issues\n" +
+		"For each proposal use this format:\n\n" +
+		"- **<short title>** — <why this is worth filing> (labels: label1, label2)\n\n" +
+		"Only propose follow-ups for things the diff NEARLY touched but leaving " +
+		"them in scope would be creep. Boy Scout rule: 'leave the code cleaner', " +
+		"not 'rewrite half the repo'.\n\n" +
+		"## Verdict\n\n" +
+		"End with EXACTLY one line of the form:\n\n" +
+		"    VERDICT: approve\n" +
+		"or  VERDICT: changes_requested\n" +
+		"or  VERDICT: comment\n\n" +
+		"Do not hedge. If blockers is empty, verdict is approve. Otherwise " +
+		"verdict is changes_requested."
+
+	var principles strings.Builder
+	for _, p := range c.Principles {
+		fmt.Fprintf(&principles, "- **%s** — %s\n", p.Name, p.Summary)
+	}
+
+	user := fmt.Sprintf(
+		"## Issue %s/%s#%d: %s\n\n%s\n\n## Chosen sketch summary\n\n(see Critic report for context)\n\n## Patch to review\n\n```diff\n%s\n```\n\n## Engineering principles\n\n%s",
+		c.Issue.Owner, c.Issue.Repo, c.Issue.Number, c.Issue.Title,
+		c.Issue.Body, patch, principles.String(),
+	)
+
+	resp, err := r.Provider.Complete(ctx, llm.Request{
+		System: system,
+		Messages: []llm.Message{
+			{Role: "user", Content: user},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reviewer: %w", err)
+	}
+
+	md := strings.TrimSpace(resp.Content)
+	rev := &Review{
+		Markdown:  md,
+		Blockers:  parseReviewNotes(md, "Blockers", "blocker"),
+		Suggests:  parseReviewNotes(md, "Suggestions", "suggestion"),
+		FollowUps: parseFollowUps(md),
+		Verdict:   extractVerdict(md),
+	}
+	return rev, nil
+}
+
+// WriteFollowUps persists the proposed follow-ups to
+// `<repoRoot>/.aidev/followups.md`. Idempotent per run — overwrites any
+// existing file. Returns the path written.
+func (r *Review) WriteFollowUps(repoRoot string) (string, error) {
+	if r == nil {
+		return "", errors.New("reviewer: nil review")
+	}
+	if len(r.FollowUps) == 0 {
+		return "", nil
+	}
+	dir := filepath.Join(repoRoot, ".aidev")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("reviewer: mkdir: %w", err)
+	}
+	path := filepath.Join(dir, "followups.md")
+
+	var b strings.Builder
+	b.WriteString("# Follow-up issues proposed by the Reviewer\n\n")
+	fmt.Fprintf(&b, "_Generated by aidev on %s. Review these, then file manually or wait for `aidev followups --file-issues` in a future release._\n\n", time.Now().UTC().Format("2006-01-02"))
+	for i, f := range r.FollowUps {
+		fmt.Fprintf(&b, "## %d. %s\n\n", i+1, f.Title)
+		if len(f.Labels) > 0 {
+			fmt.Fprintf(&b, "labels: %s\n\n", strings.Join(f.Labels, ", "))
+		}
+		b.WriteString(f.Body)
+		b.WriteString("\n\n---\n\n")
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		return "", fmt.Errorf("reviewer: write: %w", err)
+	}
+	return path, nil
+}
+
+// parseReviewNotes extracts bullet items from the named section of a
+// review report. Section boundaries are "## <name>" headers; bullets
+// start with "- " at the left margin.
+func parseReviewNotes(md, section, severity string) []ReviewNote {
+	body := extractSection(md, section)
+	if body == "" {
+		return nil
+	}
+	var out []ReviewNote
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "- ") {
+			continue
+		}
+		text := strings.TrimSpace(strings.TrimPrefix(line, "- "))
+		if text == "" {
+			continue
+		}
+		out = append(out, ReviewNote{Severity: severity, Text: text})
+	}
+	return out
+}
+
+// followUpLineRe matches the structured follow-up bullet produced by
+// the system prompt: `- **Title** — description (labels: a, b)`
+var followUpLineRe = regexp.MustCompile(`^- \*\*(.+?)\*\*\s*[—-]\s*(.+?)(?:\s*\(labels:\s*(.+?)\))?$`)
+
+// parseFollowUps extracts the structured follow-up list from the
+// "Follow-up issues" section. Lines that don't match the expected shape
+// are skipped — the model occasionally adds a summary sentence that
+// shouldn't become an issue.
+func parseFollowUps(md string) []FollowUpIssue {
+	body := extractSection(md, "Follow-up issues")
+	if body == "" {
+		return nil
+	}
+	var out []FollowUpIssue
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "- ") {
+			continue
+		}
+		m := followUpLineRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		var labels []string
+		if m[3] != "" {
+			for _, l := range strings.Split(m[3], ",") {
+				l = strings.TrimSpace(l)
+				if l != "" {
+					labels = append(labels, l)
+				}
+			}
+		}
+		out = append(out, FollowUpIssue{
+			Title:  strings.TrimSpace(m[1]),
+			Body:   strings.TrimSpace(m[2]),
+			Labels: labels,
+		})
+	}
+	return out
+}
+
+// extractSection returns the body of the section whose heading is
+// "## <name>". The body runs until the next "## " heading or the end of
+// the document.
+func extractSection(md, name string) string {
+	lines := strings.Split(md, "\n")
+	var start, end int
+	start, end = -1, len(lines)
+	needle := "## " + name
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if start < 0 {
+			if trimmed == needle {
+				start = i + 1
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "## ") {
+			end = i
+			break
+		}
+	}
+	if start < 0 || start >= end {
+		return ""
+	}
+	return strings.TrimSpace(strings.Join(lines[start:end], "\n"))
+}
+
+// extractVerdict finds the trailing "VERDICT: <word>" line and returns
+// the canonical lowercase form. Unknown or missing verdicts collapse to
+// "comment" so the Reporter always has something meaningful to show.
+func extractVerdict(md string) string {
+	lines := strings.Split(md, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if !strings.HasPrefix(strings.ToUpper(line), "VERDICT:") {
+			continue
+		}
+		val := strings.TrimSpace(line[len("VERDICT:"):])
+		val = strings.ToLower(strings.TrimSpace(val))
+		switch val {
+		case "approve", "changes_requested", "comment":
+			return val
+		}
+	}
+	return "comment"
+}

--- a/internal/agents/reviewer_test.go
+++ b/internal/agents/reviewer_test.go
@@ -1,0 +1,146 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sampleReview = `# Review
+
+## Blockers
+- Uses ` + "`" + `any` + "`" + ` type in internal/foo.go:42 — violates "No any types" principle
+- Missing test for the edge case when x == 0 in internal/bar.go
+
+## Suggestions
+- Extract the anonymous function in baz.go:17 to a named helper for readability
+- Add a doc comment on the new ExportedFunc
+
+## Follow-up issues
+- **Refactor oldPkg/legacy.go** — 200-line function the new code touches indirectly (labels: tech-debt, refactor)
+- **Add integration test for the Foo flow** — no existing coverage; the new code nearly touches it (labels: testing)
+- summary paragraph that should not become an issue
+
+## Verdict
+
+VERDICT: changes_requested
+`
+
+func TestParseReviewNotes(t *testing.T) {
+	blockers := parseReviewNotes(sampleReview, "Blockers", "blocker")
+	if len(blockers) != 2 {
+		t.Errorf("got %d blockers, want 2", len(blockers))
+	}
+	for _, b := range blockers {
+		if b.Severity != "blocker" {
+			t.Errorf("severity = %q, want blocker", b.Severity)
+		}
+	}
+
+	suggests := parseReviewNotes(sampleReview, "Suggestions", "suggestion")
+	if len(suggests) != 2 {
+		t.Errorf("got %d suggestions, want 2", len(suggests))
+	}
+}
+
+func TestParseReviewNotesEmptySectionReturnsNil(t *testing.T) {
+	md := "# Review\n\n## Blockers\n\n## Suggestions\n- a suggestion\n\nVERDICT: comment\n"
+	got := parseReviewNotes(md, "Blockers", "blocker")
+	if len(got) != 0 {
+		t.Errorf("empty section should return nil, got %v", got)
+	}
+}
+
+func TestParseFollowUps(t *testing.T) {
+	got := parseFollowUps(sampleReview)
+	if len(got) != 2 {
+		t.Errorf("got %d follow-ups, want 2 (summary paragraph must be skipped)", len(got))
+	}
+	if got[0].Title != "Refactor oldPkg/legacy.go" {
+		t.Errorf("title[0] = %q", got[0].Title)
+	}
+	if len(got[0].Labels) != 2 || got[0].Labels[0] != "tech-debt" {
+		t.Errorf("labels[0] = %v", got[0].Labels)
+	}
+	if got[1].Title != "Add integration test for the Foo flow" {
+		t.Errorf("title[1] = %q", got[1].Title)
+	}
+	if len(got[1].Labels) != 1 || got[1].Labels[0] != "testing" {
+		t.Errorf("labels[1] = %v", got[1].Labels)
+	}
+}
+
+func TestExtractVerdict(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{sampleReview, "changes_requested"},
+		{"VERDICT: approve\n", "approve"},
+		{"VERDICT:   APPROVE  ", "approve"},
+		{"VERDICT: comment", "comment"},
+		{"VERDICT: maybe", "comment"}, // unknown defaults to comment
+		{"no verdict at all", "comment"},
+	}
+	for _, c := range cases {
+		got := extractVerdict(c.in)
+		if got != c.want {
+			t.Errorf("extractVerdict(%q) = %q, want %q", c.in[:min(30, len(c.in))], got, c.want)
+		}
+	}
+}
+
+func TestExtractSection(t *testing.T) {
+	md := "# Review\n\n## Blockers\n- one\n- two\n\n## Suggestions\n- three\n"
+	b := extractSection(md, "Blockers")
+	if !strings.Contains(b, "- one") || !strings.Contains(b, "- two") {
+		t.Errorf("blockers body wrong: %q", b)
+	}
+	if strings.Contains(b, "- three") {
+		t.Errorf("blockers body leaked into suggestions: %q", b)
+	}
+	s := extractSection(md, "Suggestions")
+	if !strings.Contains(s, "- three") {
+		t.Errorf("suggestions body wrong: %q", s)
+	}
+	if x := extractSection(md, "Missing"); x != "" {
+		t.Errorf("missing section should be empty, got %q", x)
+	}
+}
+
+func TestReviewWriteFollowUpsCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	rev := &Review{
+		FollowUps: []FollowUpIssue{
+			{Title: "Do the thing", Body: "because reasons", Labels: []string{"a", "b"}},
+			{Title: "Do another thing", Body: "also", Labels: nil},
+		},
+	}
+	path, err := rev.WriteFollowUps(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(path) != "followups.md" {
+		t.Errorf("basename = %q", filepath.Base(path))
+	}
+	data, _ := os.ReadFile(path)
+	s := string(data)
+	if !strings.Contains(s, "Do the thing") || !strings.Contains(s, "Do another thing") {
+		t.Errorf("followups.md missing titles: %q", s)
+	}
+	if !strings.Contains(s, "labels: a, b") {
+		t.Errorf("followups.md missing labels line: %q", s)
+	}
+}
+
+func TestReviewWriteFollowUpsReturnsEmptyWhenNoFollowUps(t *testing.T) {
+	dir := t.TempDir()
+	rev := &Review{FollowUps: nil}
+	path, err := rev.WriteFollowUps(dir)
+	if err != nil {
+		t.Errorf("err = %v", err)
+	}
+	if path != "" {
+		t.Errorf("path should be empty when no follow-ups, got %q", path)
+	}
+}

--- a/internal/orchestrator/github_reporter.go
+++ b/internal/orchestrator/github_reporter.go
@@ -117,6 +117,10 @@ func (r *GitHubReporter) OnEvent(ctx context.Context, ev Event) error {
 		return r.transition(ctx, "tests-passed", "✅ Tests passed", ev.Message)
 	case StateTestsFailed:
 		return r.transition(ctx, "tests-failed", "❌ Tests failed", ev.Message)
+	case StateReviewing:
+		return r.transition(ctx, "reviewing", "👀 Reviewer auditing patch...", ev.Message)
+	case StateReviewDone:
+		return r.transition(ctx, "review-done", "📝 Review complete", ev.Message)
 	case StateKilled:
 		return r.transition(ctx, "killed", "🛑 Killed", ev.Message)
 	case StateError:

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -51,6 +51,8 @@ const (
 	StateTesting       State = "testing"
 	StateTestsPassed   State = "tests_passed"
 	StateTestsFailed   State = "tests_failed"
+	StateReviewing     State = "reviewing"
+	StateReviewDone    State = "review_done"
 	StateDone          State = "done"
 	StateKilled        State = "killed"
 	StateError         State = "error"
@@ -79,9 +81,11 @@ type Orchestrator struct {
 	architect   *agents.Architect
 	implementer *agents.Implementer
 	tester      *agents.Tester
+	reviewer    *agents.Reviewer
 	critRpt     *agents.Report
 	patch       *agents.Patch
 	testResult  *agents.TestResult
+	review      *agents.Review
 
 	// sketchCount is the N the Architect uses when it runs. It is set by
 	// New via the sketchCount config field and may be overridden at runtime
@@ -192,12 +196,62 @@ func New(cfg *config.Config, opts ...Option) (*Orchestrator, error) {
 	if err != nil {
 		return nil, err
 	}
+	reviewer, err := agents.NewReviewer(router)
+	if err != nil {
+		return nil, err
+	}
 	o.scout = scout
 	o.critic = critic
 	o.architect = architect
 	o.implementer = implementer
 	o.tester = tester
+	o.reviewer = reviewer
 	return o, nil
+}
+
+// Review returns the last Reviewer output, if any.
+func (o *Orchestrator) Review() *agents.Review { return o.review }
+
+// ReviewPatch runs the Reviewer against the given patch string and
+// emits reviewing → review_done. Proposed follow-ups are written to
+// `<repo>/.aidev/followups.md` if any are present. The patch argument
+// lets callers supply either the orchestrator's own Implementer output
+// or an external diff file (for `aidev review -patch foo.diff`).
+func (o *Orchestrator) ReviewPatch(ctx context.Context, patch string) <-chan Event {
+	out := make(chan Event, 4)
+	go func() {
+		defer close(out)
+		if o.ctx.Issue == nil {
+			o.state = StateError
+			o.emit(ctx, out, Event{State: StateError, Err: errors.New("orchestrator: no issue loaded")})
+			return
+		}
+		o.state = StateReviewing
+		o.emit(ctx, out, Event{State: o.state, Message: "Reviewer performing Boy Scout pass..."})
+
+		rev, err := o.reviewer.Run(ctx, o.ctx, patch)
+		if err != nil {
+			o.state = StateError
+			o.emit(ctx, out, Event{State: StateError, Err: err})
+			return
+		}
+		o.review = rev
+
+		// Best-effort follow-up persistence.
+		if o.ctx.Snapshot != nil && len(rev.FollowUps) > 0 {
+			if _, werr := rev.WriteFollowUps(o.ctx.Snapshot.Root); werr != nil {
+				fmt.Fprintf(o.reporterLog, "aidev reviewer: write followups: %v\n", werr)
+			}
+		}
+
+		o.state = StateReviewDone
+		o.emit(ctx, out, Event{
+			State: o.state,
+			Message: fmt.Sprintf("Review complete: %d blockers, %d suggestions, %d follow-ups, verdict %q",
+				len(rev.Blockers), len(rev.Suggests), len(rev.FollowUps), rev.Verdict),
+		})
+	}()
+	return out
 }
 
 // TestResult returns the last Tester result, if any.


### PR DESCRIPTION
## Summary

v0.4 ships the **Reviewer** agent, completing the full aidev pipeline: Scout → Critic → Architect → Implementer → Tester → **Reviewer**. Given a patch, the Reviewer does a Boy Scout pass and produces a structured review with three sections: blockers, suggestions, and proposed follow-up issues. The verdict (`approve` / `changes_requested` / `comment`) drives the controller's label.

Proposed follow-up issues are written to `<repo>/.aidev/followups.md` — never auto-filed. Auto-filing will land in a future `aidev followups --file-issues` subcommand once we've used the proposals in anger.

## What's in the PR

**new**
- `internal/agents/reviewer.go` — Reviewer type, Run, Review struct with Blockers/Suggests/FollowUps/Verdict, ReviewNote, FollowUpIssue, WriteFollowUps helper, strict parsers (parseReviewNotes, parseFollowUps, extractSection, extractVerdict)
- `internal/agents/reviewer_test.go` — 8 unit tests covering happy-path parsing, empty-section handling, verdict extraction (including unknown/missing fallback), section extraction, follow-up file writing, and the no-op early return

**modified**
- `internal/orchestrator/orchestrator.go` — new `StateReviewing`/`StateReviewDone` states, `ReviewPatch(ctx, patch)` method, `Review()` accessor, Reviewer wired into `New()`
- `internal/orchestrator/github_reporter.go` — controller handles the two new states with label swaps (`aidev:reviewing`, `aidev:review-done`)
- `cmd/aidev/main.go` — new `review` subcommand that loads a patch file (default `.aidev/proposed.patch`), runs the Reviewer with issue context, prints the review, and persists follow-ups
- `README.md` — updated status and roadmap; v0.4 is 'full agent pipeline shipped'

## Design decisions

- **Reviewer is input-agnostic.** `ReviewPatch(ctx, patch)` takes a raw diff string, so it works on the Implementer's output, an external `.diff` file, or any other source. Keeps the Reviewer decoupled from the rest of the pipeline.
- **Three fixed sections with a strict parser.** Just like the Architect's sketch format, the Reviewer emits a deterministic section structure so parsing is reliable. Empty sections are legal — if there are no blockers, the parser returns an empty slice rather than erroring.
- **Follow-ups use a structured bullet format.** `- **Title** — body (labels: a, b)` so the parser can extract them cleanly. A summary paragraph inside the follow-ups section (which models sometimes add) is silently skipped rather than becoming a bogus issue.
- **Verdict has a canonical fallback.** Unknown, missing, or hedged verdicts collapse to 'comment'. The controller always has something to render; no NPE paths.
- **No auto-filing.** Writing issues to GitHub without user review is a 'one-way door' operation by our own principles file. The Reviewer proposes; the user decides. An opt-in `--file-issues` follows once the proposal quality is validated.
- **No-op short circuit.** If the patch starts with `# no-op` (the Implementer's marker for documentation-only sketches), the Reviewer returns `approve` immediately with no LLM call.
- **Medium tier routing.** Review is high-volume text analysis, not deep reasoning; the medium tier is the right cost/quality point.

## State machine

`ReviewPatch` is valid from any state once the issue is loaded. The typical flow is `patch_ready → reviewing → review_done`, but the standalone subcommand can invoke it directly from a fresh orchestrator loading an external patch file.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all existing tests pass + 8 new reviewer tests
- [x] `aidev review -h` shows the subcommand flags
- [ ] **Manual smoke (for @crisscross82 tomorrow):**
  - After running `aidev -headless -auto -sketch 1` to get a proposed patch, run `aidev review -issue <url> -repo <path>` and verify the structured output prints
  - Verify `.aidev/followups.md` is created when the model produces follow-up proposals
  - Try with `-patch /path/to/external.diff` to confirm the external-patch path works
  - Run against a patch that violates a principle — verify the BLOCKERS section picks it up and the verdict is `changes_requested`

## Worth reviewing carefully

- **Parser strictness vs model reliability.** Models sometimes drift from the exact format. The parser is tolerant of extra whitespace, case on the VERDICT line, and extra prose inside sections. If you hit a real-world case where a sensible review is parsed as 'zero blockers' because the section header is missing, I'll tighten the parser.
- **Follow-up title length.** No hard cap. A model that produces 200-char titles will write 200-char titles. Adding a sanity limit is a follow-up if it becomes a problem.
- **Verdict-to-label mapping.** The controller uses `aidev:reviewing` and `aidev:review-done` regardless of verdict. If you want verdict-specific labels (`aidev:approved`, `aidev:blocked`), say so and I'll split in a follow-up.

## Out of scope

- Auto-filing follow-up issues (`aidev followups --file-issues`)
- TUI integration for review display
- Line-level inline review comments on a PR diff
- Recurring review on a changing patch