### PR TITLE
feat: add clarifier agent with dependency-aware question graph and subcommand

### DIFF
--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -16,15 +16,15 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-
-	"strings"
 
 	"github.com/aisu-ai/aidev/internal/agents"
 	"github.com/aisu-ai/aidev/internal/config"
@@ -79,6 +79,16 @@ func main() {
 	if len(os.Args) > 1 && os.Args[1] == "followups" {
 		os.Args = append(os.Args[:1], os.Args[2:]...)
 		runFollowUpsSubcommand()
+		return
+	}
+	// Intercept the `clarify` subcommand. Runs the Clarifier agent
+	// against an issue + fresh Critic report, walks the resulting
+	// question graph in dependency-aware waves, and writes the
+	// session to .aidev/clarifier.md for the Architect to absorb on
+	// its next run.
+	if len(os.Args) > 1 && os.Args[1] == "clarify" {
+		os.Args = append(os.Args[:1], os.Args[2:]...)
+		runClarifySubcommand()
 		return
 	}
 
@@ -165,6 +175,101 @@ func main() {
 	if _, err := p.Run(); err != nil {
 		fatal(fmt.Sprintf("tui: %v", err))
 	}
+}
+
+// runClarifySubcommand handles `aidev clarify`. It runs the full
+// Scout + Critic pipeline so the Clarifier has context to work from,
+// then asks the Clarifier to produce a structured question graph,
+// then walks the graph in dependency-aware waves with stdin-based
+// answers from the developer, and finally persists the session to
+// `<repo>/.aidev/clarifier.md`.
+//
+// Unlike the full `aidev -issue ...` flow this subcommand does NOT
+// run the Architect afterwards — it's a standalone interview you run
+// BEFORE the Architect when the Critic flagged ambiguities.
+func runClarifySubcommand() {
+	var (
+		issueURL  = flag.String("issue", "", "GitHub issue URL (required)")
+		repoPath  = flag.String("repo", ".", "Path to the target repository")
+		configDir = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
+	)
+	flag.Parse()
+	if *issueURL == "" {
+		fatal("missing required flag: -issue")
+	}
+
+	cfg := mustLoadConfig(*configDir)
+	orch, err := orchestrator.New(cfg)
+	if err != nil {
+		fatal(fmt.Sprintf("orchestrator: %v", err))
+	}
+	ctx := context.Background()
+	if err := orch.LoadIssue(ctx, *issueURL); err != nil {
+		fatal(fmt.Sprintf("load issue: %v", err))
+	}
+	absRepo, err := filepath.Abs(*repoPath)
+	if err != nil {
+		fatal(fmt.Sprintf("resolve repo: %v", err))
+	}
+	if err := orch.LoadRepo(absRepo); err != nil {
+		fatal(fmt.Sprintf("scan repo: %v", err))
+	}
+
+	// Run the first-pass pipeline so the agent context has a fresh
+	// Scout brief + Critic report to hand to the Clarifier.
+	fmt.Fprintln(os.Stderr, "aidev clarify: running scout + critic to gather context...")
+	for ev := range orch.Run(ctx) {
+		if ev.Err != nil {
+			fatal(ev.Err.Error())
+		}
+	}
+
+	router, err := llm.NewRouter(cfg)
+	if err != nil {
+		fatal(fmt.Sprintf("router: %v", err))
+	}
+	clarifier, err := agents.NewClarifier(router)
+	if err != nil {
+		fatal(fmt.Sprintf("clarifier: %v", err))
+	}
+
+	fmt.Fprintln(os.Stderr, "aidev clarify: asking the Clarifier to produce a question graph...")
+	graph, err := clarifier.Run(ctx, orch.AgentContext())
+	if err != nil {
+		fatal(fmt.Sprintf("clarifier: %v", err))
+	}
+	if len(graph.Questions) == 0 {
+		fmt.Fprintln(os.Stderr, "Clarifier produced no questions — the Critic report has nothing ambiguous worth asking about. Skipping the interview.")
+		return
+	}
+
+	// Walk the graph in waves.
+	waves := agents.BatchByDependencies(graph)
+	var answers []agents.Answer
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Fprintf(os.Stderr, "\n%d questions in %d wave(s). Answer each one, then press enter.\n\n", len(graph.Questions), len(waves))
+	for wi, wave := range waves {
+		fmt.Fprintf(os.Stderr, "— Wave %d (%d question(s)) —\n\n", wi+1, len(wave))
+		for _, q := range wave {
+			fmt.Fprintf(os.Stderr, "%s: %s\n> ", q.ID, q.Text)
+			line, err := reader.ReadString('\n')
+			if err != nil && line == "" {
+				fatal(fmt.Sprintf("read answer: %v", err))
+			}
+			answers = append(answers, agents.Answer{
+				ID:   q.ID,
+				Text: strings.TrimRight(line, "\n"),
+			})
+		}
+		fmt.Fprintln(os.Stderr)
+	}
+
+	path, err := agents.WriteClarifierMarkdown(absRepo, graph, answers)
+	if err != nil {
+		fatal(fmt.Sprintf("write clarifier: %v", err))
+	}
+	fmt.Fprintf(os.Stderr, "wrote %s\n", path)
 }
 
 // runFollowUpsSubcommand handles `aidev followups`. With --file-issues,

--- a/internal/agents/clarifier.go
+++ b/internal/agents/clarifier.go
@@ -1,0 +1,346 @@
+// Clarifier is v0.5c's "adaptive dialogue" agent. It sits between the
+// Critic and the Architect and turns the Critic's ambiguities into a
+// structured, dependency-aware question graph that the orchestrator
+// (or the `aidev clarify` subcommand) can walk in waves: independent
+// questions batch, chained questions serialise.
+//
+// I specifically chose NOT to rewrite the Critic's output format
+// (which was the alternative path proposed in the v0.2b sparring
+// round). The Critic's adversarial markdown report is worth keeping.
+// The Clarifier is a new agent that reads the Critic's output as
+// prose and distils its open questions into a graph.
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aisu-ai/aidev/internal/llm"
+)
+
+// Clarifier is the v0.5c agent.
+type Clarifier struct {
+	Provider llm.Provider
+}
+
+// NewClarifier builds a Clarifier from the router's RoleCritic mapping
+// (reuses the critic tier since the task is adjacent — close
+// reasoning about the Critic's own output).
+func NewClarifier(router *llm.Router) (*Clarifier, error) {
+	p, err := router.For(llm.RoleCritic)
+	if err != nil {
+		return nil, err
+	}
+	return &Clarifier{Provider: p}, nil
+}
+
+// Question is one node in the Clarifier's output graph.
+type Question struct {
+	ID        string   `json:"id"`         // stable identifier like "q1"
+	Text      string   `json:"text"`       // the prompt the user sees
+	DependsOn []string `json:"depends_on"` // IDs of questions whose answers gate this one
+}
+
+// QuestionGraph is the Clarifier's structured output.
+type QuestionGraph struct {
+	Questions []Question `json:"questions"`
+}
+
+// Answer pairs a Question ID with the user's reply.
+type Answer struct {
+	ID   string
+	Text string
+}
+
+// Run asks the Clarifier LLM to produce a question graph for the
+// current issue and Critic report. The caller (a subcommand or the
+// orchestrator) is responsible for walking the graph in waves and
+// collecting answers.
+func (c *Clarifier) Run(ctx context.Context, cc *Context) (*QuestionGraph, error) {
+	if cc == nil || cc.Issue == nil {
+		return nil, errors.New("clarifier: missing issue")
+	}
+	if cc.CriticReport == "" {
+		return nil, errors.New("clarifier: critic report must run first")
+	}
+
+	system := "You are the Clarifier for aidev, a multi-agent coding tool.\n" +
+		"\n" +
+		"The Critic has just produced a report on a proposed change. Your job\n" +
+		"is to read that report and the issue body, identify the unresolved\n" +
+		"questions whose answers would materially affect the Architect's\n" +
+		"sketches, and return them as a STRUCTURED QUESTION GRAPH.\n" +
+		"\n" +
+		"REQUIREMENTS:\n" +
+		"\n" +
+		"1. Output ONLY a JSON object with a single top-level field `questions`\n" +
+		"   containing an array of question objects. No markdown, no code\n" +
+		"   fence, no prose around it. If you want to wrap it, I will tolerate\n" +
+		"   a ```json fence.\n" +
+		"\n" +
+		"2. Each question has exactly three fields:\n" +
+		"     - id: a stable identifier like 'q1', 'q2'. Must be unique.\n" +
+		"     - text: the question as the developer will see it.\n" +
+		"     - depends_on: an array of other question IDs whose answers are\n" +
+		"       prerequisites for asking this one. Empty array [] means the\n" +
+		"       question is independent and can be asked in the first wave.\n" +
+		"\n" +
+		"3. A dependency means 'the answer to this earlier question changes\n" +
+		"   what the later question should even be'. Do NOT list dependencies\n" +
+		"   for questions that are merely related — only for questions that\n" +
+		"   would be DIFFERENT or UNNECESSARY given the earlier answer.\n" +
+		"\n" +
+		"4. Emit no more than 8 questions. If the Critic raised more\n" +
+		"   concerns than that, pick the ones that matter most for the\n" +
+		"   Architect's choice of approach.\n" +
+		"\n" +
+		"5. If the Critic report has NO unresolved questions worth asking\n" +
+		"   (e.g. the change is trivial or the Critic already recommended\n" +
+		"   kill), return a JSON object with an empty questions array.\n" +
+		"\n" +
+		"Example output (follow this shape exactly):\n" +
+		"\n" +
+		"{\"questions\":[\n" +
+		"  {\"id\":\"q1\",\"text\":\"What latency target matters most?\",\"depends_on\":[]},\n" +
+		"  {\"id\":\"q2\",\"text\":\"Is the data partitionable by tenant?\",\"depends_on\":[]},\n" +
+		"  {\"id\":\"q3\",\"text\":\"Given q1 and q2, choose a storage backend: Postgres, Redis, or a managed service?\",\"depends_on\":[\"q1\",\"q2\"]}\n" +
+		"]}"
+
+	var principles strings.Builder
+	for _, p := range cc.Principles {
+		fmt.Fprintf(&principles, "- **%s** — %s\n", p.Name, p.Summary)
+	}
+
+	user := fmt.Sprintf(
+		"## Issue %s/%s#%d: %s\n\n%s\n\n## Critic report\n\n%s\n\n## Engineering principles\n\n%s",
+		cc.Issue.Owner, cc.Issue.Repo, cc.Issue.Number, cc.Issue.Title,
+		cc.Issue.Body, cc.CriticReport, principles.String(),
+	)
+
+	resp, err := c.Provider.Complete(ctx, llm.Request{
+		System: system,
+		Messages: []llm.Message{
+			{Role: "user", Content: user},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("clarifier: %w", err)
+	}
+
+	return ParseQuestionGraph(resp.Content)
+}
+
+// clarifierJSONRe matches the first {...} block in the response. A
+// markdown code fence around the JSON is handled too — we strip leading
+// and trailing ``` lines before parsing.
+var clarifierJSONRe = regexp.MustCompile(`(?s)\{.*\}`)
+
+// ParseQuestionGraph extracts a QuestionGraph from a raw model
+// response. Tolerates markdown code fences and leading/trailing prose
+// (as long as exactly one JSON object is present). Validates that:
+//
+//   - every question has a non-empty id and text
+//   - every depends_on ID refers to another question in the same graph
+//   - the resulting graph is acyclic
+//
+// Exported so the subcommand and tests can share it.
+func ParseQuestionGraph(raw string) (*QuestionGraph, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, errors.New("empty clarifier response")
+	}
+	// Strip a single surrounding code fence if present.
+	raw = stripCodeFence(raw)
+
+	var g QuestionGraph
+	if err := json.Unmarshal([]byte(raw), &g); err == nil {
+		return validateQuestionGraph(&g)
+	}
+
+	// Fallback: pull the first JSON object from the body.
+	match := clarifierJSONRe.FindString(raw)
+	if match == "" {
+		return nil, fmt.Errorf("no JSON object in clarifier response: %q", firstLine(raw))
+	}
+	if err := json.Unmarshal([]byte(match), &g); err != nil {
+		return nil, fmt.Errorf("parse clarifier JSON: %w", err)
+	}
+	return validateQuestionGraph(&g)
+}
+
+// validateQuestionGraph enforces structural invariants: unique IDs,
+// non-empty text, depends_on references to real questions, and an
+// acyclic dependency graph (detected by a simple DFS colouring).
+func validateQuestionGraph(g *QuestionGraph) (*QuestionGraph, error) {
+	if g == nil {
+		return nil, errors.New("nil question graph")
+	}
+	seen := make(map[string]bool, len(g.Questions))
+	for _, q := range g.Questions {
+		if q.ID == "" {
+			return nil, errors.New("question with empty id")
+		}
+		if q.Text == "" {
+			return nil, fmt.Errorf("question %q has empty text", q.ID)
+		}
+		if seen[q.ID] {
+			return nil, fmt.Errorf("duplicate question id %q", q.ID)
+		}
+		seen[q.ID] = true
+	}
+	// Validate depends_on references.
+	for _, q := range g.Questions {
+		for _, dep := range q.DependsOn {
+			if !seen[dep] {
+				return nil, fmt.Errorf("question %q depends on unknown id %q", q.ID, dep)
+			}
+			if dep == q.ID {
+				return nil, fmt.Errorf("question %q depends on itself", q.ID)
+			}
+		}
+	}
+	// Cycle detection via DFS colouring.
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	colour := make(map[string]int, len(g.Questions))
+	byID := make(map[string]Question, len(g.Questions))
+	for _, q := range g.Questions {
+		byID[q.ID] = q
+	}
+	var visit func(id string) error
+	visit = func(id string) error {
+		switch colour[id] {
+		case gray:
+			return fmt.Errorf("cycle detected at question %q", id)
+		case black:
+			return nil
+		}
+		colour[id] = gray
+		for _, dep := range byID[id].DependsOn {
+			if err := visit(dep); err != nil {
+				return err
+			}
+		}
+		colour[id] = black
+		return nil
+	}
+	for _, q := range g.Questions {
+		if err := visit(q.ID); err != nil {
+			return nil, err
+		}
+	}
+	return g, nil
+}
+
+// BatchByDependencies walks the question graph in waves: every wave
+// contains questions whose dependencies have all been answered in
+// earlier waves. Returns a slice of waves where each wave is a slice
+// of questions that can be asked concurrently.
+//
+// This is the core of the "adaptive dialogue" promise: independent
+// questions batch, chained questions serialise. The result drives the
+// subcommand's interview loop.
+func BatchByDependencies(g *QuestionGraph) [][]Question {
+	if g == nil || len(g.Questions) == 0 {
+		return nil
+	}
+	byID := make(map[string]Question, len(g.Questions))
+	for _, q := range g.Questions {
+		byID[q.ID] = q
+	}
+
+	answered := make(map[string]bool)
+	var waves [][]Question
+	remaining := make([]Question, len(g.Questions))
+	copy(remaining, g.Questions)
+
+	for len(remaining) > 0 {
+		var wave []Question
+		var next []Question
+		for _, q := range remaining {
+			ready := true
+			for _, dep := range q.DependsOn {
+				if !answered[dep] {
+					ready = false
+					break
+				}
+			}
+			if ready {
+				wave = append(wave, q)
+			} else {
+				next = append(next, q)
+			}
+		}
+		// Sort the wave by ID so the output is deterministic across
+		// map iteration orders.
+		sort.Slice(wave, func(i, j int) bool { return wave[i].ID < wave[j].ID })
+		if len(wave) == 0 {
+			// Shouldn't happen after validateQuestionGraph, but defend
+			// against a partially-cycled graph being passed directly.
+			return waves
+		}
+		waves = append(waves, wave)
+		for _, q := range wave {
+			answered[q.ID] = true
+		}
+		remaining = next
+	}
+	return waves
+}
+
+// WriteClarifierMarkdown serialises a Clarifier session (graph + the
+// answers the user gave) as markdown to `<repoRoot>/.aidev/clarifier.md`.
+// The Architect picks this file up on the next run the same way it
+// picks up the charter.
+func WriteClarifierMarkdown(repoRoot string, g *QuestionGraph, answers []Answer) (string, error) {
+	if repoRoot == "" {
+		return "", errors.New("clarifier: empty repo root")
+	}
+	if g == nil {
+		return "", errors.New("clarifier: nil graph")
+	}
+	dir := filepath.Join(repoRoot, ".aidev")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("clarifier: mkdir: %w", err)
+	}
+	path := filepath.Join(dir, "clarifier.md")
+
+	answerByID := make(map[string]string, len(answers))
+	for _, a := range answers {
+		answerByID[a.ID] = a.Text
+	}
+
+	var b strings.Builder
+	b.WriteString("# Clarifier session\n\n")
+	fmt.Fprintf(&b, "_Recorded by aidev on %s._\n\n", time.Now().UTC().Format("2006-01-02"))
+	waves := BatchByDependencies(g)
+	for w, wave := range waves {
+		fmt.Fprintf(&b, "## Wave %d\n\n", w+1)
+		for _, q := range wave {
+			fmt.Fprintf(&b, "### %s — %s\n\n", q.ID, q.Text)
+			if len(q.DependsOn) > 0 {
+				fmt.Fprintf(&b, "_Depends on: %s_\n\n", strings.Join(q.DependsOn, ", "))
+			}
+			ans := answerByID[q.ID]
+			if ans == "" {
+				ans = "(unanswered)"
+			}
+			fmt.Fprintf(&b, "**Answer:** %s\n\n", ans)
+		}
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		return "", fmt.Errorf("clarifier: write: %w", err)
+	}
+	return path, nil
+}

