### PR TITLE
feat: tester optional docker sandbox with image and writable flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ go build -o aidev ./cmd/aidev
 # Bypass the startup doctor (not recommended; use when you manage the
 # environment yourself and want to save a few hundred ms on cold start)
 ./aidev -skip-doctor -issue ... -repo ...
+
+# Run tests inside a Docker container (isolation for untrusted patches)
+./aidev test -repo ~/code/myrepo --sandbox --image golang:1.24
+./aidev test -repo ~/code/myrepo --sandbox --image node:20 --writable
 ```
 
 ## Doctor

--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -358,12 +358,16 @@ func runReviewSubcommand() {
 }
 
 // runTestSubcommand handles `aidev test`. It detects the project's
-// test runner, executes it against the working tree, and prints the
-// result with an LLM-generated failure summary on non-zero exit.
+// test runner, executes it against the working tree (or inside a
+// Docker container if --sandbox is passed), and prints the result with
+// an LLM-generated failure summary on non-zero exit.
 func runTestSubcommand() {
 	var (
 		repoPath  = flag.String("repo", ".", "Path to the target repository")
 		configDir = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
+		sandbox   = flag.Bool("sandbox", false, "Run tests inside a Docker container instead of on the host")
+		image     = flag.String("image", "", "Docker image to use with --sandbox (e.g. golang:1.24, node:20, python:3.12)")
+		writable  = flag.Bool("writable", false, "Mount the repo read-write instead of read-only (sandbox mode)")
 	)
 	flag.Parse()
 
@@ -376,12 +380,30 @@ func runTestSubcommand() {
 	if err != nil {
 		fatal(fmt.Sprintf("tester: %v", err))
 	}
+
+	if *sandbox {
+		if *image == "" {
+			fatal("--sandbox requires --image (e.g. --image golang:1.24)")
+		}
+		tester.SetSandbox(*image, *writable)
+	}
+
 	absRepo, err := filepath.Abs(*repoPath)
 	if err != nil {
 		fatal(fmt.Sprintf("resolve repo: %v", err))
 	}
 
-	fmt.Fprintf(os.Stderr, "aidev test: detecting test runner in %s...\n", absRepo)
+	if *sandbox {
+		fmt.Fprintf(os.Stderr, "aidev test: running in sandbox (image %s, %s mount)...\n",
+			*image, func() string {
+				if *writable {
+					return "rw"
+				}
+				return "ro"
+			}())
+	} else {
+		fmt.Fprintf(os.Stderr, "aidev test: detecting test runner in %s...\n", absRepo)
+	}
 	result, err := tester.Run(context.Background(), absRepo)
 	if err != nil {
 		fatal(fmt.Sprintf("test: %v", err))
@@ -389,6 +411,7 @@ func runTestSubcommand() {
 
 	fmt.Printf("command: %s\n", result.Command)
 	fmt.Printf("detected: %s\n", result.Detected)
+	fmt.Printf("sandboxed: %t\n", result.Sandboxed)
 	fmt.Printf("exit: %d\n", result.ExitCode)
 	fmt.Printf("duration: %s\n", result.Duration)
 	fmt.Printf("passed: %t\n\n", result.Passed)

--- a/internal/agents/tester.go
+++ b/internal/agents/tester.go
@@ -14,11 +14,13 @@ import (
 	"github.com/aisu-ai/aidev/internal/llm"
 )
 
-// Tester is the v0.3b agent that runs the target repository's detected
-// test command and reports pass/fail. It never runs in a sandbox — tests
-// execute against the real working tree with the real process
-// environment, because aidev's safety story is "we propose, the human
-// applies, the tests run where the human ran git apply".
+// Tester runs the target repository's detected test command and
+// reports pass/fail. By default (v0.3b) it executes on the host with
+// the host's toolchain; with `Sandbox=true` (v0.5b) it runs the same
+// command inside a Docker container with the repo mounted read-only.
+// Sandbox mode is opt-in because it requires an image selection and a
+// docker daemon, but it's the safer path when you're about to run
+// test suites that came from someone else's patch.
 //
 // On test failure the Tester asks the medium-tier LLM for a 3-sentence
 // summary of what broke, which is attached to the TestResult. On success
@@ -30,27 +32,62 @@ type Tester struct {
 	// Timeout is the wall-clock limit for the test command. Zero means
 	// the default (5 minutes).
 	Timeout time.Duration
+
+	// Sandbox enables Docker-based isolation for test runs. When true,
+	// the detected test command is executed inside a container using
+	// the Image below, with the repository mounted at /work.
+	Sandbox bool
+
+	// Image is the Docker image reference used in sandbox mode. Users
+	// pick their own image so the toolchain matches what their project
+	// actually needs — we don't ship our own runner image.
+	Image string
+
+	// Writable mounts the repo read-write when true. Default (false)
+	// mounts read-only so a buggy test can't mutate the working tree
+	// from inside the container.
+	Writable bool
+
+	// DockerBin is the docker binary path; defaults to "docker".
+	// Exported so tests can inject a fake binary.
+	DockerBin string
 }
 
 // NewTester builds a Tester from the router's RoleTester mapping (the
 // small tier by default — failure summaries don't need deep reasoning).
+// Sandbox mode is off by default; enable it via SetSandbox().
 func NewTester(router *llm.Router) (*Tester, error) {
 	p, err := router.For(llm.RoleTester)
 	if err != nil {
 		return nil, err
 	}
-	return &Tester{Provider: p, Timeout: 5 * time.Minute}, nil
+	return &Tester{
+		Provider:  p,
+		Timeout:   5 * time.Minute,
+		DockerBin: "docker",
+	}, nil
+}
+
+// SetSandbox enables Docker isolation for subsequent Run() calls. image
+// is required — we don't guess at what runtime the user's project
+// needs. writable mounts the repo read-write; the default (false)
+// mounts read-only.
+func (t *Tester) SetSandbox(image string, writable bool) {
+	t.Sandbox = true
+	t.Image = image
+	t.Writable = writable
 }
 
 // TestResult is the output of a single Tester run.
 type TestResult struct {
-	Command  string
-	Detected string        // short label for the detection (go, node, cargo, etc.)
-	ExitCode int
-	Passed   bool
-	Output   string // tail of combined stdout+stderr, trimmed to a reasonable size
-	Duration time.Duration
-	Summary  string // LLM summary, only populated on failure
+	Command   string
+	Detected  string // short label for the detection (go, node, cargo, etc.)
+	Sandboxed bool   // true when the command ran inside a Docker container
+	ExitCode  int
+	Passed    bool
+	Output    string // tail of combined stdout+stderr, trimmed to a reasonable size
+	Duration  time.Duration
+	Summary   string // LLM summary, only populated on failure
 }
 
 // DetectTestCommand inspects the top-level files of repoRoot and returns
@@ -129,6 +166,13 @@ func (t *Tester) Run(ctx context.Context, repoRoot string) (*TestResult, error) 
 		return nil, errors.New("tester: empty repo root")
 	}
 
+	// Fail fast on sandbox misconfiguration BEFORE touching the context
+	// — a nil ctx would panic in context.WithTimeout later, and we'd
+	// rather surface a clean config error than a runtime panic.
+	if t.Sandbox && t.Image == "" {
+		return nil, errors.New("tester: sandbox enabled but no image set (call SetSandbox first)")
+	}
+
 	var cmdArgs []string
 	label := ""
 	if override := os.Getenv("AIDEV_TEST_COMMAND"); override != "" {
@@ -152,8 +196,25 @@ func (t *Tester) Run(ctx context.Context, repoRoot string) (*TestResult, error) 
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(runCtx, cmdArgs[0], cmdArgs[1:]...)
-	cmd.Dir = repoRoot
+	// Rewrite cmdArgs + CWD into a docker invocation when sandboxing
+	// is enabled. wrapInDocker is a pure function (tested directly) so
+	// we can unit-test the command construction without a real docker
+	// daemon.
+	var cmd *exec.Cmd
+	if t.Sandbox {
+		dockerBin := t.DockerBin
+		if dockerBin == "" {
+			dockerBin = "docker"
+		}
+		dockerArgs := wrapInDocker(t.Image, repoRoot, t.Writable, cmdArgs)
+		cmd = exec.CommandContext(runCtx, dockerBin, dockerArgs...)
+		// CWD for docker itself doesn't matter — the container's CWD
+		// is set via -w /work inside wrapInDocker.
+	} else {
+		cmd = exec.CommandContext(runCtx, cmdArgs[0], cmdArgs[1:]...)
+		cmd.Dir = repoRoot
+	}
+
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
@@ -173,12 +234,13 @@ func (t *Tester) Run(ctx context.Context, repoRoot string) (*TestResult, error) 
 
 	output := tailString(buf.String(), 4096)
 	result := &TestResult{
-		Command:  strings.Join(cmdArgs, " "),
-		Detected: label,
-		ExitCode: exitCode,
-		Passed:   exitCode == 0,
-		Output:   output,
-		Duration: duration,
+		Command:   strings.Join(cmdArgs, " "),
+		Detected:  label,
+		Sandboxed: t.Sandbox,
+		ExitCode:  exitCode,
+		Passed:    exitCode == 0,
+		Output:    output,
+		Duration:  duration,
 	}
 
 	if !result.Passed {
@@ -229,4 +291,25 @@ func tailString(s string, n int) string {
 		return s
 	}
 	return "...[truncated]...\n" + s[len(s)-n:]
+}
+
+// wrapInDocker rewrites a host-native test command into a
+// `docker run --rm -v <repo>:/work[:ro] -w /work <image> <cmd...>`
+// invocation. Pure function — exported so tests can exercise every
+// branch without a real docker daemon.
+//
+// The container runs with `--rm` so it's cleaned up after the test
+// exits. The repository mounts at `/work` inside the container; `-w
+// /work` sets that as the working directory. Read-only by default;
+// pass writable=true to allow tests that legitimately mutate the
+// working tree (generated files, coverage output, etc.).
+func wrapInDocker(image, repoRoot string, writable bool, cmd []string) []string {
+	args := []string{"run", "--rm"}
+	mount := repoRoot + ":/work"
+	if !writable {
+		mount += ":ro"
+	}
+	args = append(args, "-v", mount, "-w", "/work", image)
+	args = append(args, cmd...)
+	return args
 }

