### PR TITLE
fix: slash commands need allowed-tools frontmatter and empty-arg guards

### DIFF
--- a/internal/plugin/files/aidev-charter.md
+++ b/internal/plugin/files/aidev-charter.md
@@ -1,12 +1,23 @@
 ---
 description: Run the aidev Charter interview against a target repo
 argument-hint: <repo-path>
+allowed-tools: Bash(aidev:*)
 ---
 
-Run the aidev Charter interview against the repository at `$ARGUMENTS`.
+Run the aidev Charter interview against the repository the user
+specifies.
+
+If `$ARGUMENTS` is empty, STOP and ask the user which repository they
+want to create a charter for. Accept either an absolute or a relative
+path. Do not default to the current directory — the charter is
+repo-specific and running it against the wrong directory writes a
+`.aidev/charter.md` in the wrong place.
+
+When you have a valid path, run:
+
+!`aidev charter -repo $ARGUMENTS`
+
 This is an interactive subcommand — the user will be prompted for five
 questions in their terminal. After it completes, read the resulting
 `<repo>/.aidev/charter.md` and summarise its Purpose section for the
 user so they can quickly verify it captured their intent.
-
-!`aidev charter -repo $ARGUMENTS`

--- a/internal/plugin/files/aidev-doctor.md
+++ b/internal/plugin/files/aidev-doctor.md
@@ -1,5 +1,6 @@
 ---
 description: Run the aidev precondition audit
+allowed-tools: Bash(aidev:*)
 ---
 
 Run aidev's environment doctor and summarise the result for the user.

--- a/internal/plugin/files/aidev-review.md
+++ b/internal/plugin/files/aidev-review.md
@@ -1,15 +1,19 @@
 ---
 description: Run the aidev Reviewer on the current proposed patch
 argument-hint: <issue-url> <repo-path>
+allowed-tools: Bash(aidev:*)
 ---
 
 Run the aidev Reviewer against the patch at `<repo>/.aidev/proposed.patch`
 for the given issue. This is the Boy Scout pass before the user commits
 the change.
 
-Parse `$ARGUMENTS` as two whitespace-separated tokens:
-  1. issue URL
-  2. repo path
+If `$ARGUMENTS` is empty or does not contain two whitespace-separated
+tokens, STOP and ask the user for:
+  1. the GitHub issue URL
+  2. the absolute or relative path to the local repository
+
+When you have both, run:
 
 !`aidev review -issue $1 -repo $2`
 

--- a/internal/plugin/files/aidev-run.md
+++ b/internal/plugin/files/aidev-run.md
@@ -1,17 +1,23 @@
 ---
 description: Run the full aidev agent pipeline on a GitHub issue
 argument-hint: <issue-url> <repo-path>
+allowed-tools: Bash(aidev:*)
 ---
 
 You are driving `aidev`, the multi-agent coding tool. The user has
 invoked this slash command with arguments naming a GitHub issue and a
 local repository path.
 
-Parse `$ARGUMENTS` as two whitespace-separated tokens:
-  1. issue URL (https://github.com/owner/repo/issues/N)
-  2. repo path (absolute or relative)
+If `$ARGUMENTS` is empty or does not contain two whitespace-separated
+tokens, STOP and ask the user for:
+  1. the GitHub issue URL (https://github.com/owner/repo/issues/N)
+  2. the absolute or relative path to the local repository
 
-Then run aidev in headless mode with auto-architect and sketch 1 picked:
+Do not attempt to run aidev without both values — a missing value will
+blow up inside the tool with a noisy error.
+
+When you have both, run aidev in headless mode with auto-architect and
+sketch 1 picked:
 
 !`aidev -headless -auto -sketch 1 -issue $1 -repo $2`
 

--- a/internal/plugin/files/aidev-test.md
+++ b/internal/plugin/files/aidev-test.md
@@ -1,13 +1,22 @@
 ---
 description: Run the detected test suite for a repository via aidev
 argument-hint: <repo-path>
+allowed-tools: Bash(aidev:*)
 ---
 
-Run `aidev test` against the repository at `$ARGUMENTS`. aidev will
-detect the project's test runner (go/cargo/python/node/gradle/maven/
-just/make) and execute it.
+Run `aidev test` against the repository the user specifies.
+
+If `$ARGUMENTS` is empty, STOP and ask the user which repository they
+want to test. Do not default to the current directory — the user is
+invoking from inside Claude Code and the cwd is usually the Claude
+project, not the aidev target.
+
+When you have a valid path, run:
 
 !`aidev test -repo $ARGUMENTS`
+
+aidev will detect the project's test runner (go/cargo/python/node/
+gradle/maven/just/make) and execute it.
 
 If the run fails, surface the 3-sentence LLM failure summary at the
 top of your response so the user sees the likely cause immediately.

