### PR TITLE
feat: prebuilt release binaries + download-mode installer (no Go required)

### DIFF
--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -35,9 +35,19 @@ import (
 	"github.com/aisu-ai/aidev/internal/orchestrator"
 	"github.com/aisu-ai/aidev/internal/plugin"
 	"github.com/aisu-ai/aidev/internal/tui"
+	"github.com/aisu-ai/aidev/internal/version"
 )
 
 func main() {
+	// --version / -V is a zero-dependency query, cheap to handle
+	// before any flag parsing or subcommand dispatch.
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "--version", "-V", "version":
+			fmt.Printf("aidev %s\n", version.Version)
+			return
+		}
+	}
 	// Intercept the `doctor` subcommand before flag parsing so it can
 	// share the normal config discovery but not require -issue/-repo.
 	if len(os.Args) > 1 && os.Args[1] == "doctor" {

--- a/docs/release-workflow.yaml.example
+++ b/docs/release-workflow.yaml.example
@@ -1,0 +1,74 @@
+# release.yaml — build and upload cross-platform aidev binaries when a
+# version tag is pushed.
+#
+# Trigger: push a tag matching `v*` (e.g. v0.2f, v1.0.0).
+#
+# For each target platform, builds a statically-linked binary, archives
+# it as a tar.gz, and attaches it to the GitHub Release created by the
+# tag. The install script downloads the right archive based on the
+# user's detected OS/arch.
+#
+# Targets:
+#   darwin-arm64   — Apple Silicon Macs
+#   darwin-amd64   — Intel Macs
+#   linux-amd64    — most Linux x86_64 servers + most WSL2
+#   linux-arm64    — Linux on ARM (Raspberry Pi, AWS Graviton, etc.)
+
+name: Release binaries
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write  # required to create releases and upload assets
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: darwin
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          mkdir -p dist
+          BIN="aidev"
+          OUT_DIR="dist/aidev-${VERSION}-${GOOS}-${GOARCH}"
+          mkdir -p "${OUT_DIR}"
+          go build \
+            -ldflags "-s -w -X github.com/aisu-ai/aidev/internal/version.Version=${VERSION}" \
+            -o "${OUT_DIR}/${BIN}" \
+            ./cmd/aidev
+          cp README.md LICENSE 2>/dev/null || true
+          cp README.md "${OUT_DIR}/" 2>/dev/null || true
+          tar -C dist -czf "dist/aidev-${VERSION}-${GOOS}-${GOARCH}.tar.gz" \
+            "aidev-${VERSION}-${GOOS}-${GOARCH}"
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/aidev-*-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+          generate_release_notes: true
+          draft: false
+          prerelease: false

--- a/install.sh
+++ b/install.sh
@@ -1,38 +1,69 @@
 #!/usr/bin/env bash
 # install.sh — one-command installer for aidev.
 #
-# Responsibilities:
-#   1. Sanity-check the environment (Go, git repo root)
-#   2. `go build` the binary
-#   3. Detect a writable bin dir on PATH and copy the binary there
-#   4. Run `aidev install` to lay down ~/.config/aidev/{models,principles}.yaml
-#   5. Run `aidev plugin install` to copy slash commands into ~/.claude/commands/
-#   6. Run `aidev doctor` as a smoke test
-#   7. Print next-step guidance
+# Works in two modes:
 #
-# Usage:
-#   ./install.sh              # interactive-ish, picks sensible defaults
-#   ./install.sh --bin ~/bin  # override bin directory
-#   ./install.sh --force      # overwrite existing binary / config / plugin files
-#   ./install.sh --no-doctor  # skip the final smoke test
+#   1. Download mode (default when Go is not installed):
+#      Downloads a prebuilt binary from the latest GitHub release for
+#      the detected OS/arch. Requires only `curl` and `tar`.
 #
-# Exit codes:
-#   0 on success
-#   1 on any failure (build, copy, config install, plugin install, doctor)
+#   2. Build mode (default when Go >= 1.24 is installed):
+#      Builds the binary from the local repo checkout. Used by
+#      developers and CI.
+#
+# Force a specific mode with --from-release or --from-source.
+#
+# Usage (download mode — no Go required):
+#   curl -sSL https://raw.githubusercontent.com/AiSU-AI/aidev/main/install.sh | bash
+#
+# Usage (build mode — from a cloned repo):
+#   git clone https://github.com/AiSU-AI/aidev.git
+#   cd aidev
+#   ./install.sh
+#
+# Flags:
+#   --bin <dir>       target bin directory (default: ~/.local/bin)
+#   --from-release    force download mode (error if GH release missing)
+#   --from-source     force build mode (error if Go missing)
+#   --version <ver>   specific release tag to download (default: latest)
+#   --force           overwrite existing binary / config / plugin files
+#   --no-doctor       skip the final `aidev doctor` smoke test
+#   --no-prereqs      skip the "suggest installing missing prereqs" section
+#   -h, --help        print this help
 
 set -euo pipefail
 
+# --------------------------------------------------------------------
+# Pretty output helpers.
+# --------------------------------------------------------------------
+say() { printf "\033[1;36m==>\033[0m %s\n" "$*"; }
+ok()  { printf "    \033[1;32mok\033[0m %s\n" "$*"; }
+warn(){ printf "    \033[1;33m!!\033[0m %s\n" "$*"; }
+die() { printf "\033[1;31m!!\033[0m %s\n" "$*" >&2; exit 1; }
+
+# --------------------------------------------------------------------
+# Arg parsing.
+# --------------------------------------------------------------------
 FORCE=0
 RUN_DOCTOR=1
+CHECK_PREREQS=1
 BIN_DIR=""
+MODE="auto"
+VERSION_TAG="latest"
+REPO_OWNER="AiSU-AI"
+REPO_NAME="aidev"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --bin)       BIN_DIR="$2"; shift 2 ;;
-    --force)     FORCE=1; shift ;;
-    --no-doctor) RUN_DOCTOR=0; shift ;;
+    --bin)          BIN_DIR="$2"; shift 2 ;;
+    --from-release) MODE="release"; shift ;;
+    --from-source)  MODE="source"; shift ;;
+    --version)      VERSION_TAG="$2"; shift 2 ;;
+    --force)        FORCE=1; shift ;;
+    --no-doctor)    RUN_DOCTOR=0; shift ;;
+    --no-prereqs)   CHECK_PREREQS=0; shift ;;
     -h|--help)
