### PR TITLE
docs: canonicalize clone-and-run install while the repo is private

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 > A local multi-agent coding assistant that **argues with you before it writes code**. Built in Go. Works with your Claude Max/Pro subscription — no API key required.
 
 ```sh
-curl -sSL https://raw.githubusercontent.com/AiSU-AI/aidev/main/install.sh | bash
+gh repo clone AiSU-AI/aidev ~/code/personal/aidev   # or git clone with SSH
+cd ~/code/personal/aidev
+./install.sh
 ```
 
 Then, from inside any Claude Code session:
@@ -42,42 +44,54 @@ The rest of the pipeline is designed around the same principle: **propose, never
 
 ## Install
 
-### The easy way (no Go required)
+`AiSU-AI/aidev` is currently a private repo, so the canonical install path is **clone + `./install.sh`**. You'll need Go 1.24+ on your machine for the from-source build.
 
 ```sh
-curl -sSL https://raw.githubusercontent.com/AiSU-AI/aidev/main/install.sh | bash
-```
-
-The installer detects your OS/arch, downloads the right prebuilt binary from the latest GitHub release, installs it to `~/.local/bin/aidev`, drops default config at `~/.config/aidev/`, and installs slash commands for Claude Code at `~/.claude/commands/aidev-*.md`.
-
-### From source
-
-```sh
-git clone https://github.com/AiSU-AI/aidev.git
-cd aidev
+gh repo clone AiSU-AI/aidev ~/code/personal/aidev    # or: git clone git@github.com:AiSU-AI/aidev.git ~/code/personal/aidev
+cd ~/code/personal/aidev
 ./install.sh
 ```
 
-Auto-detects that you have Go and builds from the checkout. Same end state as the download path.
+The installer:
 
-### Other flags
+1. Builds the binary with `go build`
+2. Copies it to `~/.local/bin/aidev` (or `~/bin` or `/usr/local/bin`, first writable dir on PATH)
+3. Writes default config to `~/.config/aidev/{models,principles}.yaml`
+4. Installs Claude Code slash commands to `~/.claude/commands/aidev-*.md`
+5. Runs `aidev doctor` to smoke-test the environment
+6. Prints next steps
+
+If the install dir isn't on your PATH already, the script will tell you the exact `export PATH=...` line to add to `~/.zshrc` or `~/.bashrc`.
+
+### Flags
 
 ```sh
 ./install.sh --bin ~/bin        # override target bin directory
-./install.sh --from-release     # force download mode even if Go is installed
-./install.sh --from-source      # force build mode
-./install.sh --version v0.2f    # pin a specific release
+./install.sh --from-source      # force build mode (the default when Go is present)
+./install.sh --from-release     # download from a GitHub release (requires the repo to be public OR GITHUB_TOKEN with contents:read access)
+./install.sh --version v0.2f    # pin a specific release tag (release mode only)
 ./install.sh --force            # overwrite existing binary/config/plugin files
 ./install.sh --no-doctor        # skip the post-install smoke test
 ./install.sh --no-prereqs       # skip the 'suggest installing ollama' check
 ```
 
+### Future: one-line install via release binaries
+
+The install script has a release-download mode that would let anyone run:
+
+```sh
+curl -sSL https://raw.githubusercontent.com/AiSU-AI/aidev/main/install.sh | bash
+```
+
+without cloning the repo or having Go installed. That flow only works when `AiSU-AI/aidev` is public or when the user has a `GITHUB_TOKEN` with read access. The `v*` tag → GitHub Actions → release-asset pipeline is in place (`.github/workflows/release.yaml`); once the repo goes public, the `curl | bash` one-liner becomes the canonical install path and replaces the clone-first flow above.
+
 ### Requirements
 
 - **macOS or Linux.** Windows is not supported yet — the TUI has POSIX-isms.
+- **Go 1.24+** to build from source. Install from https://go.dev/dl/.
 - **[Claude Code](https://claude.ai/download)** installed and logged in (`claude /login`). aidev's medium and large tiers route through `claude --print`, so agent calls bill against your Max/Pro subscription. No `ANTHROPIC_API_KEY` required for the default config.
 - **[Ollama](https://ollama.com)** for the small tier (Scout, Tester failure summary). Optional — you can route the small tier through the claude CLI too by editing `config/models.yaml`, at the cost of subscription tokens.
-- **`GITHUB_TOKEN`** in your environment for reading private issues and posting the audit trail (`Issues: Read and write` scope).
+- **`GITHUB_TOKEN`** in your environment for reading private issues and posting the audit trail (`Issues: Read and write` scope). The same token is also used for `git push` if your repo access is HTTPS-based.
 
 Run `aidev doctor` at any point to verify the environment. If Ollama is installed but not running, doctor will spawn `ollama serve` in the background automatically.
 


### PR DESCRIPTION
## Summary

@crisscross82 confirmed `AiSU-AI/aidev` stays private for now. That means the README's `curl -sSL ...install.sh | bash` one-liner doesn't actually work (`raw.githubusercontent.com` returns 404 on private repos to unauthenticated requests, which is what happens when you pipe into bash) and I need to stop pretending it does.

This PR fixes the README to show the real working install path as the primary flow and mentions the `curl | bash` story only as a future state that activates when the repo goes public.

## Changes

### Headline install block

Before:

```sh
curl -sSL https://raw.githubusercontent.com/AiSU-AI/aidev/main/install.sh | bash
```

After:

```sh
gh repo clone AiSU-AI/aidev ~/code/personal/aidev
cd ~/code/personal/aidev
./install.sh
```

Three lines instead of one, but it actually works.

### Install section

Complete rewrite. Previously advertised `curl | bash` as 'the easy way (no Go required)' and from-source as the secondary option. Now:

- **'Install' top**: states explicitly that the repo is private and clone + `./install.sh` is the canonical path.
- **Walks through what the installer does** in numbered steps, since new users don't know what they're opting into.
- **Flags section**: same list as before, with `--from-source` documented as the default (auto-detected when Go is present) and `--from-release` labelled as needing a public repo or a `GITHUB_TOKEN` with contents:read.
- **'Future: one-line install via release binaries'**: a paragraph explaining the curl|bash flow exists as infrastructure and becomes the canonical path the moment the repo goes public. Keeps hope alive without lying about the current state.
- **Requirements**: adds Go 1.24+ as a hard requirement now that source build is the primary path. Previously hidden behind the from-source subsection.

## Not changed

- `install.sh` itself — the two-mode logic is correct; `--from-source` works perfectly for private-repo installs, and `--from-release` remains plumbed in for the day the repo goes public. No code changes.
- `.github/workflows/release.yaml` — the GitHub Actions release pipeline stays in place. It still fires on `v*` tag pushes and builds the four platform binaries, even though they can't be downloaded by unauthenticated `curl` yet. When the repo goes public, everything Just Works.
- The rest of the README (usage, config, pipeline diagram, troubleshooting, roadmap, layout). This is a targeted fix to the headline + install section only.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all passing (docs-only change)
- [ ] **@crisscross82 glance check**: does the new install section read as 'actually usable' vs 'aspirational fiction'?

## What happens when you eventually flip to public

One-line change to revert this PR's headline + install section back to `curl | bash` primary. I'd probably also add a 'what changed' line to the README around that time to help existing users know about the new flow. Will ship that as a follow-up when you decide to flip — tell me and I'll draft the PR in one turn.