--- a/internal/agents/clarifier_test.go
+++ b/internal/agents/clarifier_test.go
@@ -1,0 +1,231 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sampleQuestionGraphJSON = `{
+  "questions": [
+    {"id": "q1", "text": "What latency target matters?", "depends_on": []},
+    {"id": "q2", "text": "Is the data partitionable?", "depends_on": []},
+    {"id": "q3", "text": "Given q1, q2, which storage backend?", "depends_on": ["q1", "q2"]}
+  ]
+}`
+
+func TestParseQuestionGraphHappyPath(t *testing.T) {
+	g, err := ParseQuestionGraph(sampleQuestionGraphJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(g.Questions) != 3 {
+		t.Errorf("got %d questions, want 3", len(g.Questions))
+	}
+	if g.Questions[2].ID != "q3" || len(g.Questions[2].DependsOn) != 2 {
+		t.Errorf("q3 shape wrong: %+v", g.Questions[2])
+	}
+}
+
+func TestParseQuestionGraphWithCodeFence(t *testing.T) {
+	wrapped := "```json\n" + sampleQuestionGraphJSON + "\n```"
+	g, err := ParseQuestionGraph(wrapped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(g.Questions) != 3 {
+		t.Errorf("got %d questions, want 3", len(g.Questions))
+	}
+}
+
+func TestParseQuestionGraphEmptyQuestionsAllowed(t *testing.T) {
+	g, err := ParseQuestionGraph(`{"questions":[]}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(g.Questions) != 0 {
+		t.Errorf("expected empty, got %v", g.Questions)
+	}
+}
+
+func TestParseQuestionGraphRejectsDuplicateID(t *testing.T) {
+	raw := `{"questions":[
+    {"id":"q1","text":"a","depends_on":[]},
+    {"id":"q1","text":"b","depends_on":[]}
+  ]}`
+	_, err := ParseQuestionGraph(raw)
+	if err == nil {
+		t.Error("expected duplicate id error")
+	}
+}
+
+func TestParseQuestionGraphRejectsUnknownDependency(t *testing.T) {
+	raw := `{"questions":[
+    {"id":"q1","text":"a","depends_on":["missing"]}
+  ]}`
+	_, err := ParseQuestionGraph(raw)
+	if err == nil {
+		t.Error("expected unknown dependency error")
+	}
+}
+
+func TestParseQuestionGraphRejectsSelfDependency(t *testing.T) {
+	raw := `{"questions":[
+    {"id":"q1","text":"a","depends_on":["q1"]}
+  ]}`
+	_, err := ParseQuestionGraph(raw)
+	if err == nil {
+		t.Error("expected self-dependency error")
+	}
+}
+
+func TestParseQuestionGraphRejectsCycle(t *testing.T) {
+	raw := `{"questions":[
+    {"id":"q1","text":"a","depends_on":["q2"]},
+    {"id":"q2","text":"b","depends_on":["q1"]}
+  ]}`
+	_, err := ParseQuestionGraph(raw)
+	if err == nil {
+		t.Error("expected cycle detection error")
+	}
+	if err != nil && !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error should mention cycle: %v", err)
+	}
+}
+
+func TestParseQuestionGraphRejectsEmptyText(t *testing.T) {
+	raw := `{"questions":[
+    {"id":"q1","text":"","depends_on":[]}
+  ]}`
+	_, err := ParseQuestionGraph(raw)
+	if err == nil {
+		t.Error("expected empty text error")
+	}
+}
+
+func TestBatchByDependenciesIndependent(t *testing.T) {
+	g := &QuestionGraph{Questions: []Question{
+		{ID: "q1", Text: "a"},
+		{ID: "q2", Text: "b"},
+		{ID: "q3", Text: "c"},
+	}}
+	waves := BatchByDependencies(g)
+	if len(waves) != 1 {
+		t.Errorf("independent questions should fit in 1 wave, got %d", len(waves))
+	}
+	if len(waves[0]) != 3 {
+		t.Errorf("wave 0 should contain all 3 questions, got %d", len(waves[0]))
+	}
+}
+
+func TestBatchByDependenciesChained(t *testing.T) {
+	g := &QuestionGraph{Questions: []Question{
+		{ID: "q1", Text: "a"},
+		{ID: "q2", Text: "b", DependsOn: []string{"q1"}},
+		{ID: "q3", Text: "c", DependsOn: []string{"q2"}},
+	}}
+	waves := BatchByDependencies(g)
+	if len(waves) != 3 {
+		t.Errorf("chained questions should produce 3 waves, got %d", len(waves))
+	}
+	if waves[0][0].ID != "q1" {
+		t.Errorf("wave 0 should have q1, got %q", waves[0][0].ID)
+	}
+	if waves[1][0].ID != "q2" {
+		t.Errorf("wave 1 should have q2, got %q", waves[1][0].ID)
+	}
+	if waves[2][0].ID != "q3" {
+		t.Errorf("wave 2 should have q3, got %q", waves[2][0].ID)
+	}
+}
+
+func TestBatchByDependenciesMixed(t *testing.T) {
+	// q1, q2 independent; q3 depends on q1 and q2.
+	g := &QuestionGraph{Questions: []Question{
+		{ID: "q1", Text: "a"},
+		{ID: "q2", Text: "b"},
+		{ID: "q3", Text: "c", DependsOn: []string{"q1", "q2"}},
+	}}
+	waves := BatchByDependencies(g)
+	if len(waves) != 2 {
+		t.Errorf("should be 2 waves, got %d", len(waves))
+	}
+	if len(waves[0]) != 2 {
+		t.Errorf("wave 0 should have 2 questions (q1, q2), got %d", len(waves[0]))
+	}
+	if len(waves[1]) != 1 || waves[1][0].ID != "q3" {
+		t.Errorf("wave 1 should have q3, got %v", waves[1])
+	}
+}
+
+func TestBatchByDependenciesEmptyGraph(t *testing.T) {
+	waves := BatchByDependencies(&QuestionGraph{})
+	if waves != nil {
+		t.Errorf("empty graph should produce no waves, got %v", waves)
+	}
+}
+
+func TestBatchByDependenciesDeterministic(t *testing.T) {
+	g := &QuestionGraph{Questions: []Question{
+		{ID: "q_c", Text: "c"},
+		{ID: "q_a", Text: "a"},
+		{ID: "q_b", Text: "b"},
+	}}
+	waves := BatchByDependencies(g)
+	if len(waves[0]) != 3 {
+		t.Fatal("one wave with three questions")
+	}
+	// Sorted by ID — not insertion order.
+	want := []string{"q_a", "q_b", "q_c"}
+	for i, w := range want {
+		if waves[0][i].ID != w {
+			t.Errorf("waves[0][%d] = %q, want %q", i, waves[0][i].ID, w)
+		}
+	}
+}
+
+func TestWriteClarifierMarkdownCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	g := &QuestionGraph{Questions: []Question{
+		{ID: "q1", Text: "latency?"},
+		{ID: "q2", Text: "storage?", DependsOn: []string{"q1"}},
+	}}
+	answers := []Answer{
+		{ID: "q1", Text: "under 50 ms"},
+		{ID: "q2", Text: "postgres"},
+	}
+	path, err := WriteClarifierMarkdown(dir, g, answers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(path) != "clarifier.md" {
+		t.Errorf("basename = %q", filepath.Base(path))
+	}
+	data, _ := os.ReadFile(path)
+	s := string(data)
+	if !strings.Contains(s, "Wave 1") || !strings.Contains(s, "Wave 2") {
+		t.Errorf("file missing wave headings: %q", s)
+	}
+	if !strings.Contains(s, "under 50 ms") || !strings.Contains(s, "postgres") {
+		t.Errorf("file missing answers: %q", s)
+	}
+	if !strings.Contains(s, "Depends on: q1") {
+		t.Errorf("file missing dependency annotation: %q", s)
+	}
+}
+
+func TestWriteClarifierMarkdownHandlesUnansweredQuestions(t *testing.T) {
+	dir := t.TempDir()
+	g := &QuestionGraph{Questions: []Question{
+		{ID: "q1", Text: "?"},
+	}}
+	path, err := WriteClarifierMarkdown(dir, g, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "(unanswered)") {
+		t.Errorf("missing unanswered marker: %q", data)
+	}
+}

--- a/internal/agents/scout.go
+++ b/internal/agents/scout.go
@@ -71,6 +71,11 @@ func (s *Scout) Run(ctx context.Context, c *Context) (string, error) {
 		b.WriteString(truncate(snap.CharterContent, 4096))
 		b.WriteString("\n\n")
 	}
+	if snap.ClarifierContent != "" {
+		b.WriteString("## .aidev/clarifier.md (recent clarifier session — human decisions on ambiguous points)\n\n")
+		b.WriteString(truncate(snap.ClarifierContent, 4096))
+		b.WriteString("\n\n")
+	}
 
 	system := `You are the Scout for aidev, a multi-agent coding tool.
 Your job is to produce a FACTUAL, concise brief of the repository a developer

--- a/internal/repo/scout.go
+++ b/internal/repo/scout.go
@@ -28,6 +28,8 @@ type Snapshot struct {
 	ArchitectureDoc string // ARCHITECTURE.md if present
 	CharterPath     string // .aidev/charter.md if present
 	CharterContent  string // contents of CharterPath
+	ClarifierPath   string // .aidev/clarifier.md if present
+	ClarifierContent string // contents of ClarifierPath
 	PrinciplesPath  string // .aidev/principles.yaml if present
 	TotalFiles      int
 }
@@ -116,6 +118,12 @@ func Scan(root string) (*Snapshot, error) {
 		snap.CharterPath = p
 		if data, err := os.ReadFile(p); err == nil {
 			snap.CharterContent = string(data)
+		}
+	}
+	if p := pickFirst(".aidev/clarifier.md"); p != "" {
+		snap.ClarifierPath = p
+		if data, err := os.ReadFile(p); err == nil {
+			snap.ClarifierContent = string(data)
 		}
 	}
 	if p := pickFirst(".aidev/principles.yaml", "config/principles.yaml"); p != "" {


### PR DESCRIPTION
## Summary

v0.5c ships the 'adaptive dialogue' feature I've pushed back on twice — this time built as a NEW agent rather than a rewrite of the Critic. The **Clarifier** runs after the Critic and before user approval, reads the Critic's report, and produces a structured JSON question graph. The `aidev clarify` subcommand walks the graph in dependency-aware waves: independent questions batch, chained questions serialise. Answers are persisted to `.aidev/clarifier.md` which the Scout absorbs on the next run, so the Architect's sketches land with the ambiguities already resolved.

Why new agent instead of Critic rewrite: the Critic's adversarial markdown is worth keeping byte-identical. I don't trust a prompt that tries to do 'argue both sides' AND 'emit structured JSON' in the same call. Splitting them means the Critic stays sharp, and the Clarifier can be tuned independently.

## What's in the PR

**new**
- `internal/agents/clarifier.go` — `Clarifier` type, `Question`, `QuestionGraph`, `Answer` types. `Run(ctx, context)` LLM call with a strict JSON-only prompt. `ParseQuestionGraph` with code-fence tolerance and full validation (unique IDs, non-empty text, depends_on references real questions, no self-deps, no cycles via DFS colouring). `BatchByDependencies` groups the graph into waves — this is the core of the adaptive dialogue. `WriteClarifierMarkdown` persists a session to `.aidev/clarifier.md`.
- `internal/agents/clarifier_test.go` — 14 tests: happy-path parse, code-fence tolerance, empty-questions allowed, duplicate-id rejection, unknown-dep rejection, self-dep rejection, cycle detection, empty-text rejection, three BatchByDependencies cases (independent, chained, mixed), deterministic sort ordering, file-write with waves + answers, unanswered question marker.

**modified**
- `cmd/aidev/main.go` — new `clarify` subcommand that runs Scout+Critic to populate context, calls `Clarifier.Run`, walks the returned graph with a stdin-based interviewer, writes the session.
- `internal/repo/scout.go` — new `ClarifierPath` / `ClarifierContent` fields on Snapshot, automatic discovery at `.aidev/clarifier.md`.
- `internal/agents/scout.go` — the Scout's prompt now includes a `## .aidev/clarifier.md` section when the file exists, so the Critic (on re-run) and Architect (on next run) both get the clarifier decisions as context.

## Design decisions

- **New agent, not Critic rewrite.** The v0.2b sparring round proposed rewriting the Critic's output format to JSON so the orchestrator could drive adaptive questions directly. I pushed back on this because asking one prompt to 'argue both sides adversarially AND emit strict JSON' is a recipe for output quality collapse. A new agent that reads the Critic's output as prose keeps both prompts tight.
- **Subcommand, not orchestrator state machine.** I considered wiring the Clarifier into the main pipeline as a new state between AwaitUser and Architecting. Decided against it for v0.5c because: (1) the Clarifier is opt-in — not every pipeline run needs it, (2) wiring it into the TUI flow is a separate UI design problem, (3) running it as a standalone subcommand means the user's answers get persisted to `.aidev/clarifier.md` and the next normal `aidev -issue ...` run automatically picks them up. Clean separation.
- **Dependency-aware batching is the core feature.** `BatchByDependencies` walks the graph in waves: wave 0 is every question with no dependencies, wave 1 is every question whose deps are now answered, etc. A flat graph produces 1 wave; a chain produces N waves; a realistic mixed graph produces 2–3 waves. This is the 'adaptive dialogue' promise from the original design discussion — independent questions batch, chained questions serialise — and it's the pure-logic heart of the agent, fully unit-tested.
- **Graph validation is strict.** The parser rejects cycles, self-dependencies, duplicate IDs, empty text, and dangling references. A bad graph fails loudly at parse time rather than silently producing nonsense. Detected cycles via DFS colouring (white/gray/black) — classic algorithm, tested with a 2-node cycle.
- **Deterministic ordering.** Questions within a wave are sorted by ID before emission so the subcommand's output is stable across runs. Go's map iteration order is unspecified and I don't want the user to see the same graph with questions in different orders on two invocations.
- **Empty question graph is OK.** If the Critic report has nothing ambiguous worth asking about (trivial changes, already-killed proposals), the Clarifier can legitimately return `{questions: []}`. The subcommand prints a 'nothing to ask' message and exits without writing `.aidev/clarifier.md`.
- **Routing: reuses the critic tier.** The Clarifier's reasoning is close to the Critic's — it reads the Critic's output and distills it. Rather than add a new `RoleClarifier` to `models.yaml`, I reused `RoleCritic`. If you want to split them later, one-line addition to `llm/provider.go` plus a new tier row.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — 14 new Clarifier tests + all existing tests pass
- [x] `aidev clarify -h` shows the subcommand flags
- [ ] **Manual on @crisscross82's Mac:**
  - Run `aidev clarify -issue <url> -repo <path>` against a real issue that has real ambiguity
  - Verify: Scout + Critic run first, Clarifier produces 2–5 questions, stdin interviewer asks them in waves, answers get persisted to `.aidev/clarifier.md`
  - Re-run `aidev -issue <url> -repo <path>` against the same repo — verify the Scout brief mentions the clarifier session in its context and the Critic/Architect both cite the user's answers
  - Edge cases: issue with no ambiguity (Clarifier emits empty graph, subcommand exits cleanly), LLM returns malformed JSON (ParseQuestionGraph error, subcommand fatal with clear message)

## Worth reviewing carefully

- **The graph prompt.** I cap at 8 questions and describe 'dependency means the answer changes what the later question should even be'. Real LLM behaviour may drift — models sometimes over-produce dependencies or under-produce them. Worth looking at the first few real graphs to see if tuning is needed.
- **No TUI integration.** The Clarifier only works from the `aidev clarify` subcommand. TUI wiring (add a 'c' keybinding after Critic to enter an interview view) is a v0.5c.1 follow-up. I didn't ship it here because the interview UX in Bubble Tea is non-trivial (multi-question form, wave transitions, back/forward navigation) and I wanted the agent itself to exist before designing that.
- **No `aidev clarify --answers-from foo.yaml` mode.** The subcommand only supports interactive stdin. If you want to script answers (e.g. for CI), you currently can't. Plumbing a YAML-answers mode is ~30 lines if you want it.
- **Reuses the critic tier.** If that feels wrong — e.g. you want the Clarifier on a cheaper/faster tier since the task is more structured — a new RoleClarifier is a one-line addition.

## Out of scope

- TUI integration for the Clarifier interview (v0.5c.1)
- Scripted answer input (`--answers-from foo.yaml`)
- Re-running the Clarifier incrementally (resume a partial session)
- Linking individual questions to specific passages of the Critic report (useful but unimportant)
- Orchestrator state machine hook for in-pipeline clarifier — subcommand covers the same ground