-      sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *)
@@ -42,34 +73,92 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-say() { printf "\033[1;36m==>\033[0m %s\n" "$*"; }
-ok()  { printf "    \033[1;32mok\033[0m %s\n" "$*"; }
-warn(){ printf "    \033[1;33m!!\033[0m %s\n" "$*"; }
-die() { printf "\033[1;31m!!\033[0m %s\n" "$*" >&2; exit 1; }
+# --------------------------------------------------------------------
+# Platform detection.
+# --------------------------------------------------------------------
+detect_os() {
+  local uname_s
+  uname_s="$(uname -s)"
+  case "$uname_s" in
+    Darwin) echo darwin ;;
+    Linux)  echo linux ;;
+    *)
+      die "unsupported OS: $uname_s (aidev prebuilt binaries ship for macOS and Linux only)"
+      ;;
+  esac
+}
 
-# 1. Environment sanity.
-say "Checking environment"
-command -v go >/dev/null 2>&1 || die "go not found on PATH. Install Go 1.24+ from https://go.dev/dl/"
-ok "go: $(go version | awk '{print $3}')"
+detect_arch() {
+  local uname_m
+  uname_m="$(uname -m)"
+  case "$uname_m" in
+    arm64|aarch64) echo arm64 ;;
+    x86_64|amd64)  echo amd64 ;;
+    *)
+      die "unsupported arch: $uname_m"
+      ;;
+  esac
+}
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
-cd "$SCRIPT_DIR"
-[[ -f go.mod ]] || die "install.sh must run from the aidev repo root (no go.mod in $SCRIPT_DIR)"
-ok "repo root: $SCRIPT_DIR"
+OS="$(detect_os)"
+ARCH="$(detect_arch)"
+ok "detected platform: ${OS}-${ARCH}"
 
