### PR TITLE
fix: slash commands use shell-level argument guards, not prompt-body guards

### DIFF
--- a/internal/plugin/files/aidev-charter.md
+++ b/internal/plugin/files/aidev-charter.md
@@ -5,19 +5,21 @@ allowed-tools: Bash(aidev:*)
 ---
 
 Run the aidev Charter interview against the repository the user
-specifies.
+specifies via `$ARGUMENTS`.
 
-If `$ARGUMENTS` is empty, STOP and ask the user which repository they
-want to create a charter for. Accept either an absolute or a relative
-path. Do not default to the current directory — the charter is
-repo-specific and running it against the wrong directory writes a
-`.aidev/charter.md` in the wrong place.
+The `!` command below includes a shell-level guard — if the user
+invoked `/aidev-charter` with no arguments, it prints a usage line
+instead of calling aidev with a broken flag.
 
-When you have a valid path, run:
+!`if [ -n "$ARGUMENTS" ]; then aidev charter -repo "$ARGUMENTS"; else echo "usage: /aidev-charter <repo-path>"; fi`
 
-!`aidev charter -repo $ARGUMENTS`
+If the shell above printed a usage line (no repo path was given), ask
+the user which repository they want to create a charter for and tell
+them to re-invoke `/aidev-charter <path>`. Do not default to the
+current directory — the charter is repo-specific and running it
+against the wrong directory writes a `.aidev/charter.md` in the wrong
+place.
 
-This is an interactive subcommand — the user will be prompted for five
-questions in their terminal. After it completes, read the resulting
+Otherwise, the Charter interview has run. Read the resulting
 `<repo>/.aidev/charter.md` and summarise its Purpose section for the
 user so they can quickly verify it captured their intent.

--- a/internal/plugin/files/aidev-review.md
+++ b/internal/plugin/files/aidev-review.md
@@ -5,22 +5,26 @@ allowed-tools: Bash(aidev:*)
 ---
 
 Run the aidev Reviewer against the patch at `<repo>/.aidev/proposed.patch`
-for the given issue. This is the Boy Scout pass before the user commits
-the change.
+for the given issue. This is the Boy Scout pass before the user
+commits the change.
 
-If `$ARGUMENTS` is empty or does not contain two whitespace-separated
-tokens, STOP and ask the user for:
-  1. the GitHub issue URL
-  2. the absolute or relative path to the local repository
+The `!` command below uses `set --` to split `$ARGUMENTS` into shell
+positional parameters, then guards on both being non-empty. If either
+is missing, it prints a usage line instead of calling aidev with a
+broken flag.
 
-When you have both, run:
+!`set -- $ARGUMENTS; if [ -n "$1" ] && [ -n "$2" ]; then aidev review -issue "$1" -repo "$2"; else echo "usage: /aidev-review <issue-url> <repo-path>"; fi`
 
-!`aidev review -issue $1 -repo $2`
+If the shell above printed a usage line, ask the user for the missing
+values and tell them to re-invoke
+`/aidev-review <issue-url> <repo-path>`.
 
-After the review completes:
-  - Report the **verdict** prominently (approve / changes_requested / comment)
-  - List any **blockers** the Reviewer found — these MUST be addressed before merge
-  - List any **follow-up issues** the Reviewer proposed — ask the user
-    whether they want to file any of them with `gh issue create`
-  - The follow-ups are also persisted to `<repo>/.aidev/followups.md`
+Otherwise, the Reviewer has completed. Report to the user:
+  - the **verdict** prominently (approve / changes_requested / comment)
+  - any **blockers** the Reviewer found — these MUST be addressed
+    before merge
+  - any **follow-up issues** the Reviewer proposed — ask the user
+    whether they want to file any of them with
+    `aidev followups --file-issues` or by hand via `gh issue create`
+  - the follow-ups are also persisted to `<repo>/.aidev/followups.md`
     for later triage

--- a/internal/plugin/files/aidev-run.md
+++ b/internal/plugin/files/aidev-run.md
@@ -4,27 +4,29 @@ argument-hint: <issue-url> <repo-path>
 allowed-tools: Bash(aidev:*)
 ---
 
