### PR TITLE
fix: aidev doctor auto-spawns ollama daemon instead of bailing

### DIFF
--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -354,12 +354,17 @@ func runCharterSubcommand() {
 	fmt.Fprintf(os.Stderr, "\nwrote %s\n", path)
 }
 
-// runDoctorSubcommand handles `aidev doctor`. It always runs non-interactive
-// (no auto-spawn, no prompts) and prints the full report. Exit code is 0
-// when there are no FAILs, 1 otherwise.
+// runDoctorSubcommand handles `aidev doctor`. It never prompts for user
+// input (no missing-model menu, no pull consent), but it IS allowed to
+// auto-spawn the Ollama daemon if the binary is present and the daemon
+// isn't already running — spawning is idempotent, doesn't require a
+// TTY, and the daemon persists after aidev exits so it's effectively
+// the same as the user typing `ollama serve` in another terminal. Exit
+// code is 0 when there are no FAILs, 1 otherwise.
 func runDoctorSubcommand() {
 	var (
 		configDir = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
+		noSpawn   = flag.Bool("no-spawn", false, "Disable auto-spawning `ollama serve` if the daemon isn't running")
 	)
 	flag.Parse()
 
@@ -367,7 +372,7 @@ func runDoctorSubcommand() {
 
 	opts := doctor.Options{
 		Interactive:     false,
-		AutoSpawnOllama: false,
+		AutoSpawnOllama: !*noSpawn,
 		Out:             os.Stderr,
 	}
 	report := doctor.Run(context.Background(), cfg, opts)

--- a/internal/doctor/ollama.go
+++ b/internal/doctor/ollama.go
@@ -57,7 +57,13 @@ func checkOllama(ctx context.Context, cfg *config.Config, opts Options) []Result
 	if pingOllama(ctx, endpoint) {
 		daemonResult.Severity = OK
 		daemonResult.Message = "daemon reachable at " + endpoint
-	} else if opts.AutoSpawnOllama && opts.Interactive {
+	} else if opts.AutoSpawnOllama {
+		// Note: auto-spawn is gated only on opts.AutoSpawnOllama, not
+		// opts.Interactive. Spawning `ollama serve` is idempotent and
+		// the daemon persists beyond aidev's lifetime (we don't own
+		// it), so it is safe to do in non-interactive contexts like
+		// `aidev doctor`. Interactivity only gates user PROMPTS —
+		// pulling a model or swapping to an alternative.
 		fmt.Fprintf(opts.Out, "ollama daemon not reachable. spawning `ollama serve` in the background...\n")
 		spawnErr := spawnOllama()
 		if spawnErr != nil {


### PR DESCRIPTION
## Summary

@crisscross82's first real `aidev doctor` run on his Mac hit `[FAIL] ollama-daemon — daemon not reachable` even though the `ollama` binary was installed and available. The intent behind v0.2b was 'aidev owns the spawning burden, user doesn't have to touch the daemon' — but I shipped it broken because the auto-spawn path was gated on `opts.AutoSpawnOllama && opts.Interactive`, and `aidev doctor` explicitly sets `Interactive: false`.

I conflated two different concerns:

- **Interactive** — can prompt the user for input (pull a model? swap to an alternative?). These paths need a TTY.
- **AutoSpawnOllama** — can `exec.Command("ollama", "serve").Start()` without asking. This is idempotent, the daemon persists beyond aidev's lifetime (we don't own it), and there's no user input required.

## Fix

- `checkOllama` in `internal/doctor/ollama.go` now gates auto-spawn ONLY on `opts.AutoSpawnOllama` — the `opts.Interactive` conjunction is removed. Spawning in a non-interactive context is safe by construction.
- `runDoctorSubcommand` in `cmd/aidev/main.go` now sets `AutoSpawnOllama: true` by default, with a new `-no-spawn` flag for users who want the old 'report-only' behaviour (e.g. a CI job that wants to know whether the daemon is running, not to start it).
- Prompts (pulling/swapping missing models) still require `Interactive: true`. `aidev doctor` never hits those paths, so a doctor run with the daemon down and a model missing will still FAIL on the model — but the daemon itself auto-spawns, which is the behaviour the user expected from v0.2b.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all existing tests pass (the spawn path isn't unit-tested because it touches a real subprocess, but the gating change is mechanical)
- [ ] **Manual on @crisscross82's Mac:** with ollama installed but `ollama serve` not running, `aidev doctor` should print `ollama daemon not reachable. spawning \`ollama serve\` in the background...` to stderr, wait up to 15 seconds for it to come up, and report `[OK] ollama-daemon — daemon spawned and reachable`.

## Not in scope

- Actually running the interactive missing-model prompt from inside `aidev doctor` — doctor is still non-interactive (no stdin). If the daemon auto-spawns but required models are missing, doctor will FAIL on `ollama-models` with guidance to `ollama pull <model>` manually. The interactive fix flow still only fires during a normal `aidev -issue ...` run.
- The `-no-spawn` flag is added but not tested in CI because we don't have a daemon-less test harness. It's a simple boolean plumbing change.