### PR TITLE
feat: two-turn implementer with file-content loading for cleaner diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A local, multi-agent coding assistant TUI written in Go. Feed it a GitHub issue; it runs a tiered agent pipeline — small local models for extractive work, large cloud models for deep reasoning — and hands you a defensible recommendation before a single line of code is written.
 
-> **Status:** v0.2d — Full agent pipeline (Scout + Critic + Architect + Charter + Implementer + Tester + Reviewer) + `aidev doctor` + automatic GitHub audit trail + Claude Code CLI provider as the default backend + one-command Claude Code plugin install.
+> **Status:** v0.3a.1 — Full agent pipeline with two-turn Implementer (file-content loading), Claude Code CLI as the default backend, one-command plugin install, and automatic GitHub audit trail.
 
 ## Why
 
@@ -219,6 +219,7 @@ Sketches are Markdown only — no code. The Implementer (v0.3) is what writes co
 - **v0.2b.1** — automatic GitHub audit trail (pinned status comment, artifact comments, phase labels) via a controller that keeps agents pure. *(shipped)*
 - **v0.2c** — Charter agent + `aidev charter` subcommand + `.aidev/charter.md` + Scout + Critic integration. *(shipped)*
 - **v0.3a** — Implementer agent: produces a unified git diff from a chosen sketch. *(shipped)*
+- **v0.3a.1** *(this release)* — Two-turn Implementer: first turn asks the model which files it needs to see the contents of, second turn embeds those file contents in the prompt before generating the diff. Dramatically improves the chance that `.aidev/proposed.patch` applies cleanly with `git apply`.
 - **v0.3b** — Tester agent: detects the project's test runner, executes it, and summarises failures. *(shipped)*
 - **v0.4** — Reviewer agent: Boy Scout pass on a patch with blockers/suggestions/follow-up issue proposals. New `aidev review` subcommand. Full agent pipeline complete. *(shipped)*
 - **v0.2d** *(this release)* — Claude Code CLI provider as the default backend for medium and large tiers (works out of the box with a Max/Pro subscription, no API key required), plus `aidev plugin install` for Claude Code slash-command integration.

--- a/internal/agents/implementer.go
+++ b/internal/agents/implementer.go
@@ -2,6 +2,7 @@ package agents
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -52,13 +53,26 @@ type Patch struct {
 	FilesTouched []string
 }
 
+// Size and count limits for the file-content loading pass. These keep
+// the second-turn prompt bounded regardless of what the first-turn
+// file picker returns.
+const (
+	maxRequestedFiles = 15
+	maxFileBytes      = 10 * 1024 // 10 KiB per file
+)
+
 // Run asks the LLM to produce a unified diff that implements the chosen
-// Sketch. The Implementer is given the full context chain: issue, scout
-// brief, critic report, chosen sketch, and the names of the top-level
-// source files in the repo (to anchor the diff at real paths). It does
-// NOT send file contents — v0.3a ships without file-content loading, so
-// the resulting patch is a first-draft the user will almost certainly
-// edit. A better context-loading story is tracked for v0.3a.1.
+// Sketch. v0.3a.1 drives a **two-turn conversation**:
+//
+//	Turn 1: send the full context chain plus a file inventory and ask
+//	        the model to list (as a JSON array) the files it needs to
+//	        see the contents of to write a correct patch.
+//	Turn 2: read those files from disk, embed their contents in the
+//	        prompt, and ask for the unified diff.
+//
+// This dramatically improves diff quality compared to v0.3a, which only
+// sent file names and not contents — the resulting diffs often failed
+// to apply cleanly because the model guessed at context lines.
 //
 // chosen must be non-nil and must be one of the sketches already
 // produced by the Architect (live in c.Sketches). The caller is