-You are driving `aidev`, the multi-agent coding tool. The user has
-invoked this slash command with arguments naming a GitHub issue and a
-local repository path.
+You are driving `aidev`, the multi-agent coding tool. The user invoked
+this slash command expecting two arguments in `$ARGUMENTS`: a GitHub
+issue URL and a local repository path.
 
-If `$ARGUMENTS` is empty or does not contain two whitespace-separated
-tokens, STOP and ask the user for:
-  1. the GitHub issue URL (https://github.com/owner/repo/issues/N)
-  2. the absolute or relative path to the local repository
+The `!` command below uses `set --` to split `$ARGUMENTS` into shell
+positional parameters, then guards on both being non-empty. If either
+is missing, it prints a usage line instead of calling aidev with a
+broken flag.
 
-Do not attempt to run aidev without both values — a missing value will
-blow up inside the tool with a noisy error.
+!`set -- $ARGUMENTS; if [ -n "$1" ] && [ -n "$2" ]; then aidev -headless -auto -sketch 1 -issue "$1" -repo "$2"; else echo "usage: /aidev-run <issue-url> <repo-path>"; fi`
 
-When you have both, run aidev in headless mode with auto-architect and
-sketch 1 picked:
+If the shell above printed a usage line, ask the user for the missing
+values and tell them to re-invoke
+`/aidev-run <issue-url> <repo-path>`. Do NOT try to re-run the command
+yourself with guessed arguments — the user decides which issue to
+work on.
 
-!`aidev -headless -auto -sketch 1 -issue $1 -repo $2`
-
-After the command finishes, summarise the output for the user:
+Otherwise, the full pipeline has run. Summarise the output for the
+user:
   - what the Critic recommended
   - how many sketches the Architect produced
-  - whether the Implementer wrote a patch at `$2/.aidev/proposed.patch`
+  - whether the Implementer wrote a patch at
+    `<repo>/.aidev/proposed.patch`
   - any warnings from the doctor
 
 If the Critic recommended `kill` or `defer`, stop and report the

--- a/internal/plugin/files/aidev-test.md
+++ b/internal/plugin/files/aidev-test.md
@@ -4,20 +4,23 @@ argument-hint: <repo-path>
 allowed-tools: Bash(aidev:*)
 ---
 
-Run `aidev test` against the repository the user specifies.
+Run `aidev test` against the repository the user specifies via
+`$ARGUMENTS`.
 
-If `$ARGUMENTS` is empty, STOP and ask the user which repository they
-want to test. Do not default to the current directory — the user is
-invoking from inside Claude Code and the cwd is usually the Claude
-project, not the aidev target.
+The `!` command below includes a shell-level guard — if the user
+invoked `/aidev-test` with no arguments, it prints a usage line
+instead of calling aidev with a broken flag.
 
-When you have a valid path, run:
+!`if [ -n "$ARGUMENTS" ]; then aidev test -repo "$ARGUMENTS"; else echo "usage: /aidev-test <repo-path>"; fi`
 
-!`aidev test -repo $ARGUMENTS`
+If the shell above printed a usage line, ask the user which
+repository they want to test and tell them to re-invoke
+`/aidev-test <path>`. Do not default to the current directory — the
+user is invoking from inside Claude Code and the cwd is usually the
+Claude project, not the aidev target.
 
-aidev will detect the project's test runner (go/cargo/python/node/
-gradle/maven/just/make) and execute it.
-
-If the run fails, surface the 3-sentence LLM failure summary at the
-top of your response so the user sees the likely cause immediately.
-The full output is available for follow-up questions.
+Otherwise, aidev has detected and run the project's test suite
+(go/cargo/python/node/gradle/maven/just/make). If the run failed,
+surface the 3-sentence LLM failure summary at the top of your response
+so the user sees the likely cause immediately. The full output is
+available for follow-up questions.

--- a/plugin/aidev/commands/aidev-charter.md
+++ b/plugin/aidev/commands/aidev-charter.md
@@ -5,19 +5,21 @@ allowed-tools: Bash(aidev:*)
 ---
 
 Run the aidev Charter interview against the repository the user
-specifies.
+specifies via `$ARGUMENTS`.
 