--- a/plugin/aidev/commands/aidev-charter.md
+++ b/plugin/aidev/commands/aidev-charter.md
@@ -1,12 +1,23 @@
 ---
 description: Run the aidev Charter interview against a target repo
 argument-hint: <repo-path>
+allowed-tools: Bash(aidev:*)
 ---
 
-Run the aidev Charter interview against the repository at `$ARGUMENTS`.
+Run the aidev Charter interview against the repository the user
+specifies.
+
+If `$ARGUMENTS` is empty, STOP and ask the user which repository they
+want to create a charter for. Accept either an absolute or a relative
+path. Do not default to the current directory — the charter is
+repo-specific and running it against the wrong directory writes a
+`.aidev/charter.md` in the wrong place.
+
+When you have a valid path, run:
+
+!`aidev charter -repo $ARGUMENTS`
+
 This is an interactive subcommand — the user will be prompted for five
 questions in their terminal. After it completes, read the resulting
 `<repo>/.aidev/charter.md` and summarise its Purpose section for the
 user so they can quickly verify it captured their intent.
-
-!`aidev charter -repo $ARGUMENTS`

--- a/plugin/aidev/commands/aidev-doctor.md
+++ b/plugin/aidev/commands/aidev-doctor.md
@@ -1,5 +1,6 @@
 ---
 description: Run the aidev precondition audit
+allowed-tools: Bash(aidev:*)
 ---
 
 Run aidev's environment doctor and summarise the result for the user.

--- a/plugin/aidev/commands/aidev-review.md
+++ b/plugin/aidev/commands/aidev-review.md
@@ -1,15 +1,19 @@
 ---
 description: Run the aidev Reviewer on the current proposed patch
 argument-hint: <issue-url> <repo-path>
+allowed-tools: Bash(aidev:*)
 ---
 
 Run the aidev Reviewer against the patch at `<repo>/.aidev/proposed.patch`
 for the given issue. This is the Boy Scout pass before the user commits
 the change.
 
-Parse `$ARGUMENTS` as two whitespace-separated tokens:
-  1. issue URL
-  2. repo path
+If `$ARGUMENTS` is empty or does not contain two whitespace-separated
+tokens, STOP and ask the user for:
+  1. the GitHub issue URL
+  2. the absolute or relative path to the local repository
+
+When you have both, run:
 
 !`aidev review -issue $1 -repo $2`
 

--- a/plugin/aidev/commands/aidev-run.md
+++ b/plugin/aidev/commands/aidev-run.md
@@ -1,17 +1,23 @@
 ---
 description: Run the full aidev agent pipeline on a GitHub issue
 argument-hint: <issue-url> <repo-path>
+allowed-tools: Bash(aidev:*)
 ---
 
 You are driving `aidev`, the multi-agent coding tool. The user has
 invoked this slash command with arguments naming a GitHub issue and a
 local repository path.
 
-Parse `$ARGUMENTS` as two whitespace-separated tokens:
-  1. issue URL (https://github.com/owner/repo/issues/N)
-  2. repo path (absolute or relative)
+If `$ARGUMENTS` is empty or does not contain two whitespace-separated
+tokens, STOP and ask the user for:
+  1. the GitHub issue URL (https://github.com/owner/repo/issues/N)
+  2. the absolute or relative path to the local repository
 
-Then run aidev in headless mode with auto-architect and sketch 1 picked:
+Do not attempt to run aidev without both values — a missing value will
+blow up inside the tool with a noisy error.
+
+When you have both, run aidev in headless mode with auto-architect and
+sketch 1 picked:
 
 !`aidev -headless -auto -sketch 1 -issue $1 -repo $2`
 

--- a/plugin/aidev/commands/aidev-test.md
+++ b/plugin/aidev/commands/aidev-test.md
@@ -1,13 +1,22 @@
 ---
 description: Run the detected test suite for a repository via aidev
 argument-hint: <repo-path>
+allowed-tools: Bash(aidev:*)
 ---
 
-Run `aidev test` against the repository at `$ARGUMENTS`. aidev will
-detect the project's test runner (go/cargo/python/node/gradle/maven/
-just/make) and execute it.
+Run `aidev test` against the repository the user specifies.
+
+If `$ARGUMENTS` is empty, STOP and ask the user which repository they
+want to test. Do not default to the current directory — the user is
+invoking from inside Claude Code and the cwd is usually the Claude
+project, not the aidev target.
+
+When you have a valid path, run:
 
 !`aidev test -repo $ARGUMENTS`
+
+aidev will detect the project's test runner (go/cargo/python/node/
+gradle/maven/just/make) and execute it.
 
 If the run fails, surface the 3-sentence LLM failure summary at the
 top of your response so the user sees the likely cause immediately.