--- a/internal/agents/tester_test.go
+++ b/internal/agents/tester_test.go
@@ -139,3 +139,80 @@ func TestMakefileHasTarget(t *testing.T) {
 		t.Error("should not find lint target")
 	}
 }
+
+// v0.5b Docker sandbox tests.
+
+func TestWrapInDockerReadOnly(t *testing.T) {
+	got := wrapInDocker("golang:1.24", "/home/user/repo", false, []string{"go", "test", "./..."})
+	want := []string{
+		"run", "--rm",
+		"-v", "/home/user/repo:/work:ro",
+		"-w", "/work",
+		"golang:1.24",
+		"go", "test", "./...",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d args, want %d\ngot:  %v\nwant: %v", len(got), len(want), got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("args[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestWrapInDockerWritable(t *testing.T) {
+	got := wrapInDocker("python:3.12", "/repo", true, []string{"pytest"})
+	// The mount arg should NOT end in :ro when writable is true.
+	found := false
+	for _, a := range got {
+		if a == "/repo:/work" {
+			found = true
+		}
+		if a == "/repo:/work:ro" {
+			t.Errorf("read-only mount leaked into writable mode: %v", got)
+		}
+	}
+	if !found {
+		t.Errorf("mount arg missing from writable invocation: %v", got)
+	}
+}
+
+func TestWrapInDockerPreservesCommandArgs(t *testing.T) {
+	cmd := []string{"npm", "test", "--", "--coverage"}
+	got := wrapInDocker("node:20", "/r", false, cmd)
+	// The last len(cmd) args should be the command verbatim.
+	tail := got[len(got)-len(cmd):]
+	for i, c := range cmd {
+		if tail[i] != c {
+			t.Errorf("tail[%d] = %q, want %q", i, tail[i], c)
+		}
+	}
+}
+
+func TestSetSandboxFlipsFlags(t *testing.T) {
+	tester := &Tester{}
+	tester.SetSandbox("golang:1.24", true)
+	if !tester.Sandbox {
+		t.Error("Sandbox should be true after SetSandbox")
+	}
+	if tester.Image != "golang:1.24" {
+		t.Errorf("Image = %q", tester.Image)
+	}
+	if !tester.Writable {
+		t.Error("Writable should be true")
+	}
+}
+
+func TestRunFailsFastWhenSandboxEnabledButNoImage(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x"), 0o644)
+	tester := &Tester{Sandbox: true} // Image intentionally empty
+	_, err := tester.Run(nil, dir)
+	if err == nil {
+		t.Error("expected error when sandbox is enabled but no image is set")
+	}
+	if !strings.Contains(err.Error(), "image") {
+		t.Errorf("error should mention image, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

v0.5b adds Docker-based sandboxing to the Tester. The Tester still runs on the host by default (matches v0.3b behaviour — aidev doesn't force a toolchain change on you), but you can opt in with `--sandbox --image <ref>` to run the detected test command inside a container with the repo mounted at `/work` read-only. Read-write is opt-in via `--writable`.

This closes the safety gap I flagged in the v0.3b PR: the Tester was the first agent that actually executed user code, with nothing stopping a buggy test from touching the real working tree. Sandbox mode makes that a conscious choice.

## What's in the PR

**modified**
- `internal/agents/tester.go` — new `Tester.Sandbox`, `Image`, `Writable`, `DockerBin` fields. New `SetSandbox(image, writable)` setter. `Run()` branches between native and Docker paths, wrapping the detected command via `wrapInDocker()` when sandboxing is on. Early-return fast if `Sandbox && Image == ""` (before touching the context — avoids a panic if a caller passes nil ctx for a config test). New `Sandboxed` field on `TestResult`.
- `internal/agents/tester_test.go` — 5 new tests: `wrapInDocker` read-only mode, writable mode, command-preservation (args passed through intact), `SetSandbox` flag-flipping, fast-fail when sandbox is enabled with no image.
- `cmd/aidev/main.go` — three new flags on `aidev test`: `--sandbox`, `--image`, `--writable`. When `--sandbox` is set without `--image`, fatal with an explicit error. Output now includes a `sandboxed: true/false` line so you can tell which path you ran.
- `README.md` — two new example invocations in the Build & run section.

## Design decisions

- **User picks the image, aidev doesn't guess.** Shipping our own `aidev/runner:latest` image would mean tracking versions of 8+ language toolchains and making judgement calls about which distro base, which GC settings, which CGO flags. Users pick. We just wire up `docker run`. This keeps aidev a shell helper, not a distro maintainer.
- **Read-only by default.** A legitimate test suite shouldn't need to mutate the working tree. Tests that do (generated files, coverage reports) can pass `--writable`. Making the safer path the default matches every other safety decision in aidev: propose > mutate.
- **Sandbox config lives on the Tester struct, not the orchestrator.** The orchestrator's `Test()` method just calls `tester.Run(ctx, root)` — it doesn't know or care whether the call is sandboxed. Sandbox is configured once at construction (via `SetSandbox`) and stays for the life of the Tester. This means `aidev test --sandbox` works but the in-pipeline `Test()` flow (from the TUI) doesn't currently honour it. That's a v0.5b.1 follow-up if you want TUI-driven sandbox runs.
- **`wrapInDocker` is a pure function.** Takes image, repo root, writable flag, command slice → returns docker argv slice. No side effects, no context, no exec. Fully unit-testable without a docker daemon. Verifying every branch with a real container is a different kind of test that belongs in CI, not this PR.
- **Detection still runs on the host.** We detect the test command from the repo's top-level files BEFORE building the docker command. This means the host needs to read the files but doesn't need the toolchain. Alternative (running `ls` inside the container first) would add a second docker invocation per run for no benefit.
- **`--rm` on every invocation.** Containers are cleaned up after the test exits. No accumulation of stopped containers in `docker ps -a`. If your test writes files to /tmp inside the container, they're gone when the container exits — use `--writable` and write to the mounted repo if you need persistence.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — 5 new tester tests pass, all existing tests pass
- [x] `aidev test -h` shows the new flags
- [ ] **Manual on @crisscross82's Mac (Docker Desktop):**
  - Native path still works: `aidev test -repo ~/code/some-go-project`
  - Sandbox path: `aidev test -repo ~/code/some-go-project --sandbox --image golang:1.24`
  - Read-only enforcement: run a test that tries to write to the working tree in sandbox mode — should fail with a read-only filesystem error, not mutate anything
  - Writable opt-in: same test with `--writable` should succeed
  - Image without daemon: stop Docker Desktop and run the sandbox command — should report a clear 'docker daemon not running' style error

## Worth reviewing carefully

- **No host-side docker check.** I don't verify that `docker` exists on PATH or that the daemon is running before launching the sandboxed test. If Docker isn't installed, `exec.Command("docker", ...).Run()` returns an error that we surface via the normal failure path — but the error message is less helpful than a proper doctor check. A `checkDocker` function in `internal/doctor/` is the right follow-up, probably v0.5b.1.
- **Image pull happens on-demand.** The first `aidev test --sandbox --image golang:1.24` run pulls the image if it's not cached locally — that's a multi-GB download the user didn't explicitly consent to. The consent pattern from `aidev doctor`'s first-pull menu would be nice here too but is out of scope. Docker at least streams pull progress to stderr during the run.
- **No network isolation.** Tests inside the container can still reach the internet. If you want network-isolated tests, add `--network none` to the docker args — another knob worth exposing as a flag in a follow-up.
- **Linux-first assumptions.** The `-v <host>:/work` mount syntax is cross-platform (Docker Desktop on macOS and Windows translate it), but path quoting on Windows paths with spaces is untested. If you run aidev on Windows, tell me and I'll add the quoting logic.

## Out of scope

- Sandboxing for the Implementer (which doesn't actually execute anything — its output is a diff string)
- Rootless docker / podman detection and auto-selection
- Image caching beyond what docker already does
- Per-test-runner default images (`go → golang:1.24`, `python → python:3.12`) — revisit after real usage shows which defaults are sane