-If `$ARGUMENTS` is empty, STOP and ask the user which repository they
-want to create a charter for. Accept either an absolute or a relative
-path. Do not default to the current directory — the charter is
-repo-specific and running it against the wrong directory writes a
-`.aidev/charter.md` in the wrong place.
+The `!` command below includes a shell-level guard — if the user
+invoked `/aidev-charter` with no arguments, it prints a usage line
+instead of calling aidev with a broken flag.
 
-When you have a valid path, run:
+!`if [ -n "$ARGUMENTS" ]; then aidev charter -repo "$ARGUMENTS"; else echo "usage: /aidev-charter <repo-path>"; fi`
 
-!`aidev charter -repo $ARGUMENTS`
+If the shell above printed a usage line (no repo path was given), ask
+the user which repository they want to create a charter for and tell
+them to re-invoke `/aidev-charter <path>`. Do not default to the
+current directory — the charter is repo-specific and running it
+against the wrong directory writes a `.aidev/charter.md` in the wrong
+place.
 
-This is an interactive subcommand — the user will be prompted for five
-questions in their terminal. After it completes, read the resulting
+Otherwise, the Charter interview has run. Read the resulting
 `<repo>/.aidev/charter.md` and summarise its Purpose section for the
 user so they can quickly verify it captured their intent.

--- a/plugin/aidev/commands/aidev-review.md
+++ b/plugin/aidev/commands/aidev-review.md
@@ -5,22 +5,26 @@ allowed-tools: Bash(aidev:*)
 ---
 
 Run the aidev Reviewer against the patch at `<repo>/.aidev/proposed.patch`
-for the given issue. This is the Boy Scout pass before the user commits
-the change.
+for the given issue. This is the Boy Scout pass before the user
+commits the change.
 
-If `$ARGUMENTS` is empty or does not contain two whitespace-separated
-tokens, STOP and ask the user for:
-  1. the GitHub issue URL
-  2. the absolute or relative path to the local repository
+The `!` command below uses `set --` to split `$ARGUMENTS` into shell
+positional parameters, then guards on both being non-empty. If either
+is missing, it prints a usage line instead of calling aidev with a
+broken flag.
 
-When you have both, run:
+!`set -- $ARGUMENTS; if [ -n "$1" ] && [ -n "$2" ]; then aidev review -issue "$1" -repo "$2"; else echo "usage: /aidev-review <issue-url> <repo-path>"; fi`
 
-!`aidev review -issue $1 -repo $2`
+If the shell above printed a usage line, ask the user for the missing
+values and tell them to re-invoke
+`/aidev-review <issue-url> <repo-path>`.
 
-After the review completes:
-  - Report the **verdict** prominently (approve / changes_requested / comment)
-  - List any **blockers** the Reviewer found — these MUST be addressed before merge
-  - List any **follow-up issues** the Reviewer proposed — ask the user
-    whether they want to file any of them with `gh issue create`
-  - The follow-ups are also persisted to `<repo>/.aidev/followups.md`
+Otherwise, the Reviewer has completed. Report to the user:
+  - the **verdict** prominently (approve / changes_requested / comment)
+  - any **blockers** the Reviewer found — these MUST be addressed
+    before merge
+  - any **follow-up issues** the Reviewer proposed — ask the user
+    whether they want to file any of them with
+    `aidev followups --file-issues` or by hand via `gh issue create`
+  - the follow-ups are also persisted to `<repo>/.aidev/followups.md`
     for later triage

--- a/plugin/aidev/commands/aidev-run.md
+++ b/plugin/aidev/commands/aidev-run.md
@@ -4,27 +4,29 @@ argument-hint: <issue-url> <repo-path>
 allowed-tools: Bash(aidev:*)
 ---
 
-You are driving `aidev`, the multi-agent coding tool. The user has
-invoked this slash command with arguments naming a GitHub issue and a
-local repository path.
+You are driving `aidev`, the multi-agent coding tool. The user invoked
+this slash command expecting two arguments in `$ARGUMENTS`: a GitHub
+issue URL and a local repository path.
 
