### PR TITLE
feat: tui wires up implementer, tester, and reviewer via number keys + t + v

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ A single `aidev:<phase>` label on the issue gives you a kanban-style view of eve
 |-----|--------|
 | `r` | Run Scout + Critic |
 | `a` | After Critic: approve → kick off Architect |
+| `1`–`9` | After Sketches: pick a sketch → kick off Implementer |
+| `t` | After Patch/Tests: run the detected test suite |
+| `v` | After Patch/Tests: run the Reviewer on the patch |
 | `k` | Kill the proposal |
 | `tab` | Cycle pane focus |
 | `q` / `ctrl+c` | Quit |

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -6,21 +6,27 @@ import "github.com/charmbracelet/bubbles/key"
 // place makes the Help view and the Update switch statement agree by
 // construction.
 type keyMap struct {
-	Quit    key.Binding
-	Run     key.Binding
-	Tab     key.Binding
-	Approve key.Binding
-	Kill    key.Binding
-	Help    key.Binding
+	Quit       key.Binding
+	Run        key.Binding
+	Tab        key.Binding
+	Approve    key.Binding
+	Kill       key.Binding
+	Help       key.Binding
+	PickSketch key.Binding // 1-9 in phaseSketches kicks off the Implementer
+	Test       key.Binding // 't' in phasePatchReady runs the Tester
+	ReviewKey  key.Binding // 'v' in phasePatchReady/phaseTestsDone runs the Reviewer
 }
 
 func defaultKeys() keyMap {
 	return keyMap{
-		Quit:    key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
-		Run:     key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "run pipeline")),
-		Tab:     key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "cycle pane")),
-		Approve: key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "approve (build)")),
-		Kill:    key.NewBinding(key.WithKeys("k"), key.WithHelp("k", "kill proposal")),
-		Help:    key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+		Quit:       key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
+		Run:        key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "run pipeline")),
+		Tab:        key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "cycle pane")),
+		Approve:    key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "approve (build)")),
+		Kill:       key.NewBinding(key.WithKeys("k"), key.WithHelp("k", "kill proposal")),
+		Help:       key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+		PickSketch: key.NewBinding(key.WithKeys("1", "2", "3", "4", "5", "6", "7", "8", "9"), key.WithHelp("1-9", "pick sketch")),
+		Test:       key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "run tests")),
+		ReviewKey:  key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "review patch")),
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -16,14 +16,15 @@ import (
 
 // pane identifies the currently focused viewport so Tab can cycle between
 // them. The third pane doubles as the critic pane in the first half of the
-// pipeline and the sketches pane in the second half — toggled by
-// Model.showingSketches.
+// pipeline and the "current output" pane later — it retitles and rewrites
+// its content as each downstream phase (critic → architect → implementer →
+// tester → reviewer) produces new output.
 type pane int
 
 const (
 	paneIssue pane = iota
 	paneScout
-	paneCritic
+	paneOutput
 	numPanes
 )
 
@@ -33,13 +34,19 @@ const (
 type phase int
 
 const (
-	phaseIdle       phase = iota // waiting for user to press 'r'
-	phaseRunning                 // scout or critic is mid-flight
-	phaseAwaitUser               // critic done, waiting for a/k
-	phaseArchitect               // architect is mid-flight
-	phaseSketches                // sketches ready for review
-	phaseKilled                  // user killed the proposal
-	phaseErrored                 // something broke
+	phaseIdle        phase = iota // waiting for user to press 'r'
+	phaseRunning                  // scout or critic is mid-flight
+	phaseAwaitUser                // critic done, waiting for a/k
+	phaseArchitect                // architect is mid-flight
+	phaseSketches                 // sketches ready for review — 1-9 to pick one
+	phaseImplementing             // implementer mid-flight
+	phasePatchReady               // patch ready — t to test, v to review
+	phaseTesting                  // tester mid-flight
+	phaseTestsDone                // tests passed or failed — v to review
+	phaseReviewing                // reviewer mid-flight
+	phaseReviewDone               // review complete — q to finish
+	phaseKilled                   // user killed the proposal
+	phaseErrored                  // something broke
 )
 
 // Model is the root Bubble Tea model.
@@ -50,7 +57,7 @@ type Model struct {
 
 	issueVP  viewport.Model
 	scoutVP  viewport.Model
-	criticVP viewport.Model
+	outputVP viewport.Model
 
 	focus   pane
 	keys    keyMap
@@ -63,12 +70,14 @@ type Model struct {
 	// phase caches the high-level TUI state so view() can branch without
 	// reaching into the orchestrator on every render.
 	phase phase
-	// showingSketches flips the criticVP label from "Critic report" to
-	// "Architect sketches" once the Architect has produced output.
-	showingSketches bool
+
+	// outputTitle is the current label on the rightmost pane. It flips
+	// through "Critic report" → "Architect sketches" → "Implementer
+	// patch" → "Test result" → "Review" as the pipeline advances.
+	outputTitle string
 
 	// events is the current active event stream; only one phase drives it
-	// at a time (either Run or Continue).
+	// at a time (Run, Continue, Implement, Test, or ReviewPatch).
 	events <-chan orchestrator.Event
 }
 
@@ -76,12 +85,13 @@ type Model struct {
 func New(o *orchestrator.Orchestrator, issueURL, repoRoot string) Model {
 	preview := o.CostPreview()
 	return Model{
-		orch:     o,
-		issueURL: issueURL,
-		repoRoot: repoRoot,
-		keys:     defaultKeys(),
-		phase:    phaseIdle,
-		status: formatIdleStatus(preview.N, preview.TotalOutputTokens, preview.EstimatedSeconds),
+		orch:        o,
+		issueURL:    issueURL,
+		repoRoot:    repoRoot,
+		keys:        defaultKeys(),
+		phase:       phaseIdle,
+		outputTitle: "Critic report",
+		status:      formatIdleStatus(preview.N, preview.TotalOutputTokens, preview.EstimatedSeconds),
 	}
 }
 
@@ -104,6 +114,34 @@ func (m *Model) runPipelineCmd() tea.Cmd {
 func (m *Model) continuePipelineCmd() tea.Cmd {
 	m.events = m.orch.Continue(context.Background())
 	m.phase = phaseArchitect
+	return waitForEvent(m.events)
+}
+
+// implementCmd kicks off the Implementer on the given sketch number.
+func (m *Model) implementCmd(n int) tea.Cmd {
+	m.events = m.orch.Implement(context.Background(), n)
+	m.phase = phaseImplementing
+	return waitForEvent(m.events)
+}
+
+// testCmd kicks off the Tester against the currently-loaded repo.
+func (m *Model) testCmd() tea.Cmd {
+	m.events = m.orch.Test(context.Background())
+	m.phase = phaseTesting
+	return waitForEvent(m.events)
+}
+
+// reviewCmd kicks off the Reviewer against the current patch.
+func (m *Model) reviewCmd() tea.Cmd {
+	patch := ""
+	if p := m.orch.Patch(); p != nil {
+		patch = p.Diff
+	}
+	if patch == "" {
+		return nil
+	}
+	m.events = m.orch.ReviewPatch(context.Background(), patch)
+	m.phase = phaseReviewing
 	return waitForEvent(m.events)
 }
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -26,16 +26,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !m.ready {
 			m.issueVP = viewport.New(msg.Width/3, msg.Height-6)
 			m.scoutVP = viewport.New(msg.Width/3, msg.Height-6)
-			m.criticVP = viewport.New(msg.Width-2*(msg.Width/3), msg.Height-6)
+			m.outputVP = viewport.New(msg.Width-2*(msg.Width/3), msg.Height-6)
 			m.ready = true
 			m.hydrateInitialContent()
 		} else {
 			m.issueVP.Width = msg.Width / 3
 			m.scoutVP.Width = msg.Width / 3
-			m.criticVP.Width = msg.Width - 2*(msg.Width/3)
+			m.outputVP.Width = msg.Width - 2*(msg.Width/3)
 			m.issueVP.Height = msg.Height - 6
 			m.scoutVP.Height = msg.Height - 6
-			m.criticVP.Height = msg.Height - 6
+			m.outputVP.Height = msg.Height - 6
 		}
 
 	case tea.KeyMsg:
@@ -56,8 +56,33 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmd = m.continuePipelineCmd()
 				return m, cmd
 			}
+		case key.Matches(msg, m.keys.PickSketch):
 			if m.phase == phaseSketches {
-				m.status = "Sketch acceptance is a v0.3 feature (Implementer not yet wired). Pick one manually for now."
+				// The key string is the digit character; convert.
+				n := int(msg.String()[0] - '0')
+				sketches := m.orch.AgentContext().Sketches
+				if n >= 1 && n <= len(sketches) {
+					m.status = fmt.Sprintf("Running Implementer on sketch %d...", n)
+					cmd = m.implementCmd(n)
+					return m, cmd
+				}
+				m.status = fmt.Sprintf("No sketch %d (have %d). Pick 1-%d.", n, len(sketches), len(sketches))
+			}
+		case key.Matches(msg, m.keys.Test):
+			if m.phase == phasePatchReady || m.phase == phaseTestsDone {
+				m.status = "Running tests..."
+				cmd = m.testCmd()
+				return m, cmd
+			}
+		case key.Matches(msg, m.keys.ReviewKey):
+			if m.phase == phasePatchReady || m.phase == phaseTestsDone {
+				if m.orch.Patch() == nil {
+					m.status = "No patch to review. Run the Implementer first."
+				} else {
+					m.status = "Running Reviewer..."
+					cmd = m.reviewCmd()
+					return m, cmd
+				}
 			}
 		case key.Matches(msg, m.keys.Kill):
 			if m.phase == phaseAwaitUser || m.phase == phaseSketches {
@@ -85,14 +110,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.issueVP, cmd = m.issueVP.Update(msg)
 	case paneScout:
 		m.scoutVP, cmd = m.scoutVP.Update(msg)
-	case paneCritic:
-		m.criticVP, cmd = m.criticVP.Update(msg)
+	case paneOutput:
+		m.outputVP, cmd = m.outputVP.Update(msg)
 	}
 	return m, cmd
 }
 
 // hydrateInitialContent fills the issue viewport with the already-loaded
-// issue and leaves the scout/critic panes empty until the pipeline runs.
+// issue and leaves the scout/output panes empty until the pipeline runs.
 func (m *Model) hydrateInitialContent() {
 	ctx := m.orch.AgentContext()
 	if ctx.Issue != nil {
@@ -107,7 +132,7 @@ func (m *Model) hydrateInitialContent() {
 			ctx.Snapshot.Root, ctx.Snapshot.TotalFiles, ctx.Snapshot.TopLanguages(8),
 		))
 	}
-	m.criticVP.SetContent("Critic has not run yet.\nPress 'r' after Scout to generate a recommendation.")
+	m.outputVP.SetContent("Critic has not run yet.\nPress 'r' after Scout to generate a recommendation.")
 }
 
 // applyEvent folds an orchestrator event into the TUI state. It rewrites the
@@ -132,8 +157,9 @@ func (m *Model) applyEvent(ev orchestrator.Event) {
 		m.status = ev.Message
 	case orchestrator.StateAwaitUser:
 		if rpt := m.orch.CriticReport(); rpt != nil {
-			m.criticVP.SetContent(rpt.Markdown)
+			m.outputVP.SetContent(rpt.Markdown)
 		}
+		m.outputTitle = "Critic report"
 		m.phase = phaseAwaitUser
 		preview := m.orch.CostPreview()
 		m.status = fmt.Sprintf("%s  —  press 'a' to approve (Architect: %d sketches, ~%d tokens, ~%ds), 'k' to kill.",
@@ -142,10 +168,42 @@ func (m *Model) applyEvent(ev orchestrator.Event) {
 		m.phase = phaseArchitect
 		m.status = ev.Message
 	case orchestrator.StateSketchesReady:
-		m.showingSketches = true
+		m.outputTitle = "Architect sketches"
 		m.phase = phaseSketches
-		m.criticVP.SetContent(renderSketches(m.orch.AgentContext().Sketches))
-		m.status = ev.Message + "  —  'k' to kill, 'q' to quit."
+		m.outputVP.SetContent(renderSketches(m.orch.AgentContext().Sketches))
+		sketches := m.orch.AgentContext().Sketches
+		m.status = fmt.Sprintf("%s  —  press 1-%d to pick a sketch and run the Implementer, 'k' to kill.",
+			ev.Message, len(sketches))
+	case orchestrator.StateImplementing:
+		m.phase = phaseImplementing
+		m.status = ev.Message
+	case orchestrator.StatePatchReady:
+		m.outputTitle = "Implementer patch"
+		if patch := m.orch.Patch(); patch != nil {
+			m.outputVP.SetContent(patch.Diff)
+		}
+		m.phase = phasePatchReady
+		m.status = ev.Message + "  —  press 't' to run tests, 'v' to review the patch, 'q' to quit."
+	case orchestrator.StateTesting:
+		m.phase = phaseTesting
+		m.status = ev.Message
+	case orchestrator.StateTestsPassed, orchestrator.StateTestsFailed:
+		m.outputTitle = "Test result"
+		if r := m.orch.TestResult(); r != nil {
+			m.outputVP.SetContent(renderTestResult(r))
+		}
+		m.phase = phaseTestsDone
+		m.status = ev.Message + "  —  press 'v' to review, 't' to re-run tests, 'q' to quit."
+	case orchestrator.StateReviewing:
+		m.phase = phaseReviewing
+		m.status = ev.Message
+	case orchestrator.StateReviewDone:
+		m.outputTitle = "Review"
+		if rev := m.orch.Review(); rev != nil {
+			m.outputVP.SetContent(rev.Markdown)
+		}
+		m.phase = phaseReviewDone
+		m.status = ev.Message + "  —  press 'q' to quit."
 	case orchestrator.StateError:
 		if ev.Err != nil {
 			m.lastErr = ev.Err
@@ -169,6 +227,33 @@ func renderSketches(sketches []agents.Sketch) string {
 			b.WriteString("\n\n---\n\n")
 		}
 		b.WriteString(s.Markdown)
+	}
+	return b.String()
+}
+
+// renderTestResult formats a TestResult for the output pane — the headline
+// pass/fail verdict, command, duration, output tail, and the LLM summary
+// if the run failed.
+func renderTestResult(r *agents.TestResult) string {
+	var b strings.Builder
+	verdict := "PASSED"
+	if !r.Passed {
+		verdict = "FAILED"
+	}
+	fmt.Fprintf(&b, "# %s\n\n", verdict)
+	fmt.Fprintf(&b, "**command:** `%s`\n", r.Command)
+	fmt.Fprintf(&b, "**detected:** %s\n", r.Detected)
+	fmt.Fprintf(&b, "**exit code:** %d\n", r.ExitCode)
+	fmt.Fprintf(&b, "**duration:** %s\n\n", r.Duration)
+	if r.Summary != "" {
+		b.WriteString("## Failure summary\n\n")
+		b.WriteString(r.Summary)
+		b.WriteString("\n\n")
+	}
+	if r.Output != "" {
+		b.WriteString("## Output (tail)\n\n```\n")
+		b.WriteString(r.Output)
+		b.WriteString("\n```\n")
 	}
 	return b.String()
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -51,13 +51,13 @@ func (m Model) View() string {
 
 	issuePanel := panel("Issue", m.issueVP.View(), m.focus == paneIssue)
 	scoutPanel := panel("Scout brief", m.scoutVP.View(), m.focus == paneScout)
-	rightTitle := "Critic report"
-	if m.showingSketches {
-		rightTitle = "Architect sketches"
+	rightTitle := m.outputTitle
+	if rightTitle == "" {
+		rightTitle = "Critic report"
 	}
-	criticPanel := panel(rightTitle, m.criticVP.View(), m.focus == paneCritic)
+	outputPanel := panel(rightTitle, m.outputVP.View(), m.focus == paneOutput)
 
-	body := lipgloss.JoinHorizontal(lipgloss.Top, issuePanel, scoutPanel, criticPanel)
+	body := lipgloss.JoinHorizontal(lipgloss.Top, issuePanel, scoutPanel, outputPanel)
 
 	var footer string
 	if m.lastErr != nil {
@@ -77,5 +77,5 @@ func (m Model) View() string {
 }
 
 func helpHint() string {
-	return "tab: cycle panes   r: run   a: approve → Architect   k: kill   q: quit"
+	return "tab: cycle   r: run   a: approve→Architect   1-9: pick sketch→Implementer   t: test   v: review   k: kill   q: quit"
 }


### PR DESCRIPTION
## Summary

The orchestrator methods `Implement(n)`, `Test(ctx)`, and `ReviewPatch(patch)` existed since v0.3a/b/v0.4 but weren't reachable from the TUI — users had to drop to headless mode or subcommands to exercise them. v0.3a.2 wires them up with three new keybindings so the full pipeline is driveable from a single Bubble Tea session.

## New keybindings

| Key | Active in phase | Action |
|---|---|---|
| `1`–`9` | sketches_ready | pick sketch N, run Implementer |
| `t` | patch_ready, tests_done | run Tester against the working tree |
| `v` | patch_ready, tests_done | run Reviewer on the current patch |

Existing keys (`r`, `a`, `k`, `tab`, `q`) are unchanged.

## What's in the PR

**modified**
- `internal/tui/keys.go` — three new `key.Binding` fields: `PickSketch` (1-9), `Test` (t), `ReviewKey` (v). `defaultKeys()` populates them.
- `internal/tui/model.go` — renamed `paneCritic` → `paneOutput` and `criticVP` → `outputVP` since the rightmost pane is now a 'current output' pane that retitles through the pipeline. New `phase` values: `phaseImplementing`, `phasePatchReady`, `phaseTesting`, `phaseTestsDone`, `phaseReviewing`, `phaseReviewDone`. Removed the `showingSketches` bool — replaced with a more general `outputTitle` string that tracks which phase's output is currently displayed. New `implementCmd(n)`, `testCmd()`, `reviewCmd()` helpers that kick off the respective orchestrator methods and return the first waitForEvent tea.Cmd.
- `internal/tui/update.go` — key handling for the three new flows. `PickSketch` parses the digit out of the KeyMsg string, validates it against `len(Sketches)`, and calls `implementCmd`. `Test` and `ReviewKey` are guarded to their valid phases. `applyEvent` now handles every new state (`StateImplementing`, `StatePatchReady`, `StateTesting`, `StateTestsPassed`, `StateTestsFailed`, `StateReviewing`, `StateReviewDone`) by retitling the output pane, rewriting its content, and updating the status line with the next-action hint. New `renderTestResult` helper formats a TestResult as a scrollable markdown document.
- `internal/tui/view.go` — uses the new `outputTitle` field instead of the removed `showingSketches` boolean. Help hint line updated to advertise the new keys.
- `README.md` — TUI keybinding table updated with the new rows.

## Design decisions

- **Rightmost pane is now a 'current output' view, not per-phase panes.** Adding a fourth pane for each downstream phase (implementer → tester → reviewer) would make the layout cramped and the window-size math worse. Instead, the rightmost pane retitles and rewrites its content through the pipeline. The GitHub audit trail (from PR #3) is the history — if you want to re-read an earlier phase, scroll the issue, not the TUI.
- **Number keys 1-9 for sketch selection.** Matches 'this is sketch number N' in the Architect output. No ambiguity, no collision with other TUI idioms. `1-9` = 9 sketches max, which is higher than the 5 I'd ever realistically want to look at anyway.
- **`t` and `v` stay active across phases.** Both are valid from `patch_ready` AND `tests_done`, which lets you freely bounce between 'run tests' and 'review' without losing state. Re-running the Tester against the same patch is idempotent (the Tester doesn't mutate the patch), so there's no footgun.
- **No new TUI tests.** The TUI has zero unit tests today (Bubble Tea models are hard to test meaningfully without a TestingWriter abstraction I don't want to build right now). The key handling is simple enough that `go build` + manual smoke is the right bar. If you want TUI tests, file a follow-up issue.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all existing tests pass (TUI changes are untested at unit level — see Design Decisions)
- [x] Binary help flags unchanged (no new CLI flags in this PR)
- [ ] **Manual on @crisscross82's Mac:**
  - Run `aidev -issue <url> -repo <path>` interactively
  - `r` → scout + critic runs, recommendation appears
  - `a` → architect runs, sketches appear, status line says 'press 1-N to pick a sketch'
  - `1` → implementer runs, diff appears in the right pane, pane title reads 'Implementer patch'
  - `t` → tester runs, test result appears in the right pane, pane title reads 'Test result'
  - `v` → reviewer runs, review appears in the right pane, pane title reads 'Review'
  - `q` to quit at any point

## Worth reviewing carefully

- **No guards on re-running.** If you press `1` twice, the orchestrator's Implement() is called twice. The second call currently will error with `orchestrator: Implement called from state 'implementing'` (or similar) if the first is still running, or will run a fresh Implementer turn if the first finished. Idempotent-ish but not pretty. A state-machine lock would be the clean fix.
- **Killed/errored recovery.** From `phaseKilled` or `phaseErrored`, the only exit is `q`. There's no 'retry' key. If you want to recover from an error, restart aidev. This matches the existing behaviour but might be worth a `retry` keybind in a follow-up.
- **`outputTitle` is a string, not an enum.** I used a string for simplicity and because the view layer just renders it verbatim. A string-typed enum (type `outputLabel string` with consts) would be marginally safer but this isn't a hot path.

## Not in scope

- Following up on the patch (e.g. `git apply` from inside the TUI). aidev still proposes, the user still applies.
- Posting the patch to the GitHub issue as a one-shot artifact (already covered by the controller from PR #3 — no additional work here).
- Tests for TUI behaviour — Bubble Tea models are non-trivial to unit test and I didn't want to invest in a test harness for the handful of new branches. Manual smoke is the QA plan.