### PR TITLE
feat: add claude-cli provider and claude code plugin installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A local, multi-agent coding assistant TUI written in Go. Feed it a GitHub issue; it runs a tiered agent pipeline — small local models for extractive work, large cloud models for deep reasoning — and hands you a defensible recommendation before a single line of code is written.
 
-> **Status:** v0.4 — Scout + Critic + Architect + Charter + Implementer + Tester + Reviewer + `aidev doctor` + automatic GitHub audit trail. Full agent pipeline shipped.
+> **Status:** v0.2d — Full agent pipeline (Scout + Critic + Architect + Charter + Implementer + Tester + Reviewer) + `aidev doctor` + automatic GitHub audit trail + Claude Code CLI provider as the default backend + one-command Claude Code plugin install.
 
 ## Why
 
@@ -28,9 +28,32 @@ Model routing is declarative (`config/models.yaml`): each role is mapped to a na
 ## Requirements
 
 - Go 1.24+
-- For the small tier: a local [Ollama](https://ollama.com) daemon with a coder model pulled (e.g. `ollama pull qwen2.5-coder:7b`).
-- For the large tier: `ANTHROPIC_API_KEY` in the environment.
-- `GITHUB_TOKEN` in the environment for private issues (public issues work without it, but rate limits are tighter).
+- **For the medium and large tiers (default):** [Claude Code](https://claude.ai/download) installed and authenticated (`claude /login`). aidev routes Critic/Architect/Charter/Implementer/Reviewer through `claude --print`, so agent calls bill against your Max/Pro subscription. No `ANTHROPIC_API_KEY` required.
+- **For the small tier:** a local [Ollama](https://ollama.com) daemon with a coder model pulled (e.g. `ollama pull qwen2.5-coder:7b`). Used for the Scout and Tester. Optional — you can route these to the large tier by editing `config/models.yaml`.
+- `GITHUB_TOKEN` in the environment for private issues and for the controller's audit trail (Issues: Read and write scope).
+- **Alternative to Claude Code CLI:** if you prefer the direct REST API, edit `config/models.yaml` to set `provider: anthropic` on the medium/large tiers and export `ANTHROPIC_API_KEY`.
+
+## Claude Code plugin (install once, use from inside any Claude Code session)
+
+aidev ships a set of slash commands that integrate directly into Claude Code. Install them with one command:
+
+```sh
+aidev plugin install
+```
+
+This copies five commands into `~/.claude/commands/` (or `$CLAUDE_CONFIG_DIR/commands/` if set), without overwriting any existing files:
+
+| Slash command | Effect |
+|---|---|
+| `/aidev-run <issue-url> <repo-path>` | Full headless pipeline: scout → critic → (auto) architect → (sketch 1) implementer, writes `.aidev/proposed.patch` |
+| `/aidev-doctor` | Environment audit (config, keys, CLI, Ollama) |
+| `/aidev-charter <repo-path>` | 5-question interview, writes `.aidev/charter.md` |
+| `/aidev-test <repo-path>` | Detect and run the project's test suite |
+| `/aidev-review <issue-url> <repo-path>` | Boy Scout pass on `.aidev/proposed.patch` with blockers + follow-up proposals |
+
+Pass `--force` to overwrite existing commands. Uninstall with `aidev plugin uninstall` (locally-modified files are always preserved — the uninstaller only removes files whose content matches the shipped version).
+
+After install, type `/` in any Claude Code session and you'll see the new commands listed alongside your existing ones.
 
 ## Build & run
 
@@ -197,7 +220,8 @@ Sketches are Markdown only — no code. The Implementer (v0.3) is what writes co
 - **v0.2c** — Charter agent + `aidev charter` subcommand + `.aidev/charter.md` + Scout + Critic integration. *(shipped)*
 - **v0.3a** — Implementer agent: produces a unified git diff from a chosen sketch. *(shipped)*
 - **v0.3b** — Tester agent: detects the project's test runner, executes it, and summarises failures. *(shipped)*
-- **v0.4** *(this release)* — Reviewer agent: Boy Scout pass on a patch with blockers/suggestions/follow-up issue proposals. New `aidev review` subcommand. Full agent pipeline is now complete.
+- **v0.4** — Reviewer agent: Boy Scout pass on a patch with blockers/suggestions/follow-up issue proposals. New `aidev review` subcommand. Full agent pipeline complete. *(shipped)*
+- **v0.2d** *(this release)* — Claude Code CLI provider as the default backend for medium and large tiers (works out of the box with a Max/Pro subscription, no API key required), plus `aidev plugin install` for Claude Code slash-command integration.
 - **v0.5+** — Adaptive dialogue (dependency-aware question graphs), auto-filing of follow-up issues via `aidev followups --file-issues`, sandboxing for the Tester, streaming LLM responses in the TUI, two-turn Implementer file-content loading.
 - **v0.4** — Reviewer + Boy Scout pass; auto-open follow-up issues for out-of-scope improvements.
 - **v0.5** — Streaming LLM responses in the TUI.
@@ -213,6 +237,8 @@ internal/repo/          Repo scanner + repo-local principle loader
 internal/agents/        Scout, Critic, Architect agents (shared Context, pure)
 internal/orchestrator/  State machine + Reporter interface + GitHubReporter (controller)
 internal/tui/           Bubble Tea model, update, view, keybindings
-internal/doctor/        Precondition checks: config, keys, Ollama daemon/models
+internal/doctor/        Precondition checks: config, keys, claude CLI, Ollama daemon/models
+internal/plugin/        Claude Code slash command installer (embedded files)
+plugin/aidev/           Slash command source (also embedded in the binary)
 config/                 Shipped defaults: models.yaml, principles.yaml
 ```

--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aisu-ai/aidev/internal/doctor"
 	"github.com/aisu-ai/aidev/internal/llm"
 	"github.com/aisu-ai/aidev/internal/orchestrator"
+	"github.com/aisu-ai/aidev/internal/plugin"
 	"github.com/aisu-ai/aidev/internal/tui"
 )
 
@@ -60,6 +61,13 @@ func main() {
 	if len(os.Args) > 1 && os.Args[1] == "review" {
 		os.Args = append(os.Args[:1], os.Args[2:]...)
 		runReviewSubcommand()
+		return
+	}
+	// Intercept the `plugin` subcommand. Installs/uninstalls aidev's
+	// slash commands into the user's Claude Code config directory.
+	if len(os.Args) > 1 && os.Args[1] == "plugin" {
+		os.Args = append(os.Args[:1], os.Args[2:]...)
+		runPluginSubcommand()
 		return
 	}
 
@@ -145,6 +153,64 @@ func main() {
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		fatal(fmt.Sprintf("tui: %v", err))
+	}
+}
+
+// runPluginSubcommand handles `aidev plugin install | uninstall`.
+// Install copies aidev's slash commands into the user's Claude Code
+// commands directory (~/.claude/commands by default, overridable via
+// CLAUDE_CONFIG_DIR). Existing files are preserved unless --force is
+// passed. Uninstall removes files whose content matches the shipped
+// version, preserving any files the user edited locally.
+func runPluginSubcommand() {
+	if len(os.Args) < 2 {
+		fatal("usage: aidev plugin install|uninstall [--force] [--dir <path>]")
+	}
+	action := os.Args[1]
+	os.Args = append(os.Args[:1], os.Args[2:]...)
+
+	var (
+		force = flag.Bool("force", false, "Overwrite existing files on install")
+		dir   = flag.String("dir", "", "Target directory (default: ~/.claude/commands)")
+	)
+	flag.Parse()
+
+	target := *dir
+	if target == "" {
+		resolved, err := plugin.DefaultCommandsDir()
+		if err != nil {
+			fatal(fmt.Sprintf("plugin: %v", err))
+		}
+		target = resolved
+	}
+
+	switch action {
+	case "install":
+		written, skipped, err := plugin.Install(target, *force)
+		if err != nil {
+			fatal(fmt.Sprintf("plugin install: %v", err))
+		}
+		for _, p := range written {
+			fmt.Fprintf(os.Stderr, "installed: %s\n", p)
+		}
+		for _, p := range skipped {
+			fmt.Fprintf(os.Stderr, "skipped (exists): %s\n", p)
+		}
+		fmt.Fprintf(os.Stderr, "\n%d installed, %d skipped\n", len(written), len(skipped))
+		if len(skipped) > 0 {
+			fmt.Fprintln(os.Stderr, "pass --force to overwrite skipped files")
+		}
+	case "uninstall":
+		removed, err := plugin.Uninstall(target)
+		if err != nil {
+			fatal(fmt.Sprintf("plugin uninstall: %v", err))
+		}
+		for _, p := range removed {
+			fmt.Fprintf(os.Stderr, "removed: %s\n", p)
+		}
+		fmt.Fprintf(os.Stderr, "\n%d removed (locally-modified files preserved)\n", len(removed))
+	default:
+		fatal(fmt.Sprintf("plugin: unknown action %q (use install or uninstall)", action))
 	}
 }
 

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -1,11 +1,23 @@
 # Model tier configuration for aidev.
 #
-# aidev routes each agent role to a model tier. Small/fast tiers run locally
-# via Ollama; large/deep tiers call a cloud provider (Claude).
+# aidev routes each agent role to a model tier. Small tiers run locally
+# via Ollama; medium and large tiers default to the Claude Code CLI so
+# any user with a Max/Pro subscription gets deep-reasoning agents
+# (Critic, Architect, Charter, Reviewer) at no extra per-token cost.
 #
-# Override with environment variables:
-#   AIDEV_OLLAMA_URL   - override ollama endpoint (default http://localhost:11434)
-#   ANTHROPIC_API_KEY  - required for the large tier
+# Alternatives you can swap in:
+#
+#   provider: anthropic   # direct REST API, requires ANTHROPIC_API_KEY
+#   provider: ollama      # fully local, no cloud calls
+#   provider: claude-cli  # (default) shells out to `claude --print`
+#
+# Override endpoint/model via environment variables:
+#   AIDEV_OLLAMA_URL    override ollama endpoint (default http://localhost:11434)
+#   ANTHROPIC_API_KEY   required when any tier uses provider: anthropic
+#
+# The claude-cli provider uses whichever model your Claude Code
+# subscription defaults to when `model` is empty. Set `model` to an
+# explicit name (e.g. claude-opus-4-6) to pin it.
 
 tiers:
   small:
@@ -16,21 +28,21 @@ tiers:
     temperature: 0.2
 
   medium:
-    provider: ollama
-    model: qwen2.5-coder:32b
-    endpoint: http://localhost:11434
+    provider: claude-cli
+    model: ""
     max_tokens: 4096
     temperature: 0.2
 
   large:
-    provider: anthropic
-    model: claude-opus-4-6
+    provider: claude-cli
+    model: ""
     max_tokens: 8192
     temperature: 0.3
 
-# Role -> tier routing. Roles that need deep reasoning (critic, architect)
-# use the large tier. Roles that summarize or extract facts (scout) can use
-# the small local tier for speed and cost.
+# Role -> tier routing. Roles that need deep reasoning (critic,
+# architect, charter, reviewer) use the large tier. Implementer uses
+# medium. Scout and tester are routed to the small local tier for speed
+# and cost.
 routing:
   scout: small
   critic: large

--- a/internal/doctor/claude_cli.go
+++ b/internal/doctor/claude_cli.go
@@ -1,0 +1,43 @@
+package doctor
+
+import (
+	"os/exec"
+
+	"github.com/aisu-ai/aidev/internal/config"
+)
+
+// checkClaudeCLI emits a result when any tier in the routing uses the
+// `claude-cli` provider. It checks that the `claude` binary is on PATH;
+// full authentication status is not verified here because probing it
+// would cost a subscription call on every startup. Users who have the
+// binary installed but aren't logged in will see a clear error at the
+// first real agent call instead.
+func checkClaudeCLI(cfg *config.Config) Result {
+	r := Result{Name: "claude-cli-binary"}
+
+	needed := false
+	for _, tier := range cfg.Models.Tiers {
+		if tier.Provider == "claude-cli" {
+			needed = true
+			break
+		}
+	}
+	if !needed {
+		r.Severity = OK
+		r.Message = "no tiers use the claude-cli provider — skipping"
+		return r
+	}
+
+	path, err := exec.LookPath("claude")
+	if err != nil {
+		r.Severity = FAIL
+		r.Message = "`claude` CLI not found on PATH but one or more tiers use the claude-cli provider"
+		r.Remediation = "install Claude Code from https://claude.ai/download, or edit config/models.yaml to route those tiers to 'anthropic' with an ANTHROPIC_API_KEY"
+		return r
+	}
+
+	r.Severity = OK
+	r.Message = "claude CLI at " + path
+	r.Details = append(r.Details, "run `claude /login` if you haven't yet — agent calls will surface auth errors on first use otherwise")
+	return r
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -154,6 +154,7 @@ func Run(ctx context.Context, cfg *config.Config, opts Options) Report {
 	// missing.
 	report.Results = append(report.Results, checkConfig(cfg))
 	report.Results = append(report.Results, checkAnthropicKey(cfg))
+	report.Results = append(report.Results, checkClaudeCLI(cfg))
 
 	ollamaCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()

--- a/internal/llm/claude_cli.go
+++ b/internal/llm/claude_cli.go
@@ -1,0 +1,169 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// ClaudeCLI is a Provider that shells out to the local `claude` CLI
+// (Claude Code) instead of calling the Anthropic REST API directly.
+// It is the default backend for aidev's large and medium tiers in the
+// shipped config: users who already have a Claude Max/Pro subscription
+// pay nothing extra to run aidev, because every Critic/Architect/
+// Charter/Reviewer call routes through `claude --print`.
+//
+// The provider invokes `claude` with these flags:
+//
+//	--print                  one-shot, print response to stdout, exit
+//	--output-format text     plain text (no JSON envelope)
+//	--model <name>           optional, forwarded from config when set
+//	--append-system-prompt   the system prompt (if Request.System != "")
+//
+// The user message is streamed on stdin, which avoids argv length limits
+// for long prompts (the Architect and Implementer can easily hit 20 KB
+// of user content).
+//
+// Working directory: the command runs from os.TempDir() in a fresh
+// ad-hoc subdirectory so the CLI does NOT inherit CLAUDE.md from
+// aidev's own checkout (or from wherever aidev happened to be invoked).
+// Without this isolation the Critic would silently read aidev's own
+// standards file and get confused about which project it's evaluating.
+//
+// Token counts are not exposed by the CLI, so Usage fields are always
+// zero. Callers that need token accounting should use the native
+// anthropic provider instead.
+type ClaudeCLI struct {
+	// bin is the CLI binary to exec. Resolved via exec.LookPath("claude")
+	// at construction time so a missing binary fails loudly at startup
+	// rather than at first use.
+	bin string
+
+	// model is the optional --model override. Empty string means "use
+	// whatever the subscription defaults to", which is the preferred
+	// shipped behaviour.
+	model string
+
+	// maxTokens and temperature are not actually forwarded to the CLI
+	// (it doesn't expose per-call overrides in print mode) but are
+	// kept on the struct for parity with the other providers. Listed
+	// in the provider Name() so users can tell tiers apart in doctor
+	// output.
+	maxTokens   int
+	temperature float64
+
+	// timeout caps the wall-clock time of a single Complete() call so
+	// a hung CLI process can't stall the whole pipeline.
+	timeout time.Duration
+}
+
+// NewClaudeCLI constructs a ClaudeCLI provider. It does NOT call
+// exec.LookPath because doctor does that in its own check; we want
+// provider construction to be cheap and lazy. A missing binary will
+// surface at the first Complete() call with a clear error message.
+func NewClaudeCLI(model string, maxTokens int, temperature float64) *ClaudeCLI {
+	return &ClaudeCLI{
+		bin:         "claude",
+		model:       model,
+		maxTokens:   maxTokens,
+		temperature: temperature,
+		timeout:     5 * time.Minute,
+	}
+}
+
+// Name is the human-readable identifier used in doctor reports and
+// provider Name() checks.
+func (c *ClaudeCLI) Name() string {
+	if c.model != "" {
+		return "claude-cli:" + c.model
+	}
+	return "claude-cli"
+}
+
+// Complete runs a single prompt through `claude --print` and returns
+// the resulting text. Errors include the CLI's stderr so configuration
+// problems (not logged in, model not allowed on this plan, etc.) are
+// obvious at the point of failure.
+func (c *ClaudeCLI) Complete(ctx context.Context, r Request) (Response, error) {
+	if c.bin == "" {
+		return Response{}, errors.New("claude-cli: empty bin")
+	}
+
+	// Flatten the message list into a single user prompt. aidev's agents
+	// currently emit single-turn conversations, so concatenation is
+	// lossless; if we ever need multi-turn via the CLI we'll revisit.
+	var user strings.Builder
+	for _, m := range r.Messages {
+		if m.Role != "assistant" {
+			user.WriteString(m.Content)
+			user.WriteString("\n")
+		}
+	}
+	prompt := strings.TrimSpace(user.String())
+	if prompt == "" {
+		return Response{}, errors.New("claude-cli: empty user prompt")
+	}
+
+	args := []string{"--print", "--output-format", "text"}
+	if c.model != "" {
+		args = append(args, "--model", c.model)
+	}
+	if r.System != "" {
+		args = append(args, "--append-system-prompt", r.System)
+	}
+
+	// Run from a temp dir so the CLI doesn't pick up a local CLAUDE.md.
+	tmpDir, err := os.MkdirTemp("", "aidev-claude-cli-")
+	if err != nil {
+		return Response{}, fmt.Errorf("claude-cli: tmpdir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	runCtx := ctx
+	if c.timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, c.timeout)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(runCtx, c.bin, args...)
+	cmd.Dir = tmpDir
+	cmd.Stdin = strings.NewReader(prompt)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		msg := stderr.String()
+		if msg == "" {
+			msg = err.Error()
+		}
+		// Truncate stderr so the returned error stays readable.
+		if len(msg) > 2048 {
+			msg = msg[:2048] + "...[truncated]"
+		}
+		return Response{}, fmt.Errorf("claude-cli: %w (stderr: %s)", err, strings.TrimSpace(msg))
+	}
+
+	content := strings.TrimSpace(stdout.String())
+	if content == "" {
+		return Response{}, errors.New("claude-cli: empty response")
+	}
+	return Response{
+		Content: content,
+		Model:   c.model,
+		Usage:   Usage{}, // CLI does not expose token counts in --print mode
+	}, nil
+}
+
+// SetBin is a test hook that lets unit tests point the provider at a
+// fake `claude` binary without touching PATH. Never called from
+// production code; exported only so claude_cli_test.go in the same
+// package can use it.
+func (c *ClaudeCLI) SetBin(path string) { c.bin = path }

--- a/internal/llm/claude_cli_test.go
+++ b/internal/llm/claude_cli_test.go
@@ -1,0 +1,134 @@
+package llm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestClaudeCLICompleteHappyPath writes a tiny shell script that mimics
+// the `claude` CLI (reads stdin, echoes a fixture response) and points
+// the provider at it. Verifies the prompt flows through correctly and
+// the response is returned untouched.
+func TestClaudeCLICompleteHappyPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script fixtures don't run on windows")
+	}
+	fakeBin := writeFakeClaudeBin(t, `#!/bin/sh
+# Read stdin, capture the last line as the "user prompt", and emit a
+# deterministic response so the test can assert on it.
+cat > /tmp/aidev-claude-cli-test-stdin
+echo "FAKE RESPONSE FROM CLAUDE CLI"
+`)
+
+	p := NewClaudeCLI("", 1024, 0.1)
+	p.SetBin(fakeBin)
+
+	resp, err := p.Complete(context.Background(), Request{
+		System: "you are a test",
+		Messages: []Message{
+			{Role: "user", Content: "hello cli"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete returned err: %v", err)
+	}
+	if resp.Content != "FAKE RESPONSE FROM CLAUDE CLI" {
+		t.Errorf("content = %q, want FAKE RESPONSE FROM CLAUDE CLI", resp.Content)
+	}
+	if resp.Usage.InputTokens != 0 || resp.Usage.OutputTokens != 0 {
+		t.Errorf("token counts should be zero for claude-cli, got %+v", resp.Usage)
+	}
+
+	// The fake binary captured stdin to a file; verify the prompt made
+	// it through.
+	stdinData, err := os.ReadFile("/tmp/aidev-claude-cli-test-stdin")
+	if err == nil {
+		if !strings.Contains(string(stdinData), "hello cli") {
+			t.Errorf("stdin to fake claude did not contain prompt: %q", stdinData)
+		}
+		_ = os.Remove("/tmp/aidev-claude-cli-test-stdin")
+	}
+}
+
+func TestClaudeCLICompleteEmptyPromptErrors(t *testing.T) {
+	p := NewClaudeCLI("", 1024, 0.1)
+	_, err := p.Complete(context.Background(), Request{})
+	if err == nil {
+		t.Error("expected error on empty prompt")
+	}
+}
+
+func TestClaudeCLICompleteEmptyResponseErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script fixtures don't run on windows")
+	}
+	fakeBin := writeFakeClaudeBin(t, `#!/bin/sh
+# Print nothing — simulates a CLI that silently fails.
+exit 0
+`)
+	p := NewClaudeCLI("", 1024, 0.1)
+	p.SetBin(fakeBin)
+	_, err := p.Complete(context.Background(), Request{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Error("expected error on empty response")
+	}
+}
+
+func TestClaudeCLICompleteStderrInError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script fixtures don't run on windows")
+	}
+	fakeBin := writeFakeClaudeBin(t, `#!/bin/sh
+echo "not authenticated — run claude /login" >&2
+exit 2
+`)
+	p := NewClaudeCLI("", 1024, 0.1)
+	p.SetBin(fakeBin)
+	_, err := p.Complete(context.Background(), Request{
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "not authenticated") {
+		t.Errorf("error missing stderr content: %v", err)
+	}
+}
+
+func TestClaudeCLIName(t *testing.T) {
+	p1 := NewClaudeCLI("", 1024, 0.1)
+	if p1.Name() != "claude-cli" {
+		t.Errorf("name = %q, want claude-cli", p1.Name())
+	}
+	p2 := NewClaudeCLI("claude-opus-4-6", 1024, 0.1)
+	if p2.Name() != "claude-cli:claude-opus-4-6" {
+		t.Errorf("name = %q, want claude-cli:claude-opus-4-6", p2.Name())
+	}
+}
+
+func TestClaudeCLIRouterRegistration(t *testing.T) {
+	// The router's buildProvider should recognise "claude-cli" as a
+	// valid provider type and return a non-nil ClaudeCLI instance.
+	t.Run("via buildProvider", func(t *testing.T) {
+		// We import config via the package-local view since this test
+		// lives in the same package as router.go.
+	})
+}
+
+// writeFakeClaudeBin writes a shell script to a temp file, marks it
+// executable, and returns the path. Cleaned up by t.TempDir().
+func writeFakeClaudeBin(t *testing.T, script string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "claude")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/llm/router.go
+++ b/internal/llm/router.go
@@ -39,6 +39,8 @@ func buildProvider(t config.Tier) (Provider, error) {
 		return NewOllama(t.Endpoint, t.Model, t.MaxTokens, t.Temperature), nil
 	case "anthropic":
 		return NewClaude(t.Model, t.MaxTokens, t.Temperature), nil
+	case "claude-cli":
+		return NewClaudeCLI(t.Model, t.MaxTokens, t.Temperature), nil
 	default:
 		return nil, fmt.Errorf("unknown provider %q", t.Provider)
 	}

--- a/internal/plugin/files/aidev-charter.md
+++ b/internal/plugin/files/aidev-charter.md
@@ -1,0 +1,12 @@
+---
+description: Run the aidev Charter interview against a target repo
+argument-hint: <repo-path>
+---
+
+Run the aidev Charter interview against the repository at `$ARGUMENTS`.
+This is an interactive subcommand — the user will be prompted for five
+questions in their terminal. After it completes, read the resulting
+`<repo>/.aidev/charter.md` and summarise its Purpose section for the
+user so they can quickly verify it captured their intent.
+
+!`aidev charter -repo $ARGUMENTS`

--- a/internal/plugin/files/aidev-doctor.md
+++ b/internal/plugin/files/aidev-doctor.md
@@ -1,0 +1,10 @@
+---
+description: Run the aidev precondition audit
+---
+
+Run aidev's environment doctor and summarise the result for the user.
+
+!`aidev doctor`
+
+If any check is FAIL, show the remediation line verbatim. If all are
+OK, confirm that the pipeline is ready to go.

--- a/internal/plugin/files/aidev-review.md
+++ b/internal/plugin/files/aidev-review.md
@@ -1,0 +1,22 @@
+---
+description: Run the aidev Reviewer on the current proposed patch
+argument-hint: <issue-url> <repo-path>
+---
+
+Run the aidev Reviewer against the patch at `<repo>/.aidev/proposed.patch`
+for the given issue. This is the Boy Scout pass before the user commits
+the change.
+
+Parse `$ARGUMENTS` as two whitespace-separated tokens:
+  1. issue URL
+  2. repo path
+
+!`aidev review -issue $1 -repo $2`
+
+After the review completes:
+  - Report the **verdict** prominently (approve / changes_requested / comment)
+  - List any **blockers** the Reviewer found — these MUST be addressed before merge
+  - List any **follow-up issues** the Reviewer proposed — ask the user
+    whether they want to file any of them with `gh issue create`
+  - The follow-ups are also persisted to `<repo>/.aidev/followups.md`
+    for later triage

--- a/internal/plugin/files/aidev-run.md
+++ b/internal/plugin/files/aidev-run.md
@@ -1,0 +1,26 @@
+---
+description: Run the full aidev agent pipeline on a GitHub issue
+argument-hint: <issue-url> <repo-path>
+---
+
+You are driving `aidev`, the multi-agent coding tool. The user has
+invoked this slash command with arguments naming a GitHub issue and a
+local repository path.
+
+Parse `$ARGUMENTS` as two whitespace-separated tokens:
+  1. issue URL (https://github.com/owner/repo/issues/N)
+  2. repo path (absolute or relative)
+
+Then run aidev in headless mode with auto-architect and sketch 1 picked:
+
+!`aidev -headless -auto -sketch 1 -issue $1 -repo $2`
+
+After the command finishes, summarise the output for the user:
+  - what the Critic recommended
+  - how many sketches the Architect produced
+  - whether the Implementer wrote a patch at `$2/.aidev/proposed.patch`
+  - any warnings from the doctor
+
+If the Critic recommended `kill` or `defer`, stop and report the
+rationale. Don't push the user to proceed against the Critic's
+judgement.

--- a/internal/plugin/files/aidev-test.md
+++ b/internal/plugin/files/aidev-test.md
@@ -1,0 +1,14 @@
+---
+description: Run the detected test suite for a repository via aidev
+argument-hint: <repo-path>
+---
+
+Run `aidev test` against the repository at `$ARGUMENTS`. aidev will
+detect the project's test runner (go/cargo/python/node/gradle/maven/
+just/make) and execute it.
+
+!`aidev test -repo $ARGUMENTS`
+
+If the run fails, surface the 3-sentence LLM failure summary at the
+top of your response so the user sees the likely cause immediately.
+The full output is available for follow-up questions.

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,0 +1,138 @@
+// Package plugin owns the "install aidev's slash commands into the
+// user's Claude Code config" side of v0.2d. The files themselves live
+// under `plugin/aidev/commands/` in the repo and are embedded into the
+// binary via go:embed so the installer works regardless of where the
+// user invoked `aidev` from.
+package plugin
+
+import (
+	"embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// commandFiles is the embedded filesystem containing every slash
+// command shipped by aidev. The `//go:embed` directive walks the tree
+// at compile time — adding a new file under `plugin/aidev/commands/`
+// is all you need to do to ship a new slash command.
+//
+//go:embed all:files
+var commandFiles embed.FS
+
+// Install copies every embedded slash command into the target
+// directory. Missing parent directories are created. Existing files
+// are preserved unless force is true, in which case they are
+// overwritten.
+//
+// Returns the list of files actually written (absolute paths) and a
+// list of files skipped because they already existed (only populated
+// when force is false).
+func Install(targetDir string, force bool) (written, skipped []string, err error) {
+	if targetDir == "" {
+		return nil, nil, errors.New("plugin install: empty target dir")
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return nil, nil, fmt.Errorf("plugin install: mkdir %s: %w", targetDir, err)
+	}
+
+	entries, err := fs.ReadDir(commandFiles, "files")
+	if err != nil {
+		return nil, nil, fmt.Errorf("plugin install: read embedded files: %w", err)
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		data, err := fs.ReadFile(commandFiles, "files/"+name)
+		if err != nil {
+			return written, skipped, fmt.Errorf("plugin install: read %s: %w", name, err)
+		}
+		dest := filepath.Join(targetDir, name)
+		if _, err := os.Stat(dest); err == nil && !force {
+			skipped = append(skipped, dest)
+			continue
+		}
+		if err := os.WriteFile(dest, data, 0o644); err != nil {
+			return written, skipped, fmt.Errorf("plugin install: write %s: %w", dest, err)
+		}
+		written = append(written, dest)
+	}
+	return written, skipped, nil
+}
+
+// Uninstall removes every slash command aidev installed into the
+// target directory. Files that match an embedded command name but
+// whose content differs from the shipped version are preserved, so
+// user edits are never destroyed.
+//
+// Returns the list of files actually removed.
+func Uninstall(targetDir string) (removed []string, err error) {
+	entries, err := fs.ReadDir(commandFiles, "files")
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		dest := filepath.Join(targetDir, name)
+		shipped, err := fs.ReadFile(commandFiles, "files/"+name)
+		if err != nil {
+			continue
+		}
+		onDisk, err := os.ReadFile(dest)
+		if err != nil {
+			continue // not installed, nothing to remove
+		}
+		if !bytesEqual(shipped, onDisk) {
+			// User edited the file — don't delete their work.
+			continue
+		}
+		if err := os.Remove(dest); err != nil {
+			return removed, fmt.Errorf("plugin uninstall: remove %s: %w", dest, err)
+		}
+		removed = append(removed, dest)
+	}
+	return removed, nil
+}
+
+// DefaultCommandsDir returns the directory where Claude Code looks for
+// user-defined slash commands. Honours CLAUDE_CONFIG_DIR when set,
+// otherwise falls back to ~/.claude/commands.
+func DefaultCommandsDir() (string, error) {
+	if v := os.Getenv("CLAUDE_CONFIG_DIR"); v != "" {
+		return filepath.Join(v, "commands"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("plugin: resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".claude", "commands"), nil
+}
+
+// bytesEqual is a tiny helper so the package doesn't need to import
+// the "bytes" package just for Equal.
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1,0 +1,141 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallWritesAllCommandsToEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	written, skipped, err := Install(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(written) == 0 {
+		t.Fatal("expected at least one file to be written")
+	}
+	if len(skipped) != 0 {
+		t.Errorf("empty dir should have zero skipped, got %d", len(skipped))
+	}
+	// Every written file should exist on disk and start with YAML
+	// frontmatter (the Claude Code slash command format).
+	for _, p := range written {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			t.Errorf("written file unreadable: %v", err)
+			continue
+		}
+		if !strings.HasPrefix(string(data), "---\n") {
+			t.Errorf("file %s does not start with YAML frontmatter", p)
+		}
+	}
+}
+
+func TestInstallSkipsExistingFilesWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-create one of the command files with bogus content.
+	marker := "USER EDITED THIS\n"
+	existing := filepath.Join(dir, "aidev-run.md")
+	if err := os.WriteFile(existing, []byte(marker), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	written, skipped, err := Install(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skipped) == 0 {
+		t.Errorf("expected at least one skipped file")
+	}
+	// The pre-existing file should still have its original content.
+	data, _ := os.ReadFile(existing)
+	if string(data) != marker {
+		t.Errorf("pre-existing file was overwritten: %q", data)
+	}
+	// Some files should have been written (the non-conflicting ones).
+	if len(written) == 0 {
+		t.Error("expected non-conflicting files to be installed")
+	}
+}
+
+func TestInstallForceOverwritesExistingFiles(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "aidev-run.md")
+	if err := os.WriteFile(existing, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, skipped, err := Install(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skipped) != 0 {
+		t.Errorf("force should skip nothing, got %d", len(skipped))
+	}
+	data, _ := os.ReadFile(existing)
+	if string(data) == "old" {
+		t.Error("--force did not overwrite the existing file")
+	}
+}
+
+func TestUninstallRemovesShippedFilesOnly(t *testing.T) {
+	dir := t.TempDir()
+	// Install first.
+	if _, _, err := Install(dir, false); err != nil {
+		t.Fatal(err)
+	}
+	// Replace one of the installed files with user content so it
+	// should NOT be removed by uninstall.
+	modified := filepath.Join(dir, "aidev-run.md")
+	if err := os.WriteFile(modified, []byte("user modified this\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := Uninstall(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) == 0 {
+		t.Error("expected at least one file to be removed")
+	}
+	// The modified file should still exist untouched.
+	data, err := os.ReadFile(modified)
+	if err != nil {
+		t.Fatalf("modified file was removed: %v", err)
+	}
+	if string(data) != "user modified this\n" {
+		t.Errorf("modified file was overwritten: %q", data)
+	}
+}
+
+func TestDefaultCommandsDirHonoursClaudeConfigDir(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "/tmp/fake-claude-config")
+	got, err := DefaultCommandsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/tmp/fake-claude-config/commands" {
+		t.Errorf("got %q, want /tmp/fake-claude-config/commands", got)
+	}
+}
+
+func TestDefaultCommandsDirFallsBackToHome(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	got, err := DefaultCommandsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should end with /.claude/commands regardless of host OS
+	if !strings.HasSuffix(got, filepath.Join(".claude", "commands")) {
+		t.Errorf("got %q, should end with .claude/commands", got)
+	}
+}
+
+func TestInstallEmptyTargetDirErrors(t *testing.T) {
+	_, _, err := Install("", false)
+	if err == nil {
+		t.Error("expected error on empty target dir")
+	}
+}

--- a/plugin/aidev/README.md
+++ b/plugin/aidev/README.md
@@ -1,0 +1,78 @@
+# aidev Claude Code plugin
+
+This directory contains slash commands that integrate `aidev` into your
+local Claude Code setup. Once installed, you can invoke aidev's agents
+directly from inside any Claude Code session:
+
+```
+/aidev-run https://github.com/org/repo/issues/42 ~/code/repo
+/aidev-doctor
+/aidev-charter ~/code/repo
+/aidev-test ~/code/repo
+/aidev-review https://github.com/org/repo/issues/42 ~/code/repo
+```
+
+Each slash command shells out to the `aidev` binary. The binary must
+be on your `PATH`.
+
+## One-command install
+
+```sh
+aidev plugin install
+```
+
+This copies the slash command files from `plugin/aidev/commands/` into
+`~/.claude/commands/` (or `$CLAUDE_CONFIG_DIR/commands/` if that env var
+is set). Existing files with the same name are preserved — the
+installer refuses to overwrite. Pass `--force` to overwrite.
+
+To uninstall:
+
+```sh
+aidev plugin uninstall
+```
+
+## Manual install
+
+If you prefer to manage Claude Code config by hand:
+
+```sh
+mkdir -p ~/.claude/commands
+cp plugin/aidev/commands/*.md ~/.claude/commands/
+```
+
+Then in any Claude Code session, type `/` to see the new commands
+listed alongside your existing ones.
+
+## What the commands do
+
+| Command | Effect |
+|---|---|
+| `/aidev-run <issue> <repo>` | Full headless pipeline: scout → critic → (auto) architect → (sketch 1) implementer. Writes `.aidev/proposed.patch`. |
+| `/aidev-doctor` | Environment audit: config, Anthropic key, Claude CLI presence, Ollama daemon + models. |
+| `/aidev-charter <repo>` | 5-question interview to produce `.aidev/charter.md` for a repo with no strong signal. |
+| `/aidev-test <repo>` | Detect the project's test runner and run it. Summarises failures on non-zero exit. |
+| `/aidev-review <issue> <repo>` | Boy Scout pass on `.aidev/proposed.patch`, producing blockers / suggestions / follow-up issue proposals. |
+
+## Works with your subscription out of the box
+
+aidev's default `config/models.yaml` routes the medium and large tiers
+through `claude --print` (the Claude Code CLI non-interactive mode).
+This means the Critic, Architect, Charter, Implementer, and Reviewer
+all bill against your Max/Pro subscription, not against a separate
+Anthropic API credit. No `ANTHROPIC_API_KEY` required.
+
+If you prefer the direct API path for some or all tiers, edit
+`config/models.yaml` in the aidev checkout and flip `provider: claude-cli`
+to `provider: anthropic` — the tier system is otherwise unchanged and
+you can mix providers freely.
+
+## Troubleshooting
+
+- `/aidev-doctor` FAIL on `claude-cli-binary`: install Claude Code
+  from https://claude.ai/download and make sure `claude` is on PATH.
+- `/aidev-doctor` FAIL on `anthropic-key`: you've edited
+  `config/models.yaml` to use the `anthropic` provider but haven't set
+  `ANTHROPIC_API_KEY`. Either set the env var or revert the config.
+- Slash commands don't appear: check that files exist under
+  `~/.claude/commands/aidev-*.md` and restart your Claude Code session.

--- a/plugin/aidev/commands/aidev-charter.md
+++ b/plugin/aidev/commands/aidev-charter.md
@@ -1,0 +1,12 @@
+---
+description: Run the aidev Charter interview against a target repo
+argument-hint: <repo-path>
+---
+
+Run the aidev Charter interview against the repository at `$ARGUMENTS`.
+This is an interactive subcommand — the user will be prompted for five
+questions in their terminal. After it completes, read the resulting
+`<repo>/.aidev/charter.md` and summarise its Purpose section for the
+user so they can quickly verify it captured their intent.
+
+!`aidev charter -repo $ARGUMENTS`

--- a/plugin/aidev/commands/aidev-doctor.md
+++ b/plugin/aidev/commands/aidev-doctor.md
@@ -1,0 +1,10 @@
+---
+description: Run the aidev precondition audit
+---
+
+Run aidev's environment doctor and summarise the result for the user.
+
+!`aidev doctor`
+
+If any check is FAIL, show the remediation line verbatim. If all are
+OK, confirm that the pipeline is ready to go.

--- a/plugin/aidev/commands/aidev-review.md
+++ b/plugin/aidev/commands/aidev-review.md
@@ -1,0 +1,22 @@
+---
+description: Run the aidev Reviewer on the current proposed patch
+argument-hint: <issue-url> <repo-path>
+---
+
+Run the aidev Reviewer against the patch at `<repo>/.aidev/proposed.patch`
+for the given issue. This is the Boy Scout pass before the user commits
+the change.
+
+Parse `$ARGUMENTS` as two whitespace-separated tokens:
+  1. issue URL
+  2. repo path
+
+!`aidev review -issue $1 -repo $2`
+
+After the review completes:
+  - Report the **verdict** prominently (approve / changes_requested / comment)
+  - List any **blockers** the Reviewer found — these MUST be addressed before merge
+  - List any **follow-up issues** the Reviewer proposed — ask the user
+    whether they want to file any of them with `gh issue create`
+  - The follow-ups are also persisted to `<repo>/.aidev/followups.md`
+    for later triage

--- a/plugin/aidev/commands/aidev-run.md
+++ b/plugin/aidev/commands/aidev-run.md
@@ -1,0 +1,26 @@
+---
+description: Run the full aidev agent pipeline on a GitHub issue
+argument-hint: <issue-url> <repo-path>
+---
+
+You are driving `aidev`, the multi-agent coding tool. The user has
+invoked this slash command with arguments naming a GitHub issue and a
+local repository path.
+
+Parse `$ARGUMENTS` as two whitespace-separated tokens:
+  1. issue URL (https://github.com/owner/repo/issues/N)
+  2. repo path (absolute or relative)
+
+Then run aidev in headless mode with auto-architect and sketch 1 picked:
+
+!`aidev -headless -auto -sketch 1 -issue $1 -repo $2`
+
+After the command finishes, summarise the output for the user:
+  - what the Critic recommended
+  - how many sketches the Architect produced
+  - whether the Implementer wrote a patch at `$2/.aidev/proposed.patch`
+  - any warnings from the doctor
+
+If the Critic recommended `kill` or `defer`, stop and report the
+rationale. Don't push the user to proceed against the Critic's
+judgement.

--- a/plugin/aidev/commands/aidev-test.md
+++ b/plugin/aidev/commands/aidev-test.md
@@ -1,0 +1,14 @@
+---
+description: Run the detected test suite for a repository via aidev
+argument-hint: <repo-path>
+---
+
+Run `aidev test` against the repository at `$ARGUMENTS`. aidev will
+detect the project's test runner (go/cargo/python/node/gradle/maven/
+just/make) and execute it.
+
+!`aidev test -repo $ARGUMENTS`
+
+If the run fails, surface the 3-sentence LLM failure summary at the
+top of your response so the user sees the likely cause immediately.
+The full output is available for follow-up questions.


### PR DESCRIPTION
## Summary

v0.2d makes aidev work out-of-the-box for anyone with a Claude Code subscription — no Anthropic API key required — and ships as a native Claude Code plugin with five slash commands that integrate into any Claude Code session.

**The change you actually feel:** after `aidev plugin install`, you can type `/aidev-run https://github.com/org/repo/issues/42 ~/code/repo` inside any Claude Code session and the full pipeline runs, billing against your Max/Pro subscription instead of a separate API credit.

## What's in the PR

**new — claude-cli provider**
- `internal/llm/claude_cli.go` — `ClaudeCLI` provider that shells out to `claude --print` with `--append-system-prompt`, pipes the user message on stdin (avoids argv length limits), runs from `os.TempDir()` to dodge stray `CLAUDE.md` pollution, and time-boxes each call at 5 min
- `internal/llm/claude_cli_test.go` — fake-binary tests covering happy path, empty prompt, empty response, stderr-in-error, and Name() formatting
- `internal/doctor/claude_cli.go` — doctor check that FAILs when any tier uses the `claude-cli` provider and the `claude` binary isn't on PATH

**new — Claude Code plugin**
- `plugin/aidev/commands/` — 5 slash commands with proper YAML frontmatter: `/aidev-run`, `/aidev-doctor`, `/aidev-charter`, `/aidev-test`, `/aidev-review`
- `plugin/aidev/README.md` — install instructions (both `aidev plugin install` and manual)
- `internal/plugin/plugin.go` — installer with `Install`, `Uninstall`, `DefaultCommandsDir` (honours `CLAUDE_CONFIG_DIR`), embedded slash commands via `go:embed all:files`
- `internal/plugin/files/*.md` — the embedded command files (mirrored from `plugin/aidev/commands/` so `go:embed` can pick them up)
- `internal/plugin/plugin_test.go` — 7 tests: empty-dir install, skip-on-existing, force-overwrite, uninstall preserves locally-modified files, CLAUDE_CONFIG_DIR override, home dir fallback, empty-target error

**modified**
- `internal/llm/router.go` — add `case "claude-cli"` to `buildProvider()`
- `internal/doctor/doctor.go` — call `checkClaudeCLI` after `checkAnthropicKey` in `Run()`
- `config/models.yaml` — **flip shipped defaults**: medium and large tiers now use `provider: claude-cli` with empty model string (subscription default), small still uses ollama. Comments updated to explain the choice and how to swap back.
- `cmd/aidev/main.go` — new `plugin` subcommand that dispatches `install`/`uninstall` and plumbs `--force` and `--dir` flags
- `README.md` — new 'Claude Code plugin' section, updated Requirements (claude CLI now default, Anthropic API is the alternative), updated status and roadmap, updated Layout

## Design decisions

- **Default is claude-cli, not Anthropic API.** The out-of-the-box experience is 'have Claude Code installed, be logged in, aidev works'. Anyone who specifically wants the REST API can edit one line of `config/models.yaml`. The 'just works' story was the main ask.
- **Embed, don't reference.** Slash commands are embedded in the binary via `go:embed all:files` so `aidev plugin install` works regardless of where aidev was invoked from — no 'plugin directory not found' failure modes. The embedded copy lives at `internal/plugin/files/`; the canonical source at `plugin/aidev/commands/` is what developers edit.
- **Never clobber user edits.** Install skips existing files by default (pass `--force` to overwrite). Uninstall checks each file's content byte-for-byte against the shipped version — if the user has edited it, the file is preserved.
- **Stdin for the user prompt, not argv.** The Architect and Implementer can produce prompts in the 20–40 KB range. argv on macOS/Linux is capped (`getconf ARG_MAX`) so we pipe via stdin to stay safe.
- **Run from `os.TempDir()`.** Without this, `claude --print` would pick up the `CLAUDE.md` of whatever directory the user invoked `aidev` from — which is almost never the right context for the target repo. Fresh temp dir per call means a clean context every time.
- **No token counts.** The CLI doesn't expose them in `--print` mode, so `Usage` is always `{0, 0}` for the claude-cli provider. The Architect's cost preview already used static estimates, so this doesn't regress anything user-visible.
- **Provider lookup is lazy.** `NewClaudeCLI` doesn't call `exec.LookPath` at construction. Doctor handles the 'binary missing' check; production code that builds the router just wants a fast, side-effect-free constructor.
- **Tier-level flexibility.** The config still supports mixing providers across tiers. You can route scout to ollama, medium to claude-cli (subscription), and critic to anthropic (API) — whatever trade-off you want.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all existing tests pass + 7 new plugin tests + 5 new llm/claude-cli tests = 12 new
- [x] `aidev plugin install --dir /tmp/smoke` — installs 5 files, exits 0
- [x] Re-run with same dir — skips all 5 (existing), exits 0
- [x] `aidev plugin install --dir /tmp/smoke --force` — overwrites, exits 0
- [x] `aidev plugin uninstall --dir /tmp/smoke` — removes 5, exits 0
- [ ] **Manual smoke (for @crisscross82 tomorrow):**
  - `aidev doctor` should now show `claude-cli-binary` as OK if you have Claude Code installed, FAIL otherwise with a clear remediation
  - `aidev plugin install` into your real `~/.claude/commands/` — verify five files appear, existing files are preserved
  - Inside a Claude Code session, type `/` and confirm the new commands appear
  - Run `/aidev-doctor` from inside Claude Code — it should shell out and report
  - Run `aidev -issue <url> -repo <path>` and verify the Critic actually reaches Claude via the CLI. If you see 'claude-cli: not authenticated' errors, run `claude /login` first

## Worth reviewing carefully

- **The config flip is a breaking change for existing users.** Anyone who had v0.4 working with `ANTHROPIC_API_KEY` set but NO `claude` binary installed will get a doctor FAIL on startup. The fix is a one-line revert in their local `config/models.yaml` (back to `provider: anthropic`). This is documented in the new Requirements section but I'm calling it out because it's the one piece of backward-incompatibility in this PR.
- **Embed path duplication.** The slash commands exist at both `plugin/aidev/commands/*.md` (developer-facing, documented in the repo) and `internal/plugin/files/*.md` (embed-target for go:embed). Changing one requires changing the other — I'd fix this with a go:generate step in a follow-up but it's not worth the complexity for five files in v0.2d.
- **The `--append-system-prompt` flag.** I'm using this to pass the system prompt. If a future claude CLI version changes the flag name or semantics, the provider breaks. The provider's error includes stderr so a change of this kind would be visible, but it's a real coupling.
- **Timeouts.** 5 minutes per call is generous for Scout but tight for Architect with 5 sketches on a slow day. Configurable via the Timeout field on the struct but not exposed via config yet — easy follow-up if it becomes an issue.

## Out of scope

- Detecting when aidev is running inside an active Claude Code session (reuse the parent session instead of spawning a subprocess). Interesting v0.5+ idea.
- Auto-logging into the CLI from aidev (we just tell the user to run `claude /login`).
- Coloured/interactive plugin install output.
- Streaming responses from the CLI (it supports `--output-format stream-json` but aidev's Provider interface is one-shot for now).