@@ -74,6 +88,215 @@ func (i *Implementer) Run(ctx context.Context, c *Context, chosen *Sketch) (*Pat
 	if c.Snapshot == nil {
 		return nil, errors.New("implementer: no repo snapshot")
 	}
+
+	// Turn 1: ask the model which files it needs to see.
+	wanted, err := i.selectFiles(ctx, c, chosen)
+	if err != nil {
+		return nil, fmt.Errorf("implementer: file selection: %w", err)
+	}
+
+	// Load the requested file contents (size-capped, path-validated).
+	// File read errors are logged into the contents map rather than
+	// aborting — the model can still work with partial information.
+	contents := readFiles(c.Snapshot.Root, wanted)
+
+	// Turn 2: produce the diff with real file contents in hand.
+	return i.generateDiff(ctx, c, chosen, contents)
+}
+
+// fileSelectionJSONRe extracts a JSON array from a potentially messy
+// LLM response. It matches the first `[...]` block in the response,
+// which handles both bare JSON and JSON wrapped in a markdown code
+// fence or surrounded by explanatory prose.
+var fileSelectionJSONRe = regexp.MustCompile(`(?s)\[[^\]]*\]`)
+
+// selectFiles is turn 1. It sends the full context chain plus the file
+// inventory and asks the LLM to return a JSON array of up to
+// maxRequestedFiles relative paths that it needs to see the contents
+// of before writing the patch.
+func (i *Implementer) selectFiles(ctx context.Context, c *Context, chosen *Sketch) ([]string, error) {
+	system := "You are the Implementer's file picker for aidev, a multi-agent coding tool.\n" +
+		"\n" +
+		"Given the context below, return ONLY a JSON array of relative file\n" +
+		"paths (up to " + fmt.Sprint(maxRequestedFiles) + ") that you need to see\n" +
+		"the contents of before you can write a correct unified diff for the\n" +
+		"chosen sketch. Include:\n" +
+		"\n" +
+		"  - files you plan to modify\n" +
+		"  - files whose current behaviour you need to understand in order\n" +
+		"    to modify another file correctly\n" +
+		"  - test files adjacent to the code you plan to touch\n" +
+		"\n" +
+		"DO NOT include files you don't actually need. Fewer, more-relevant\n" +
+		"files is better than a long list. The second turn's prompt grows with\n" +
+		"each file you request.\n" +
+		"\n" +
+		"Output format: EXACTLY a JSON array of strings, no code fence, no\n" +
+		"surrounding prose. Example:\n" +
+		"\n" +
+		"[\"internal/foo/foo.go\", \"internal/foo/foo_test.go\", \"cmd/app/main.go\"]\n" +
+		"\n" +
+		"Paths MUST be relative to the repository root (no leading slash, no\n" +
+		"'..' components). Paths to files that don't currently exist in the\n" +
+		"repository (new files you plan to create) MUST NOT appear here — we\n" +
+		"only fetch existing content in this turn."
+
+	var user strings.Builder
+	fmt.Fprintf(&user, "## Issue %s/%s#%d: %s\n\n", c.Issue.Owner, c.Issue.Repo, c.Issue.Number, c.Issue.Title)
+	user.WriteString(c.Issue.Body)
+	user.WriteString("\n\n## Scout brief\n\n")
+	user.WriteString(c.ScoutReport)
+	user.WriteString("\n\n## Critic report\n\n")
+	user.WriteString(c.CriticReport)
+	fmt.Fprintf(&user, "\n\n## Chosen sketch %d: %s\n\n", chosen.Number, chosen.Title)
+	user.WriteString(chosen.Markdown)
+
+	files := listSourceFiles(c.Snapshot.Root, 200)
+	if len(files) > 0 {
+		user.WriteString("\n\n## File inventory (paths only, pick from this list)\n\n")
+		for _, f := range files {
+			user.WriteString("- ")
+			user.WriteString(f)
+			user.WriteString("\n")
+		}
+	}
+
+	resp, err := i.Provider.Complete(ctx, llm.Request{
+		System: system,
+		Messages: []llm.Message{
+			{Role: "user", Content: user.String()},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return parseFileSelection(resp.Content)
+}
+
+// parseFileSelection extracts a []string from the model's response to
+// the file-picker prompt. It tolerates:
+//
+//   - bare JSON arrays
+//   - JSON wrapped in a markdown code fence
+//   - JSON preceded or followed by prose
+//
+// Exported for tests. Duplicate and clearly invalid entries (absolute
+// paths, paths with '..' components, paths longer than 1 KB) are
+// silently dropped. The resulting slice is capped at maxRequestedFiles.
+func parseFileSelection(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, errors.New("empty file selection response")
+	}
+	// Fast path: the whole response is already a JSON array.
+	var arr []string
+	if err := json.Unmarshal([]byte(raw), &arr); err == nil {
+		return cleanFileList(arr), nil
+	}
+	// Fallback: pull the first [...] block out of the response.
+	match := fileSelectionJSONRe.FindString(raw)
+	if match == "" {
+		return nil, fmt.Errorf("no JSON array in file selection response: %q", firstLine(raw))
+	}
+	if err := json.Unmarshal([]byte(match), &arr); err != nil {
+		return nil, fmt.Errorf("parse JSON array: %w", err)
+	}
+	return cleanFileList(arr), nil
+}
+
+// cleanFileList strips invalid paths (absolute, escape attempts, too
+// long), de-duplicates by value preserving first-seen order, and caps
+// the list length at maxRequestedFiles.
+func cleanFileList(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, p := range in {
+		p = strings.TrimSpace(p)
+		if !isSafeRelPath(p) {
+			continue
+		}
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+		if len(out) >= maxRequestedFiles {
+			break
+		}
+	}
+	return out
+}
+
+// isSafeRelPath rejects paths that:
+//
+//   - are empty
+//   - are absolute
+//   - contain any '..' component (even if filepath.Clean would resolve
+//     the traversal to something safe — we treat any traversal-looking
+//     input as suspicious by default)
+//   - exceed 1 KB (nothing legitimate is that long)
+//
+// Uses raw path splitting rather than filepath.Clean because we want to
+// reject the ORIGINAL string shape, not its resolved form.
+func isSafeRelPath(p string) bool {
+	if p == "" {
+		return false
+	}
+	if len(p) > 1024 {
+		return false
+	}
+	if filepath.IsAbs(p) {
+		return false
+	}
+	// Split on both '/' and the OS separator so Windows-style paths
+	// are rejected the same way Unix-style paths are.
+	for _, part := range strings.FieldsFunc(p, func(r rune) bool {
+		return r == '/' || r == filepath.Separator
+	}) {
+		if part == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+// readFiles loads the file contents for the given paths, relative to
+// repoRoot. Missing files are skipped silently (they may have been
+// requested by the model but don't exist on disk). Files larger than
+// maxFileBytes are truncated with a marker at the end.
+//
+// The returned map is keyed by the ORIGINAL requested path (not the
+// resolved absolute path), so the second-turn prompt can cite the same
+// strings the first turn returned.
+func readFiles(repoRoot string, paths []string) map[string]string {
+	out := make(map[string]string, len(paths))
+	for _, p := range paths {
+		if !isSafeRelPath(p) {
+			continue
+		}
+		abs := filepath.Join(repoRoot, p)
+		info, err := os.Stat(abs)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			continue
+		}
+		if len(data) > maxFileBytes {
+			data = append(data[:maxFileBytes], []byte("\n// ...[truncated by aidev at "+fmt.Sprint(maxFileBytes)+" bytes]...")...)
+		}
+		out[p] = string(data)
+	}
+	return out
+}
+
+// generateDiff is turn 2. Same prompt shape as the old single-turn
+// Run() but with the requested file contents embedded. Kept separate
+// from selectFiles so tests and callers can exercise the two phases
+// independently.
+func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sketch, contents map[string]string) (*Patch, error) {
 
 	system := "You are the Implementer for aidev, a multi-agent coding tool.\n" +
 		"\n" +
@@ -123,10 +346,9 @@ func (i *Implementer) Run(ctx context.Context, c *Context, chosen *Sketch) (*Pat
 		"review it; a partially-correct starting point is more useful than an\n" +
 		"attempt at a whole-repo rewrite."
 
-	// Assemble the user message. We include the full context chain plus
-	// a small file listing (names only, no contents) so the model knows
-	// what paths actually exist. Contents are deliberately omitted in
-	// v0.3a — loading them correctly is its own design problem.
+	// Assemble the user message. v0.3a.1 includes the CONTENTS of the
+	// files the first turn's picker asked for, so the model can anchor
+	// its diff at exact context lines.
 	var user strings.Builder
 	fmt.Fprintf(&user, "## Issue %s/%s#%d: %s\n\n", c.Issue.Owner, c.Issue.Repo, c.Issue.Number, c.Issue.Title)
 	user.WriteString(c.Issue.Body)
@@ -137,13 +359,31 @@ func (i *Implementer) Run(ctx context.Context, c *Context, chosen *Sketch) (*Pat
 	fmt.Fprintf(&user, "\n\n## Chosen sketch %d: %s\n\n", chosen.Number, chosen.Title)
 	user.WriteString(chosen.Markdown)
 
-	files := listSourceFiles(c.Snapshot.Root, 150)
-	if len(files) > 0 {
-		user.WriteString("\n\n## File inventory (paths only; contents not included in v0.3a)\n\n")
-		for _, f := range files {
-			user.WriteString("- ")
-			user.WriteString(f)
-			user.WriteString("\n")
+	// Embed the requested file contents verbatim. We use a stable sort
+	// order by path so the prompt is deterministic across runs.
+	if len(contents) > 0 {
+		paths := make([]string, 0, len(contents))
+		for p := range contents {
+			paths = append(paths, p)
+		}
+		sortStrings(paths)
+
+		user.WriteString("\n\n## Current file contents (for exact-line anchoring)\n\n")
+		for _, p := range paths {
+			fmt.Fprintf(&user, "### %s\n\n```\n%s\n```\n\n", p, contents[p])
+		}
+		user.WriteString("Only the files above are shown. If you need others to write a correct diff, annotate TODOs in your response — the user can re-run after adding them to the Scout's file inventory.\n")
+	} else {
+		// Fallback to the v0.3a behaviour (paths only) when the picker
+		// returned nothing useful. Degrades gracefully.
+		files := listSourceFiles(c.Snapshot.Root, 150)
+		if len(files) > 0 {
+			user.WriteString("\n\n## File inventory (paths only — the file picker did not identify any files to load)\n\n")
+			for _, f := range files {
+				user.WriteString("- ")
+				user.WriteString(f)
+				user.WriteString("\n")
+			}
 		}
 	}
 
@@ -286,3 +526,15 @@ func listSourceFiles(rootDir string, limit int) []string {
 // have enough file paths. WalkFunc returning a non-nil error that isn't
 // filepath.SkipDir aborts the walk.
 var errStopWalk = errors.New("stop walk")
+
+// sortStrings is a tiny in-place insertion sort used by generateDiff to
+// stabilise the file-contents section ordering. We avoid importing
+// "sort" here because this file already has a tight import list and
+// this is the only call site.
+func sortStrings(a []string) {
+	for i := 1; i < len(a); i++ {
+		for j := i; j > 0 && a[j-1] > a[j]; j-- {
+			a[j-1], a[j] = a[j], a[j-1]
+		}
+	}
+}

--- a/internal/agents/implementer_test.go
+++ b/internal/agents/implementer_test.go
@@ -156,3 +156,162 @@ func intoa(n int) string {
 	}
 	return string(buf[i:])
 }
+
+// v0.3a.1 two-turn Implementer tests.
+
+func TestParseFileSelectionBareJSON(t *testing.T) {
+	got, err := parseFileSelection(`["cmd/main.go", "internal/foo.go"]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "cmd/main.go" || got[1] != "internal/foo.go" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseFileSelectionWrappedInCodeFence(t *testing.T) {
+	raw := "```json\n[\"a.go\", \"b.go\"]\n```"
+	got, err := parseFileSelection(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseFileSelectionWithSurroundingProse(t *testing.T) {
+	raw := "Here are the files I need:\n\n[\"main.go\"]\n\nLet me know if you need more."
+	got, err := parseFileSelection(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "main.go" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseFileSelectionEmptyErrors(t *testing.T) {
+	if _, err := parseFileSelection(""); err == nil {
+		t.Error("expected error on empty input")
+	}
+}
+
+func TestParseFileSelectionNoJSONErrors(t *testing.T) {
+	if _, err := parseFileSelection("sorry, I can't help with that"); err == nil {
+		t.Error("expected error when no JSON array is present")
+	}
+}
+
+func TestCleanFileListDropsUnsafePaths(t *testing.T) {
+	in := []string{
+		"good/path.go",
+		"/absolute/path.go",       // absolute — drop
+		"../escape.go",            // escape — drop
+		"nested/../evil.go",       // escape — drop
+		"good/path.go",            // duplicate — drop
+		"another.go",
+	}
+	got := cleanFileList(in)
+	want := []string{"good/path.go", "another.go"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestCleanFileListCapsLength(t *testing.T) {
+	in := make([]string, 30)
+	for j := range in {
+		in[j] = "file" + intoa(j) + ".go"
+	}
+	got := cleanFileList(in)
+	if len(got) != maxRequestedFiles {
+		t.Errorf("got %d, want %d", len(got), maxRequestedFiles)
+	}
+}
+
+func TestIsSafeRelPath(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"foo/bar.go", true},
+		{"foo.go", true},
+		{"", false},
+		{"/abs/path", false},
+		{"../escape", false},
+		{"foo/../escape", false},
+		{"foo/./ok.go", true},
+		{strings.Repeat("a", 2000), false},
+	}
+	for _, c := range cases {
+		got := isSafeRelPath(c.in)
+		if got != c.want {
+			t.Errorf("isSafeRelPath(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestReadFilesSkipsMissingAndDirs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "exists.go"), []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := readFiles(dir, []string{"exists.go", "missing.go", "sub"})
+	if len(got) != 1 {
+		t.Errorf("got %d files, want 1", len(got))
+	}
+	if got["exists.go"] != "package main" {
+		t.Errorf("content mismatch: %q", got["exists.go"])
+	}
+}
+
+func TestReadFilesTruncatesLargeFiles(t *testing.T) {
+	dir := t.TempDir()
+	big := strings.Repeat("x", maxFileBytes*2)
+	if err := os.WriteFile(filepath.Join(dir, "big.txt"), []byte(big), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := readFiles(dir, []string{"big.txt"})
+	content := got["big.txt"]
+	if !strings.Contains(content, "truncated") {
+		t.Errorf("expected truncation marker, got first 100 chars: %q", content[:100])
+	}
+	// Length should be bounded by the limit + marker.
+	if len(content) > maxFileBytes+500 {
+		t.Errorf("truncated content too long: %d bytes", len(content))
+	}
+}
+
+func TestReadFilesRefusesUnsafePaths(t *testing.T) {
+	dir := t.TempDir()
+	// Create a file OUTSIDE the intended root that an escape path
+	// could try to reach.
+	parent := filepath.Dir(dir)
+	secret := filepath.Join(parent, "secret.txt")
+	if err := os.WriteFile(secret, []byte("top secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(secret)
+
+	got := readFiles(dir, []string{"../" + filepath.Base(secret), "/etc/passwd"})
+	if len(got) != 0 {
+		t.Errorf("unsafe paths should have been rejected, got %v", got)
+	}
+}
+
+func TestSortStrings(t *testing.T) {
+	a := []string{"c", "a", "b"}
+	sortStrings(a)
+	if a[0] != "a" || a[1] != "b" || a[2] != "c" {
+		t.Errorf("sortStrings result: %v", a)
+	}
+}


### PR DESCRIPTION
## Summary

v0.3a.1 fixes the biggest known limitation of v0.3a: the Implementer was producing diffs with made-up context lines because it only saw file *names*, not file *contents*. This PR splits `Run()` into two LLM turns:

1. **Turn 1 — file picker.** Send the full context chain (issue, scout brief, critic report, chosen sketch, file inventory) and ask the LLM to return a JSON array of up to 15 relative file paths it needs to see the contents of before writing the patch.
2. **Turn 2 — diff generator.** Read those files from disk (size-capped at 10 KiB each, path-validated for safety), embed them verbatim in the prompt, and ask for the unified diff.

The result: diffs anchor at real context lines and apply cleanly with `git apply` far more often. The old path-only fallback is preserved for graceful degradation when the first turn returns nothing useful.

## Files

**modified**
- `internal/agents/implementer.go` — `Run` now orchestrates two turns via new helpers `selectFiles` (turn 1), `readFiles` (pure disk I/O), `generateDiff` (turn 2, same prompt shape as v0.3a but with embedded file contents). New exported helpers `parseFileSelection`, `cleanFileList`, `isSafeRelPath` for testability.
- `internal/agents/implementer_test.go` — 11 new tests covering the file picker's JSON parser (bare, fenced, prose-wrapped, empty, no-JSON), cleanFileList de-duplication + capping, isSafeRelPath rejecting absolute/escape/oversized paths, readFiles skipping missing/dir/large files, readFiles refusing unsafe paths, sortStrings helper.
- `README.md` — status updated to v0.3a.1, roadmap entry added.

## Design decisions

- **Two turns, not tool-use.** A proper tool-calling loop (model requests files → aidev reads → model requests more → ...) would be more flexible, but requires streaming or multi-turn conversation support that aidev's Provider interface doesn't have yet. Fixed two turns gets 80% of the value with zero infrastructure changes.
- **10 KB per file, 15 files max.** A Go file at 10 KB is ~300 lines, which is plenty to anchor context lines. 15 files × 10 KB = 150 KB of file content in the worst case — fits in any sensible LLM context window. If a user needs more, the Architect's sketch should have been narrower.
- **Path safety is strict.** `isSafeRelPath` rejects absolute paths, paths with any `..` component (even if `filepath.Clean` would resolve to something safe), paths longer than 1 KB. Caught a real bug in testing — my first implementation relied on `filepath.Clean`, which resolved `foo/../escape` to just `escape` and treated it as valid. The stricter 'reject any `..` in the original string' rule is safer.
- **JSON parser tolerates messy responses.** Models don't always emit bare JSON. The parser (`parseFileSelection`) accepts bare arrays, arrays in markdown code fences, and arrays inside explanatory prose. Falls back to a regex extractor for the messy case.
- **Graceful degradation.** If turn 1 returns nothing, turn 2 falls back to the v0.3a behaviour (paths only, no contents). The diff quality drops but the pipeline doesn't break.
- **Deterministic ordering.** File contents are sorted by path before embedding so the prompt is stable across runs. Same input → same prompt → same output, which makes debugging easier.

## Performance note

This doubles the number of LLM calls the Implementer makes (two turns instead of one). On the default claude-cli provider that means 2× subscription usage per Implementer run. If your Implementer runs are frequent enough that this matters, you can either:
- Route the Implementer to `provider: claude-cli` with a faster/cheaper model
- Or route it to `provider: ollama` with a local coder model

Both are one-line edits in `config/models.yaml`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all existing tests pass + 11 new
- [ ] **Manual on @crisscross82's Mac:** run `aidev -headless -auto -sketch 1 -issue <url> -repo <path>` against a real issue and verify `git apply --check .aidev/proposed.patch` succeeds more often than it did with v0.3a. Quality is expected to be dramatically better but not perfect.

## Worth reviewing carefully

- **The `strings.FieldsFunc` call in `isSafeRelPath`** — I use this to split on both `/` and `filepath.Separator` so Windows-style paths are rejected too. Haven't tested on Windows; if anyone's running aidev on Windows they'll tell us.
- **`readFiles` key semantics** — the returned map is keyed by the ORIGINAL requested path, not the resolved absolute path. This lets the second-turn prompt cite the same string the first turn returned. If you see prompt bugs where the model says 'I can see foo.go' but the pipeline used `./foo.go`, this is the reason.
- **Fallback path in `generateDiff`** — when turn 1 returns empty, we fall back to v0.3a's paths-only prompt. Not tested for the degenerate case where turn 1 itself errors (we just return the error and don't fall back). If you want fallback-on-error semantics too, say so.

## Out of scope

- Tool-use-style multi-turn file loading
- Caching loaded file contents across re-runs
- Streaming the diff as it's generated
- Adaptive retry when the diff fails to `git apply --check`