### PR DESCRIPTION
## Summary

@crisscross82 tried `/aidev-charter` from inside a Claude Code session and hit:

```
Error: Shell command permission check failed for pattern "!aidev charter -repo ": This command requires approval
```

The error has two root causes that this PR fixes together:

1. **Missing `allowed-tools` frontmatter.** Claude Code slash commands that use `!` shell execution need to declare which Bash patterns are pre-approved via frontmatter, otherwise the permission check fires on every invocation. I shipped the slash commands in PR #8 (v0.2d) without this, so every aidev slash command has been silently broken since then.
2. **Empty argument handling.** When the user invokes `/aidev-charter` without arguments, `$ARGUMENTS` substitutes to an empty string and the resulting command is `aidev charter -repo ` (trailing space, empty path). Even with `allowed-tools` in place, this would fail inside aidev with a noisy 'empty root' error.

## Fix

All five slash command files now:

1. Declare `allowed-tools: Bash(aidev:*)` in frontmatter — this tells Claude Code's permission layer that any `!aidev ...` invocation from this slash command is pre-approved.
2. Guard against empty `$ARGUMENTS` in the prompt body — if the user invoked the command with no arguments, the slash command instructs Claude to STOP and ask for the missing values interactively before running `aidev`. No more silent failures against empty paths.

## Files changed

- `plugin/aidev/commands/aidev-run.md` — allowed-tools + empty-arg guard for issue+repo
- `plugin/aidev/commands/aidev-doctor.md` — allowed-tools (no args needed)
- `plugin/aidev/commands/aidev-charter.md` — allowed-tools + empty-arg guard for repo
- `plugin/aidev/commands/aidev-test.md` — allowed-tools + empty-arg guard for repo
- `plugin/aidev/commands/aidev-review.md` — allowed-tools + empty-arg guard for issue+repo
- `internal/plugin/files/*.md` — embedded copies mirrored (go:embed picks these up for `aidev plugin install`)

## After merging — user action required

@crisscross82 needs to re-run the plugin installer with `--force` to replace the old slash command files:

```sh
aidev plugin install --force
```

This overwrites the five files in `~/.claude/commands/aidev-*.md` with the fixed versions. From there, `/aidev-charter` (and every other `/aidev-*` command) should work without hitting the permission check.

## Design notes

- **Used `Bash(aidev:*)` as the pattern, not `Bash(aidev charter:*)` etc.** Broader pattern, covers every aidev subcommand with one line, and matches the intent: 'this slash command is allowed to invoke aidev with any arguments'. Narrower patterns per command would be marginally more paranoid but add maintenance burden for zero real safety gain — the user is explicitly installing aidev's own slash commands and opting into running aidev.
- **Empty-arg guard is in the prompt body, not in bash.** I considered writing bash guard clauses like `[[ -z "$ARGUMENTS" ]] && { echo 'usage: ...' >&2; exit 1; }` before the `!aidev ...` call, but that leaks noise into Claude's context and doesn't match how slash commands are supposed to work. Instead, the prompt instructs Claude itself to check for empty arguments and ask the user interactively — which is exactly the kind of thing Claude is good at. The shell command only runs after Claude has validated the args.
- **No changes to the Go code.** This is a pure slash-command-file fix. The `plugin` subcommand and the embedded file machinery are unchanged.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all passing (plugin tests verify the embedded files are byte-identical to the canonical source, so the sync is automatic)
- [ ] **Manual on @crisscross82's Mac:**
  - `git pull && go build -o ~/.local/bin/aidev ./cmd/aidev` to get the updated embedded files into the installed binary
  - `aidev plugin install --force` to overwrite the slash commands
  - In any Claude Code session: `/aidev-doctor` — should run without a permission prompt and print the doctor report
  - `/aidev-charter` (with no args) — Claude should ask for a repo path instead of running `aidev charter -repo ` blindly
  - `/aidev-charter ~/code/somerepo` — should run the interview
  - `/aidev-run https://github.com/AiSU-AI/aidev/issues/1 ~/code/personal/aidev` — full pipeline, no permission prompts

## Future polish (not in this PR)

- The `allowed-tools` syntax has more expressive power than I'm using — e.g. I could specify per-command patterns like `Bash(aidev charter:*)` on the charter command and refuse to run any other aidev subcommand from within it. More paranoid, more maintenance. File an issue if you want this.
- Could add a shell-level usage string to the slash commands so that if the user bypasses Claude's empty-arg check somehow, aidev itself prints a clean usage message instead of a stack trace. Would need changes to each subcommand's fatal path.