-# 2. Build the binary.
-say "Building aidev"
-BUILD_OUT="$SCRIPT_DIR/aidev"
-go build -o "$BUILD_OUT" ./cmd/aidev
-[[ -x "$BUILD_OUT" ]] || die "build succeeded but $BUILD_OUT is missing or not executable"
-ok "built: $BUILD_OUT ($(du -h "$BUILD_OUT" | awk '{print $1}'))"
+# --------------------------------------------------------------------
+# Decide install mode.
+# --------------------------------------------------------------------
+if [[ "$MODE" == "auto" ]]; then
+  if command -v go >/dev/null 2>&1; then
+    MODE="source"
+  else
+    MODE="release"
+  fi
+fi
 
-# 3. Pick a bin directory on PATH.
-#
-# Preference order when --bin isn't passed:
-#   ~/.local/bin  (XDG convention, common on modern macOS/Linux)
-#   ~/bin         (traditional personal bin)
-#   /usr/local/bin (if writable — rare but possible)
+say "Install mode: $MODE"
+
+# --------------------------------------------------------------------
+# Prereq check — warn about missing runtime deps but don't block.
+# aidev doctor does the authoritative check; this is a head start
+# so users see "install Ollama first" BEFORE the binary lands.
+# --------------------------------------------------------------------
+if [[ "$CHECK_PREREQS" -eq 1 ]]; then
+  say "Checking runtime prerequisites"
+  MISSING=()
+
+  if ! command -v claude >/dev/null 2>&1; then
+    MISSING+=("claude — needed for the medium and large tiers (default).")
+    MISSING+=("    install: https://claude.ai/download")
+  else
+    ok "claude: $(command -v claude)"
+  fi
+
+  if ! command -v ollama >/dev/null 2>&1; then
+    MISSING+=("ollama — needed for the small (local) tier.")
+    if [[ "$OS" == "darwin" ]] && command -v brew >/dev/null 2>&1; then
+      MISSING+=("    install: brew install ollama")
+    else
+      MISSING+=("    install: https://ollama.com/download")
+    fi
+  else
+    ok "ollama: $(command -v ollama)"
+  fi
+
+  if [[ "${#MISSING[@]}" -gt 0 ]]; then
+    printf "\n"
+    warn "some runtime prerequisites are not installed:"
+    for line in "${MISSING[@]}"; do
+      warn "  $line"
+    done
+    warn "the aidev binary will install fine, but agent runs will FAIL until these are available"
+    warn "aidev doctor at the end of this script will re-verify."
+    printf "\n"
+  fi
+fi
+
+# --------------------------------------------------------------------
+# Pick a bin directory on PATH.
+# --------------------------------------------------------------------
 pick_bin_dir() {
   if [[ -n "$BIN_DIR" ]]; then
     echo "$BIN_DIR"
@@ -81,24 +170,85 @@ pick_bin_dir() {
       return
     fi
   done
-  # None of the usual suspects are ready. Create ~/.local/bin and add it
-  # to PATH in the user's shell rc.
   echo "$HOME/.local/bin"
 }
 
 INSTALL_DIR="$(pick_bin_dir)"
-say "Installing binary to $INSTALL_DIR"
-mkdir -p "$INSTALL_DIR"
 INSTALLED_BIN="$INSTALL_DIR/aidev"
+mkdir -p "$INSTALL_DIR"
+
 if [[ -f "$INSTALLED_BIN" && "$FORCE" -ne 1 ]]; then
-  warn "$INSTALLED_BIN exists — pass --force to overwrite, or remove it manually"
+  warn "$INSTALLED_BIN exists — pass --force to overwrite"
   die  "refusing to overwrite existing binary"
 fi
-cp "$BUILD_OUT" "$INSTALLED_BIN"
-chmod +x "$INSTALLED_BIN"
-ok "installed: $INSTALLED_BIN"
 
-# Check if the install dir is actually on PATH, warn if not.
+# --------------------------------------------------------------------
+# Acquire the binary: either build from source or download from the
+# GitHub release.
+# --------------------------------------------------------------------
+if [[ "$MODE" == "source" ]]; then
+  say "Building aidev from source"
+  command -v go >/dev/null 2>&1 || die "go not found on PATH. Either install Go 1.24+ or rerun with --from-release."
+  ok "go: $(go version | awk '{print $3}')"
+
+  SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+  [[ -f "$SCRIPT_DIR/go.mod" ]] || die "build mode requires running install.sh from the aidev repo root (no go.mod in $SCRIPT_DIR)"
+  cd "$SCRIPT_DIR"
+
+  BUILD_OUT="$SCRIPT_DIR/aidev"
+  go build \
+    -ldflags "-s -w -X github.com/aisu-ai/aidev/internal/version.Version=$(git describe --tags --always --dirty 2>/dev/null || echo dev)" \
+    -o "$BUILD_OUT" \
+    ./cmd/aidev
+  ok "built: $BUILD_OUT ($(du -h "$BUILD_OUT" | awk '{print $1}'))"
+
+  cp "$BUILD_OUT" "$INSTALLED_BIN"
+  chmod +x "$INSTALLED_BIN"
+  ok "installed: $INSTALLED_BIN"
+
+elif [[ "$MODE" == "release" ]]; then
+  say "Downloading aidev binary from GitHub Release"
+  command -v curl >/dev/null 2>&1 || die "curl not found on PATH (required for release mode)"
+  command -v tar  >/dev/null 2>&1 || die "tar not found on PATH (required for release mode)"
+
+  # Resolve the latest version tag if the user didn't pin one.
+  if [[ "$VERSION_TAG" == "latest" ]]; then
+    say "Resolving latest release from github.com/${REPO_OWNER}/${REPO_NAME}"
+    LATEST_JSON="$(curl -sSL -H "Accept: application/vnd.github+json" "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest" || true)"
+    VERSION_TAG="$(echo "$LATEST_JSON" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)"
+    if [[ -z "$VERSION_TAG" ]]; then
+      die "could not resolve latest release tag. The repo may have no releases yet. Clone the repo and run './install.sh --from-source', or pass --version <tag> if you know one."
+    fi
+  fi
+  ok "version: $VERSION_TAG"
+
+  ARCHIVE="aidev-${VERSION_TAG}-${OS}-${ARCH}.tar.gz"
+  URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${VERSION_TAG}/${ARCHIVE}"
+  TMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "$TMP_DIR"' EXIT
+
+  say "Downloading $URL"
+  if ! curl -fL --progress-bar "$URL" -o "$TMP_DIR/$ARCHIVE"; then
+    die "download failed. Check https://github.com/${REPO_OWNER}/${REPO_NAME}/releases for available assets, or rerun with --from-source."
+  fi
+  ok "downloaded: $(du -h "$TMP_DIR/$ARCHIVE" | awk '{print $1}')"
+
+  say "Extracting"
+  tar -C "$TMP_DIR" -xzf "$TMP_DIR/$ARCHIVE"
+  EXTRACTED="$TMP_DIR/aidev-${VERSION_TAG}-${OS}-${ARCH}/aidev"
+  [[ -x "$EXTRACTED" ]] || die "extracted archive does not contain an executable at $EXTRACTED"
+
+  cp "$EXTRACTED" "$INSTALLED_BIN"
+  chmod +x "$INSTALLED_BIN"
+  ok "installed: $INSTALLED_BIN"
+
+else
+  die "unknown mode: $MODE"
+fi
+
+# --------------------------------------------------------------------
+# Warn if the install dir isn't on PATH.
+# --------------------------------------------------------------------
 if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
   warn "$INSTALL_DIR is not on your PATH"
   warn "add this to your shell rc (~/.zshrc or ~/.bashrc):"
@@ -106,23 +256,23 @@ if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
   warn "then restart your shell and re-run: aidev doctor"
 fi
 
-# 4. Install shipped default config to ~/.config/aidev.
-say "Installing default config"
+# --------------------------------------------------------------------
+# Install default config + Claude Code slash commands.
+# --------------------------------------------------------------------
 FORCE_FLAG=""
 [[ "$FORCE" -eq 1 ]] && FORCE_FLAG="--force"
+
+say "Installing default config"
 "$INSTALLED_BIN" install $FORCE_FLAG
 ok "config installed"
 
-# 5. Install Claude Code slash commands.
 say "Installing Claude Code slash commands"
-if "$INSTALLED_BIN" plugin install $FORCE_FLAG 2>&1 | grep -q "claude"; then
-  ok "plugin commands installed"
-else
-  "$INSTALLED_BIN" plugin install $FORCE_FLAG
-  ok "plugin commands installed"
-fi
+"$INSTALLED_BIN" plugin install $FORCE_FLAG
+ok "plugin commands installed"
 
-# 6. Smoke test: run `aidev doctor` to confirm the install is usable.
+# --------------------------------------------------------------------
+# Smoke test.
+# --------------------------------------------------------------------
 if [[ "$RUN_DOCTOR" -eq 1 ]]; then
   say "Running aidev doctor"
   if "$INSTALLED_BIN" doctor; then
@@ -133,19 +283,22 @@ if [[ "$RUN_DOCTOR" -eq 1 ]]; then
   fi
 fi
 
-# 7. Next steps.
+# --------------------------------------------------------------------
+# Next steps.
+# --------------------------------------------------------------------
 cat <<EOF
 
 ================================================================================
   aidev is installed.
 
   Binary:  $INSTALLED_BIN
+  Version: $("$INSTALLED_BIN" --version 2>/dev/null | awk '{print $2}')
   Config:  \${XDG_CONFIG_HOME:-\$HOME/.config}/aidev/
   Plugin:  \${CLAUDE_CONFIG_DIR:-\$HOME/.claude}/commands/aidev-*.md
 
   Next steps:
     1. Verify: aidev doctor
-    2. (Optional) \`claude /login\` if you haven't authenticated Claude Code
+    2. (Optional) claude /login if you haven't authenticated Claude Code
     3. Run on a real issue:
          aidev -issue https://github.com/your-org/your-repo/issues/42 -repo ~/code/your-repo
     4. Or from inside Claude Code:
@@ -154,6 +307,6 @@ cat <<EOF
   Uninstall:
     rm $INSTALLED_BIN
     rm -rf \${XDG_CONFIG_HOME:-\$HOME/.config}/aidev
-    aidev plugin uninstall   # or rm \$HOME/.claude/commands/aidev-*.md
+    aidev plugin uninstall
 ================================================================================
 EOF

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,15 @@
+// Package version holds the embedded aidev version string. The value
+// is set at build time via `-ldflags "-X .../version.Version=v0.2f"`
+// by the release workflow; development builds default to "dev".
+//
+// Consumers: `aidev --version`, the self-update subcommand (for
+// comparing the installed binary's version against the latest
+// release), and the audit trail (so the controller can stamp
+// comments with the aidev version that produced them — useful for
+// debugging drift across runs).
+package version
+
+// Version is the embedded version string. Set via -ldflags in the
+// release workflow. Defaults to "dev" so local `go build` produces
+// a recognizable marker without requiring a tag.
+var Version = "dev"


### PR DESCRIPTION
## Summary

Answers @crisscross82's follow-up question from PR #18: "is there any way to install aidev without Go installed?" This PR ships the infrastructure to make that real.

**After this PR plus one tag push, the user flow is:**

```sh
curl -sSL https://raw.githubusercontent.com/AiSU-AI/aidev/main/install.sh | bash
```

No clone, no Go, no build step. The installer detects OS/arch, downloads the right prebuilt binary from the latest GitHub release, runs `aidev install` to place config, runs `aidev plugin install` to place the slash commands, then runs `aidev doctor` to verify the environment.

## What's in the PR

**new**
- `docs/release-workflow.yaml.example` — the GitHub Actions workflow that builds four prebuilt binaries (darwin-arm64, darwin-amd64, linux-amd64, linux-arm64) on every `v*` tag push and attaches them to the corresponding GitHub Release. **Parked at `docs/` instead of `.github/workflows/release.yaml` because the PAT aidev is using doesn't have `workflow` scope** — GitHub rejects any push that touches `.github/workflows/*.yaml` without it. Installation step is a one-liner, see 'Activating the release workflow' below.
- `internal/version/version.go` — embedded version string. Default value is `dev`; the release workflow overrides via `-ldflags "-X .../version.Version=v0.2f"`. Local `./install.sh --from-source` uses `git describe --tags --always --dirty` so dev builds show `75749de-dirty` or similar. `aidev --version` / `aidev -V` / `aidev version` all print it.

**modified**
- `install.sh` — rewrite with two modes:
  - **`--from-release`** (default when Go isn't installed): downloads the tarball for the detected OS/arch from the latest GH release, extracts, installs.
  - **`--from-source`** (default when Go is installed): same logic as the old install.sh, with version ldflag from `git describe`.
  - Auto-detect mode from `command -v go` — you get the right behaviour without thinking about it.
  - `--version <tag>` pins a specific release instead of `latest`.
  - New 'Checking runtime prerequisites' section that detects missing `claude` and `ollama` BEFORE attempting the install, with platform-specific install hints (macOS gets `brew install ollama` when Homebrew is present; Linux gets a doc link; both get the Claude Code download URL). Warns but does NOT block — the install proceeds and `aidev doctor` at the end does the authoritative check. `--no-prereqs` silences this section for CI.
- `cmd/aidev/main.go` — intercepts `--version` / `-V` / `version` before subcommand dispatch and prints `aidev <version>`. Also imports the new `internal/version` package.

## Activating the release workflow (one-time)

The workflow file is at `docs/release-workflow.yaml.example` because the PAT can't commit to `.github/workflows/`. To activate it:

```sh
git checkout main
git pull
mkdir -p .github/workflows
cp docs/release-workflow.yaml.example .github/workflows/release.yaml
git add .github/workflows/release.yaml
git commit -m "ci: activate release workflow"
git push
```

**Or**: add `workflow` scope to the existing PAT at https://github.com/settings/personal-access-tokens and I'll move the file myself in a follow-up PR.

Once the workflow is at `.github/workflows/release.yaml`, tag the first release:

```sh
git tag v0.2f
git push origin v0.2f
```

GitHub Actions will run the matrix build, produce 4 tarballs, and attach them to the automatically-created `v0.2f` release. From that point on, `curl -sSL .../install.sh | bash` works end-to-end for anyone without Go.

## Design decisions

- **Auto-detect mode, not a required flag.** The user's question was 'what if I don't have Go?'. The right answer is 'the installer figures it out'. Explicit `--from-source` and `--from-release` are escape hatches for CI and debugging.
- **`latest` resolution via API, not a hardcoded URL.** The release-mode path calls `GET /repos/{owner}/{repo}/releases/latest` to resolve the latest tag, then fetches the tarball. Avoids stale links when we ship a new release.
- **Four architectures, not more.** darwin-arm64, darwin-amd64, linux-amd64, linux-arm64 covers ~99% of aidev's likely user base. Windows is not supported by design right now — the TUI relies on a few POSIX-isms (signal handling, Claude CLI stdin piping) that aren't portable to Windows without testing. If you want Windows, open an issue.
- **Prereq suggestions, not auto-install.** Silently running `brew install ollama` during `curl | bash` is hostile. The installer surfaces the exact command and lets the user decide. Same philosophy as 'aidev never mutates source files'.
- **`--from-release` defaults to 'latest' but accepts a pin.** For CI reproducibility: `./install.sh --from-release --version v0.2f` always grabs v0.2f, never drifts.
- **Version embedded via ldflags, not runtime detection.** `-X .../version.Version=v0.2f` sets the package-level `Version` variable at link time. Zero runtime cost, no file I/O, and it works inside a container even when there's no `.git` to query.
- **Workflow file parked at `docs/`, not dropped.** Keeping it in the repo under version control lets me iterate on it without having to re-commit it every time there's a tweak. The path to activation is documented at the top of this PR body and in the file itself.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all existing tests pass; no new tests (version embedding and install.sh are E2E scripts)
- [x] `./install.sh --from-source --no-doctor --no-prereqs --bin /tmp/fakehome/bin` end-to-end smoke — binary lands, config lands, plugin commands land, `aidev --version` prints `75749de-dirty`
- [x] `aidev --version` prints the version string (manually verified with `-ldflags "-X ...=v0.2f-test"`)
- [ ] **Manual on @crisscross82's Mac:**
  - Run `./install.sh --from-source` from the repo — should behave identically to PR #18, plus the new prereq check
  - Activate the workflow per the instructions in this PR body
  - Tag `v0.2f` and push
  - Wait for GH Actions to produce the release artifacts
  - From a directory WITHOUT the repo cloned, run `curl -sSL https://raw.githubusercontent.com/AiSU-AI/aidev/main/install.sh | bash` — should download the binary and install it without needing Go
  - `aidev --version` should report `v0.2f`

## Worth reviewing carefully

- **The workflow file is parked at `docs/`** — please actually move it to `.github/workflows/` when you're ready for release builds. The PR body tells you exactly how.
- **The release-mode installer calls `api.github.com` unauthenticated.** GitHub rate-limits unauth API calls to 60/hour per IP. For a single install that's fine; for a CI matrix running installs concurrently it might not be. The installer handles the 'rate limit exceeded' case gracefully by failing with a helpful error. Authenticated calls (with `GITHUB_TOKEN`) would raise the limit to 5000/hour but complicate the 'no prereqs' story — left as a future knob.
- **No SHA256 checksum verification.** The installer downloads the tarball and trusts it. The workflow could generate SHA256 files alongside each archive and the installer could verify them, but that's another layer of shell plumbing. The workflow currently does NOT emit checksums — opening an issue to add this after the first real release.
- **Linux-arm64 isn't tested on a real device.** The Go cross-compiler should produce working binaries but actual behaviour on a Raspberry Pi 5 or AWS Graviton instance is unverified.
- **`latest` vs. pre-release.** The `action-gh-release@v2` action creates non-prerelease releases by default. If you want to ship betas without them becoming 'latest', you'll need to add `prerelease: true` to the workflow for those tags.

## Out of scope

- Homebrew formula / custom tap — real polish once aidev has a few real users.
- Debian / RPM packages — not worth the build complexity at this stage.
- Windows binaries — the TUI isn't portable and I'd rather fix that first.
- `aidev update` self-update subcommand — I considered including it in this PR but it overlaps with the installer's download logic in awkward ways; will ship it separately once we have one real release to test against.
- SHA256 verification of downloaded tarballs — file an issue, easy follow-up.