-If `$ARGUMENTS` is empty or does not contain two whitespace-separated
-tokens, STOP and ask the user for:
-  1. the GitHub issue URL (https://github.com/owner/repo/issues/N)
-  2. the absolute or relative path to the local repository
+The `!` command below uses `set --` to split `$ARGUMENTS` into shell
+positional parameters, then guards on both being non-empty. If either
+is missing, it prints a usage line instead of calling aidev with a
+broken flag.
 
-Do not attempt to run aidev without both values — a missing value will
-blow up inside the tool with a noisy error.
+!`set -- $ARGUMENTS; if [ -n "$1" ] && [ -n "$2" ]; then aidev -headless -auto -sketch 1 -issue "$1" -repo "$2"; else echo "usage: /aidev-run <issue-url> <repo-path>"; fi`
 
-When you have both, run aidev in headless mode with auto-architect and
-sketch 1 picked:
+If the shell above printed a usage line, ask the user for the missing
+values and tell them to re-invoke
+`/aidev-run <issue-url> <repo-path>`. Do NOT try to re-run the command
+yourself with guessed arguments — the user decides which issue to
+work on.
 
-!`aidev -headless -auto -sketch 1 -issue $1 -repo $2`
-
-After the command finishes, summarise the output for the user:
+Otherwise, the full pipeline has run. Summarise the output for the
+user:
   - what the Critic recommended
   - how many sketches the Architect produced
-  - whether the Implementer wrote a patch at `$2/.aidev/proposed.patch`
+  - whether the Implementer wrote a patch at
+    `<repo>/.aidev/proposed.patch`
   - any warnings from the doctor
 
 If the Critic recommended `kill` or `defer`, stop and report the

--- a/plugin/aidev/commands/aidev-test.md
+++ b/plugin/aidev/commands/aidev-test.md
@@ -4,20 +4,23 @@ argument-hint: <repo-path>
 allowed-tools: Bash(aidev:*)
 ---
 
-Run `aidev test` against the repository the user specifies.
+Run `aidev test` against the repository the user specifies via
+`$ARGUMENTS`.
 
-If `$ARGUMENTS` is empty, STOP and ask the user which repository they
-want to test. Do not default to the current directory — the user is
-invoking from inside Claude Code and the cwd is usually the Claude
-project, not the aidev target.
+The `!` command below includes a shell-level guard — if the user
+invoked `/aidev-test` with no arguments, it prints a usage line
+instead of calling aidev with a broken flag.
 
-When you have a valid path, run:
+!`if [ -n "$ARGUMENTS" ]; then aidev test -repo "$ARGUMENTS"; else echo "usage: /aidev-test <repo-path>"; fi`
 
-!`aidev test -repo $ARGUMENTS`
+If the shell above printed a usage line, ask the user which
+repository they want to test and tell them to re-invoke
+`/aidev-test <path>`. Do not default to the current directory — the
+user is invoking from inside Claude Code and the cwd is usually the
+Claude project, not the aidev target.
 
-aidev will detect the project's test runner (go/cargo/python/node/
-gradle/maven/just/make) and execute it.
-
-If the run fails, surface the 3-sentence LLM failure summary at the
-top of your response so the user sees the likely cause immediately.
-The full output is available for follow-up questions.
+Otherwise, aidev has detected and run the project's test suite
+(go/cargo/python/node/gradle/maven/just/make). If the run failed,
+surface the 3-sentence LLM failure summary at the top of your response
+so the user sees the likely cause immediately. The full output is
+available for follow-up questions.


### PR DESCRIPTION
## Summary

@crisscross82 hit a second failure mode on `/aidev-charter` after PR #21 landed:

```
❯ /aidev-charter
  ⎿  Error: Shell command failed for pattern "!aidev charter -repo ": [stderr]
     flag needs an argument: -repo
     Usage of aidev:
     ...
```

This one is different from the permission-check failure PR #21 fixed. The permission layer let the command through this time (so `allowed-tools` worked!) but the `!` prefix in Claude Code slash commands runs the shell command IMMEDIATELY, before Claude ever reads the prompt body. My 'if `$ARGUMENTS` is empty, STOP and ask the user' guard in the prompt body was useless — `!` execution is pre-Claude, not post-Claude.

