### PR TITLE
fix: doctor quiet anthropic-key check when no tier uses anthropic provider

### DIFF
--- a/internal/doctor/config.go
+++ b/internal/doctor/config.go
@@ -50,8 +50,10 @@ func checkConfig(cfg *config.Config) Result {
 
 // checkAnthropicKey reports whether the ANTHROPIC_API_KEY env var is set.
 // It is only a FAIL if the current routing actually sends some role to an
-// anthropic-typed tier — otherwise it's a WARN (the user might be running
-// a fully local setup and not need the key).
+// anthropic-typed tier. If no tier uses the anthropic provider, the key
+// is irrelevant and the check is a silent OK — previously this emitted a
+// noisy WARN, which was misleading for users who deliberately chose the
+// claude-cli path and never intended to set the env var.
 func checkAnthropicKey(cfg *config.Config) Result {
 	r := Result{Name: "anthropic-key"}
 	needsKey := false
@@ -71,11 +73,11 @@ func checkAnthropicKey(cfg *config.Config) Result {
 			r.Severity = FAIL
 			r.Message = "ANTHROPIC_API_KEY not set, but one or more roles route to an anthropic tier"
 			r.Remediation = "export ANTHROPIC_API_KEY=sk-ant-... (or swap the anthropic tiers to local providers)"
-		} else {
-			r.Severity = WARN
-			r.Message = "ANTHROPIC_API_KEY not set"
-			r.Remediation = "harmless if your routing stays local-only"
+			return r
 		}
+		// Not set, not needed — this is fine, not a warning.
+		r.Severity = OK
+		r.Message = "ANTHROPIC_API_KEY not set (not needed — no tiers use the anthropic provider)"
 		return r
 	}
 	r.Severity = OK

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -140,8 +140,11 @@ func TestCheckAnthropicKeyWarnsWhenNotRouted(t *testing.T) {
 		},
 	}
 	r := checkAnthropicKey(cfg)
-	if r.Severity != WARN {
-		t.Errorf("severity = %v, want WARN", r.Severity)
+	// Was WARN in v0.2d; downgraded to OK in the polish fix because
+	// a user on a fully local or claude-cli setup has deliberately
+	// chosen not to set the key.
+	if r.Severity != OK {
+		t.Errorf("severity = %v, want OK (no tier uses anthropic so the key is irrelevant)", r.Severity)
 	}
 }
 


### PR DESCRIPTION
## Summary

Cosmetic bug noticed during the first real run on @crisscross82's Mac: `aidev doctor` was emitting `[WARN] anthropic-key — ANTHROPIC_API_KEY not set` even when the user had deliberately chosen the claude-cli path and had no intention of ever setting the key. For the v0.2d default config (claude-cli for medium+large, ollama for small) the env var is literally irrelevant, so a warning is misleading.

## Change

- If no tier uses `provider: anthropic` AND the env var is unset: return `[OK] anthropic-key — ANTHROPIC_API_KEY not set (not needed — no tiers use the anthropic provider)` instead of `[WARN]`.
- Keep `FAIL` for the case where the env var is unset AND a tier actually needs it. That's still a real problem.
- Keep `OK` for the case where the env var is set. Unchanged.

## Test update

`TestCheckAnthropicKeyWarnsWhenNotRouted` renamed in spirit (kept the name so blame stays clean, but updated the assertion) to expect `OK` instead of `WARN`.

## Test plan

- [x] `go test ./internal/doctor/` passes
- [x] `go test ./...` passes
- [ ] **Manual on @crisscross82's Mac:** re-run `aidev doctor` — the noisy WARN line should now be an OK line.