Fix: move the argument guard into the shell command itself.

## Before

```markdown
If `$ARGUMENTS` is empty, STOP and ask the user ...  ← Claude never sees this

!`aidev charter -repo $ARGUMENTS`                     ← fires immediately
```

When `$ARGUMENTS` is empty, the `!` line becomes `aidev charter -repo ` (trailing space), which aidev rejects with 'flag needs an argument: -repo'.

## After

```markdown
!`if [ -n "$ARGUMENTS" ]; then aidev charter -repo "$ARGUMENTS"; else echo "usage: /aidev-charter <repo-path>"; fi`
```

Shell-level conditional. Empty `$ARGUMENTS` → shell prints a usage line, never invokes aidev. Non-empty → aidev runs with the user's path.

For two-argument commands (`/aidev-run`, `/aidev-review`), I use `set --` to split `$ARGUMENTS` into shell positional parameters, then guard on both `$1` and `$2` being non-empty:

```bash
set -- $ARGUMENTS
if [ -n "$1" ] && [ -n "$2" ]; then
  aidev review -issue "$1" -repo "$2"
else
  echo "usage: /aidev-review <issue-url> <repo-path>"
fi
```

Smoke-tested all four patterns (empty / non-empty / two-args-both / two-args-missing-one) before committing. Correct behaviour in every case.

## Files changed

- `plugin/aidev/commands/aidev-charter.md` — shell guard on single-arg
- `plugin/aidev/commands/aidev-test.md` — shell guard on single-arg
- `plugin/aidev/commands/aidev-run.md` — shell guard on two-arg via `set --`
- `plugin/aidev/commands/aidev-review.md` — shell guard on two-arg via `set --`
- `internal/plugin/files/*.md` — embedded copies mirrored (go:embed picks these up for `aidev plugin install`)
- `aidev-doctor.md` unchanged — it takes no arguments so there's nothing to guard

## Prompt body still asks for missing values

The shell guard handles the 'run aidev with a broken flag' case, but the user still needs to know what went wrong. After the `!` execution, Claude sees either the aidev output (success path) or the usage line (missing args path). The prompt body now instructs Claude to interpret both cases:

- If the output is a usage line → ask the user for the missing values and tell them to re-invoke the slash command
- If the output is real aidev output → summarise it normally

This keeps the conversational 'ask nicely when something is missing' UX without relying on Claude to pre-empt the `!` execution.

## After merging — user action required

```sh
cd ~/code/personal/aidev
git pull
go build -o ~/.local/bin/aidev ./cmd/aidev    # picks up the updated embedded files
aidev plugin install --force                  # overwrites ~/.claude/commands/aidev-*.md
```

Then `/aidev-charter` (with or without arguments) should work correctly:

- `/aidev-charter` → prints `usage: /aidev-charter <repo-path>`, Claude asks you which repo
- `/aidev-charter ~/code/somerepo` → runs the full interview

Same pattern for every other `/aidev-*` command.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all passing (plugin tests verify the embedded files are byte-identical to the canonical source)
- [x] Sandbox smoke: all four guard patterns (empty single-arg, non-empty single-arg, both two-args, missing one two-arg) verified to produce the expected output
- [ ] **Manual on @crisscross82's Mac:**
  - Rebuild + reinstall plugin with `--force`
  - `/aidev-charter` (no args) — should print usage, Claude should ask for the path
  - `/aidev-charter ~/code/somerepo` — should start the interview
  - Same for `/aidev-test`, `/aidev-run`, `/aidev-review`

## Lessons learned (for my own notes)

Claude Code slash commands have two execution paths:

1. **`!command` prefix** — synchronous shell execution that runs BEFORE Claude reads the prompt body. Its output is included in Claude's context. Good for simple 'always run this' cases. Terrible for argument validation because the prompt body runs after.
2. **Claude-driven Bash tool calls** — Claude reads the prompt body, decides whether to invoke Bash, Bash tool goes through permission checks. Good for conditional logic. More overhead for simple cases.

The shell-level guard pattern keeps us on path #1 (simple, fast) while getting path #2's safety (no broken invocations with empty args).