### PR TITLE
fix: /aidev-charter hung because charter is interactive — add non-interactive mode

### DIFF
--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -600,14 +601,25 @@ func runTestSubcommand() {
 	}
 }
 
-// runCharterSubcommand handles `aidev charter`. It runs the interview
-// flow against a target repo (default cwd) and writes the resulting
-// markdown to `<repo>/.aidev/charter.md`. The subcommand never runs the
-// agent pipeline — it is a one-shot tool.
+// runCharterSubcommand handles `aidev charter`. It runs in one of two
+// modes:
+//
+//   - Interactive (default): prompts the user for answers via stdin.
+//     Fails fast if stdin isn't a TTY so we never hang waiting for
+//     input that will never arrive.
+//
+//   - Non-interactive (`--answers-file <path>`): reads a JSON file
+//     with the five answer fields and skips the interviewer
+//     entirely. Used by the Claude Code `/aidev-charter` slash
+//     command, which collects answers in the chat before invoking
+//     aidev.
+//
+// Either way, the end result is a synthesised `<repo>/.aidev/charter.md`.
 func runCharterSubcommand() {
 	var (
-		repoPath  = flag.String("repo", ".", "Path to the target repository")
-		configDir = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
+		repoPath    = flag.String("repo", ".", "Path to the target repository")
+		configDir   = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
+		answersFile = flag.String("answers-file", "", "Path to a JSON file containing the five charter answers (non-interactive mode). Keys: purpose, users, constraint, out_of_scope, overrides")
 	)
 	flag.Parse()
 
@@ -626,14 +638,34 @@ func runCharterSubcommand() {
 		fatal(fmt.Sprintf("resolve repo path: %v", err))
 	}
 
-	fmt.Fprintln(os.Stderr, "aidev charter: interactive interview. Answer each question, then press enter.")
-	fmt.Fprintln(os.Stderr, "Leaving an optional field blank is fine.")
-	fmt.Fprintln(os.Stderr)
-
 	ctx := context.Background()
-	path, err := charter.Interview(ctx, absRepo)
-	if err != nil {
-		fatal(fmt.Sprintf("charter: %v", err))
+
+	var path string
+	if *answersFile != "" {
+		// Non-interactive: load answers from JSON, skip the
+		// interviewer.
+		data, err := os.ReadFile(*answersFile)
+		if err != nil {
+			fatal(fmt.Sprintf("read answers file: %v", err))
+		}
+		var answers map[string]string
+		if err := json.Unmarshal(data, &answers); err != nil {
+			fatal(fmt.Sprintf("parse answers file: %v (expected a JSON object with string values)", err))
+		}
+		fmt.Fprintf(os.Stderr, "aidev charter: running in non-interactive mode with answers from %s\n", *answersFile)
+		path, err = charter.RunWithAnswers(ctx, absRepo, answers)
+		if err != nil {
+			fatal(fmt.Sprintf("charter: %v", err))
+		}
+	} else {
+		// Interactive: walk the user through the 5 questions.
+		fmt.Fprintln(os.Stderr, "aidev charter: interactive interview. Answer each question, then press enter.")
+		fmt.Fprintln(os.Stderr, "Leaving an optional field blank is fine. For non-interactive use, pass --answers-file.")
+		fmt.Fprintln(os.Stderr)
+		path, err = charter.Interview(ctx, absRepo)
+		if err != nil {
+			fatal(fmt.Sprintf("charter: %v", err))
+		}
 	}
 	fmt.Fprintf(os.Stderr, "\nwrote %s\n", path)
 }

--- a/internal/agents/charter.go
+++ b/internal/agents/charter.go
@@ -67,9 +67,14 @@ var CharterQuestions = []ChartQuestion{
 	{Key: "overrides", Prompt: "Any engineering principles that override or extend the defaults? (free text; leave blank for none)"},
 }
 
-// Interview runs the full flow: ask all questions, synthesise the
-// charter via the LLM, and write the result to
-// `<repoRoot>/.aidev/charter.md`. Returns the path to the written file.
+// Interview runs the full interactive flow: ask all questions via the
+// configured Interviewer, synthesise the charter via the LLM, and
+// write the result to `<repoRoot>/.aidev/charter.md`. Returns the path
+// to the written file.
+//
+// For non-interactive callers (Claude Code slash commands, CI jobs),
+// use RunWithAnswers instead — Interview blocks on stdin and will hang
+// forever if stdin is not a TTY.
 func (c *Charter) Interview(ctx context.Context, repoRoot string) (string, error) {
 	if repoRoot == "" {
 		return "", errors.New("charter: empty repo root")
@@ -77,6 +82,34 @@ func (c *Charter) Interview(ctx context.Context, repoRoot string) (string, error
 	answers, err := c.askAll()
 	if err != nil {
 		return "", err
+	}
+	return c.RunWithAnswers(ctx, repoRoot, answers)
+}
+
+// RunWithAnswers is the non-interactive path: it skips the Interviewer
+// entirely and goes straight from pre-collected answers to LLM
+// synthesis + file write. Used by `aidev charter --answers-file <path>`
+// and by the Claude Code `/aidev-charter` slash command, which collects
+// answers from the user in the chat before handing them to aidev.
+//
+// The `answers` map must contain the five keys listed in
+// CharterQuestions; an empty `overrides` is allowed. Missing required
+// keys return a validation error BEFORE the LLM call.
+func (c *Charter) RunWithAnswers(ctx context.Context, repoRoot string, answers map[string]string) (string, error) {
+	if repoRoot == "" {
+		return "", errors.New("charter: empty repo root")
+	}
+	if answers == nil {
+		return "", errors.New("charter: nil answers")
+	}
+	// Validate that every required question has a non-empty answer.
+	// Missing keys are treated the same as empty strings.
+	for _, q := range CharterQuestions {
+		v := strings.TrimSpace(answers[q.Key])
+		answers[q.Key] = v
+		if v == "" && q.Key != "overrides" {
+			return "", fmt.Errorf("charter: %q is required", q.Key)
+		}
 	}
 	md, err := c.synthesise(ctx, answers)
 	if err != nil {
@@ -180,10 +213,27 @@ func (c *Charter) writeCharter(repoRoot, md string) (string, error) {
 
 // StdinInterviewer reads answers from os.Stdin. Prompts are written to
 // os.Stderr so they don't taint stdout-piped output.
+//
+// Ask fails fast if stdin isn't a TTY. This guards against the
+// 'slash command invokes aidev charter via !shell execution and aidev
+// hangs forever waiting for stdin' failure mode — without this check,
+// `fmt.Fscanln` on a non-TTY stdin blocks indefinitely. Callers that
+// need a non-interactive path should use Charter.RunWithAnswers with a
+// pre-collected map instead of this interviewer.
 type StdinInterviewer struct{}
 
 // Ask prints the prompt to stderr and reads a single line from stdin.
+// Returns an error immediately if stdin is not a TTY.
 func (StdinInterviewer) Ask(prompt string) (string, error) {
+	// Non-TTY stdin means this process was invoked from a script, a
+	// pipe, or a tool like Claude Code's `!` shell execution. None of
+	// those have a user to type answers. Fail fast instead of
+	// hanging on fmt.Fscanln.
+	if fi, err := os.Stdin.Stat(); err == nil {
+		if (fi.Mode() & os.ModeCharDevice) == 0 {
+			return "", errors.New("charter: stdin is not a TTY — use `aidev charter --answers-file <path>` for non-interactive runs")
+		}
+	}
 	fmt.Fprint(os.Stderr, prompt)
 	var line string
 	_, err := fmt.Fscanln(os.Stdin, &line)

--- a/internal/agents/charter_test.go
+++ b/internal/agents/charter_test.go
@@ -1,6 +1,7 @@
 package agents
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,5 +124,110 @@ func TestCharterQuestionsCoverAllExpectedKeys(t *testing.T) {
 	}
 	for k := range want {
 		t.Errorf("missing question key: %q", k)
+	}
+}
+
+// TestRunWithAnswersRejectsMissingFields ensures the non-interactive
+// path validates required answers BEFORE hitting the LLM. We can't
+// test the happy path without a real Provider, so this test only
+// covers the validation branch: each case is expected to error
+// during validation and never reach `synthesise`.
+func TestRunWithAnswersRejectsMissingFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		answers map[string]string
+	}{
+		{
+			name: "missing purpose",
+			answers: map[string]string{
+				"users":        "devs",
+				"constraint":   "correctness",
+				"out_of_scope": "web ui",
+			},
+		},
+		{
+			name: "whitespace-only users",
+			answers: map[string]string{
+				"purpose":      "a tool",
+				"users":        "   ",
+				"constraint":   "correctness",
+				"out_of_scope": "web ui",
+			},
+		},
+		{
+			name: "missing constraint",
+			answers: map[string]string{
+				"purpose":      "a tool",
+				"users":        "devs",
+				"out_of_scope": "web ui",
+			},
+		},
+		{
+			name: "missing out_of_scope",
+			answers: map[string]string{
+				"purpose":    "a tool",
+				"users":      "devs",
+				"constraint": "correctness",
+			},
+		},
+		{
+			name:    "nil map",
+			answers: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Provider is nil — validation must catch the missing
+			// field and return an error BEFORE the synthesise call
+			// would dereference Provider. A nil-pointer panic here
+			// means validation is wrong.
+			c := &Charter{Provider: nil}
+			_, err := c.RunWithAnswers(context.Background(), "/tmp/any", tc.answers)
+			if err == nil {
+				t.Error("expected validation error, got nil")
+			}
+		})
+	}
+}
+
+// TestRunWithAnswersOptionalOverridesDoesNotValidate ensures the
+// `overrides` field is allowed to be empty — it's the single optional
+// field in the question set.
+func TestRunWithAnswersAllowsEmptyOverrides(t *testing.T) {
+	// Can't reach the LLM path with a nil Provider, so we only
+	// check that the 'overrides is optional' rule is encoded in
+	// validation by verifying a map with every required field
+	// present + overrides missing does NOT fail at validation (it
+	// fails later at synthesise with a different error). A panic
+	// from nil-provider dereference would also satisfy this — but
+	// we defend against that by recovering and checking the
+	// recovery reason doesn't mention "is required".
+	defer func() {
+		if r := recover(); r != nil {
+			// Expected: synthesise dereferences the nil Provider.
+			// That's fine — it means we got past validation.
+			msg := toString(r)
+			if strings.Contains(msg, "is required") {
+				t.Errorf("validation error leaked into panic: %v", r)
+			}
+		}
+	}()
+	c := &Charter{Provider: nil}
+	_, _ = c.RunWithAnswers(context.Background(), "/tmp/any", map[string]string{
+		"purpose":      "a tool",
+		"users":        "devs",
+		"constraint":   "correctness",
+		"out_of_scope": "web ui",
+	})
+}
+
+func toString(v interface{}) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case error:
+		return x.Error()
+	default:
+		return ""
 	}
 }

--- a/internal/plugin/files/aidev-charter.md
+++ b/internal/plugin/files/aidev-charter.md
@@ -1,25 +1,72 @@
 ---
 description: Run the aidev Charter interview against a target repo
 argument-hint: <repo-path>
-allowed-tools: Bash(aidev:*)
+allowed-tools: Bash(aidev:*), Write
 ---
 
-Run the aidev Charter interview against the repository the user
-specifies via `$ARGUMENTS`.
+Run the aidev Charter interview for the repository at `$ARGUMENTS`.
 
-The `!` command below includes a shell-level guard — if the user
-invoked `/aidev-charter` with no arguments, it prints a usage line
-instead of calling aidev with a broken flag.
+The Charter interview collects five answers and then asks the
+large-tier model to synthesise them into a structured product charter
+at `<repo>/.aidev/charter.md`. The aidev binary has an interactive
+mode (stdin prompts) for terminal use and a non-interactive mode
+(`--answers-file <json>`) for programmatic use. Because Claude Code
+slash commands have no attached TTY, we ALWAYS use the non-interactive
+mode here — collecting the five answers from the user IN THIS CHAT,
+writing them to a temp JSON file, then invoking aidev to do the
+synthesis and file write.
 
-!`if [ -n "$ARGUMENTS" ]; then aidev charter -repo "$ARGUMENTS"; else echo "usage: /aidev-charter <repo-path>"; fi`
+STEP 1 — Validate the argument.
+If `$ARGUMENTS` is empty, ask the user which repository they want to
+create a charter for and STOP. Accept either an absolute path or one
+starting with `~` (expand `~` to `$HOME` before passing it to bash).
+Do not default to the current directory — the charter is
+repo-specific and the wrong directory writes to the wrong place.
 
-If the shell above printed a usage line (no repo path was given), ask
-the user which repository they want to create a charter for and tell
-them to re-invoke `/aidev-charter <path>`. Do not default to the
-current directory — the charter is repo-specific and running it
-against the wrong directory writes a `.aidev/charter.md` in the wrong
-place.
+STEP 2 — Ask the five questions in this chat, one at a time, in
+order. Wait for the user's answer to each before moving to the next.
 
-Otherwise, the Charter interview has run. Read the resulting
-`<repo>/.aidev/charter.md` and summarise its Purpose section for the
-user so they can quickly verify it captured their intent.
+  1. In one sentence, what does this product do?
+  2. Who uses it? (Users or audiences, in plain language.)
+  3. What's the single most important constraint?
+     (correctness / latency / cost / security / compliance / something else)
+  4. What is explicitly out of scope — things this product should
+     NOT do, even if technically possible?
+  5. (Optional) Any engineering principles that override or extend
+     the defaults in `config/principles.yaml`? Leave blank to skip.
+
+Be patient. Don't paraphrase the user's answers back or ask
+follow-ups for clarification unless they wrote something
+contradictory — the Charter agent has its own prompt and will
+synthesise the answers into a tight document.
+
+STEP 3 — Write the answers to a temp JSON file. Use the Write tool
+(NOT a bash heredoc) to create the file at
+`/tmp/aidev-charter-answers-<random>.json` with this EXACT shape
+(string values for every key; overrides may be an empty string):
+
+    {
+      "purpose": "<answer 1>",
+      "users": "<answer 2>",
+      "constraint": "<answer 3>",
+      "out_of_scope": "<answer 4>",
+      "overrides": "<answer 5 or empty string>"
+    }
+
+STEP 4 — Run aidev with the non-interactive flag. Use the Bash tool
+with this command (substituting the real paths):
+
+    aidev charter -repo "<the-path-from-$ARGUMENTS>" --answers-file "/tmp/aidev-charter-answers-<random>.json"
+
+Do NOT use the `!` shell-execution prefix for this — we need to wait
+for Step 3 to complete before running Step 4, and `!` fires before
+the chat body is processed. Use the Bash tool call.
+
+STEP 5 — After the command completes, read the resulting
+`<repo>/.aidev/charter.md` file and summarise its Purpose section for
+the user so they can quickly verify it captured their intent. Also
+remind them the charter is committable — they should `git add` it if
+they want the team to see it and they should `aidev clarify` in the
+future when the Critic flags ambiguity.
+
+STEP 6 — Clean up the temp answers file.

--- a/plugin/aidev/commands/aidev-charter.md
+++ b/plugin/aidev/commands/aidev-charter.md
@@ -1,25 +1,72 @@
 ---
 description: Run the aidev Charter interview against a target repo
 argument-hint: <repo-path>
-allowed-tools: Bash(aidev:*)
+allowed-tools: Bash(aidev:*), Write
 ---
 
-Run the aidev Charter interview against the repository the user
-specifies via `$ARGUMENTS`.
+Run the aidev Charter interview for the repository at `$ARGUMENTS`.
 
-The `!` command below includes a shell-level guard — if the user
-invoked `/aidev-charter` with no arguments, it prints a usage line
-instead of calling aidev with a broken flag.
+The Charter interview collects five answers and then asks the
+large-tier model to synthesise them into a structured product charter
+at `<repo>/.aidev/charter.md`. The aidev binary has an interactive
+mode (stdin prompts) for terminal use and a non-interactive mode
+(`--answers-file <json>`) for programmatic use. Because Claude Code
+slash commands have no attached TTY, we ALWAYS use the non-interactive
+mode here — collecting the five answers from the user IN THIS CHAT,
+writing them to a temp JSON file, then invoking aidev to do the
+synthesis and file write.
 
-!`if [ -n "$ARGUMENTS" ]; then aidev charter -repo "$ARGUMENTS"; else echo "usage: /aidev-charter <repo-path>"; fi`
+STEP 1 — Validate the argument.
+If `$ARGUMENTS` is empty, ask the user which repository they want to
+create a charter for and STOP. Accept either an absolute path or one
+starting with `~` (expand `~` to `$HOME` before passing it to bash).
+Do not default to the current directory — the charter is
+repo-specific and the wrong directory writes to the wrong place.
 
-If the shell above printed a usage line (no repo path was given), ask
-the user which repository they want to create a charter for and tell
-them to re-invoke `/aidev-charter <path>`. Do not default to the
-current directory — the charter is repo-specific and running it
-against the wrong directory writes a `.aidev/charter.md` in the wrong
-place.
+STEP 2 — Ask the five questions in this chat, one at a time, in
+order. Wait for the user's answer to each before moving to the next.
 
-Otherwise, the Charter interview has run. Read the resulting
-`<repo>/.aidev/charter.md` and summarise its Purpose section for the
-user so they can quickly verify it captured their intent.
+  1. In one sentence, what does this product do?
+  2. Who uses it? (Users or audiences, in plain language.)
+  3. What's the single most important constraint?
+     (correctness / latency / cost / security / compliance / something else)
+  4. What is explicitly out of scope — things this product should
+     NOT do, even if technically possible?
+  5. (Optional) Any engineering principles that override or extend
+     the defaults in `config/principles.yaml`? Leave blank to skip.
+
+Be patient. Don't paraphrase the user's answers back or ask
+follow-ups for clarification unless they wrote something
+contradictory — the Charter agent has its own prompt and will
+synthesise the answers into a tight document.
+
+STEP 3 — Write the answers to a temp JSON file. Use the Write tool
+(NOT a bash heredoc) to create the file at
+`/tmp/aidev-charter-answers-<random>.json` with this EXACT shape
+(string values for every key; overrides may be an empty string):
+
+    {
+      "purpose": "<answer 1>",
+      "users": "<answer 2>",
+      "constraint": "<answer 3>",
+      "out_of_scope": "<answer 4>",
+      "overrides": "<answer 5 or empty string>"
+    }
+
+STEP 4 — Run aidev with the non-interactive flag. Use the Bash tool
+with this command (substituting the real paths):
+
+    aidev charter -repo "<the-path-from-$ARGUMENTS>" --answers-file "/tmp/aidev-charter-answers-<random>.json"
+
+Do NOT use the `!` shell-execution prefix for this — we need to wait
+for Step 3 to complete before running Step 4, and `!` fires before
+the chat body is processed. Use the Bash tool call.
+
+STEP 5 — After the command completes, read the resulting
+`<repo>/.aidev/charter.md` file and summarise its Purpose section for
+the user so they can quickly verify it captured their intent. Also
+remind them the charter is committable — they should `git add` it if
+they want the team to see it and they should `aidev clarify` in the
+future when the Critic flags ambiguity.
+
+STEP 6 — Clean up the temp answers file.


### PR DESCRIPTION
## Summary

@crisscross82 ran `/aidev-charter ~/code/personal/Company-Site` and it hung at 'Caramelizing…' for 1m+ until it got interrupted. Root cause: `aidev charter` uses `fmt.Fscanln(os.Stdin, ...)` to collect five interview answers, and Claude Code's `!` shell execution has no attached TTY. `Fscanln` on a non-TTY stdin blocks forever waiting for a newline that will never arrive. aidev hangs, Claude Code waits for the command to exit, nothing happens.

This is a fundamental mismatch: the Charter interview is inherently interactive, but slash commands can't do interactive terminal I/O through `!`. The fix is three-part:

1. **Add a non-interactive mode to `aidev charter`** via a new `--answers-file <path>` flag. When set, aidev reads a JSON file with the five pre-collected answers and skips the Interviewer entirely, going straight to LLM synthesis + file write.
2. **Make `StdinInterviewer` fail fast on non-TTY stdin** so any future caller that accidentally invokes the interactive path from a script/pipe/slash-command gets a clear error message instead of an indefinite hang.
3. **Rewrite the `/aidev-charter` slash command** to collect the five answers from the user *inside* the Claude chat, Write the JSON file via Claude's Write tool, and invoke `aidev charter --answers-file <path>` via the Bash tool (not `!`). The interview happens at the Claude layer, the synthesis happens in aidev.

## Files changed

**modified**
- `internal/agents/charter.go` — new `RunWithAnswers(ctx, repoRoot, map[string]string)` method that validates required fields and calls the same `synthesise` + `writeCharter` path as `Interview`. `Interview` now delegates to `RunWithAnswers` after collecting answers, so the two paths share everything downstream of answer collection.
- `internal/agents/charter.go` — `StdinInterviewer.Ask` now checks `os.Stdin.Stat()` for the `ModeCharDevice` bit. If stdin isn't a character device (i.e. not a TTY), it returns an error immediately with the remediation `use aidev charter --answers-file <path> for non-interactive runs`. No more hangs from piped or redirected stdin.
- `internal/agents/charter_test.go` — new `TestRunWithAnswersRejectsMissingFields` with 5 cases (missing purpose, whitespace-only users, missing constraint, missing out_of_scope, nil map) and `TestRunWithAnswersAllowsEmptyOverrides` verifying that overrides is allowed to be empty. Tests deliberately use a nil Provider and assert that validation fires BEFORE the LLM call would panic.
- `cmd/aidev/main.go` — new `--answers-file <path>` flag on `aidev charter`. When set, reads the file as JSON, unmarshals to `map[string]string`, and calls `charter.RunWithAnswers`. When unset, runs the interactive path as before.
- `plugin/aidev/commands/aidev-charter.md` + `internal/plugin/files/aidev-charter.md` — complete slash command rewrite. Removes the `!` execution entirely. The new flow: validate `$ARGUMENTS`, ask the five questions in the chat one at a time, write a temp JSON file via the Write tool, invoke `aidev charter --answers-file` via the Bash tool, then read the resulting `.aidev/charter.md` and summarise for the user. Adds `Write` to `allowed-tools` alongside `Bash(aidev:*)`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean  
- [x] `go test ./...` — all passing, including 6 new charter validation tests
- [x] `aidev charter -h` exposes the new `--answers-file` flag
- [x] `aidev charter --answers-file /nonexistent -repo /tmp` fails with a clean `read answers file: open ... no such file or directory` error (tested locally)
- [ ] **Manual on @crisscross82's Mac:**
  - Rebuild + reinstall plugin with `--force`
  - In any Claude Code session: `/aidev-charter ~/code/personal/Company-Site`
  - Verify: Claude asks you the five questions one at a time in the chat (no shell hang)
  - Verify: after your fifth answer, Claude writes a temp JSON and invokes `aidev charter --answers-file`
  - Verify: `.aidev/charter.md` is written in the target repo
  - Verify: Claude summarises the Purpose section
  - Sanity check: `aidev charter -repo ~/code/somerepo` from a real terminal still works the old interactive way (doesn't regress the manual path)

## Design decisions

- **Why not also make Clarifier non-interactive?** The Clarifier already writes its questions to a file and waits for stdin answers in a loop. It has the same hang bug when invoked via `!`. I'm not fixing Clarifier in this PR because there's no slash command for `/aidev-clarify` yet — if you want one, I'll do both fixes together in a follow-up. Happy to open that as the next PR if you tell me.
- **JSON, not YAML for the answers file.** Go stdlib has encoding/json; adding YAML parsing costs a dep I don't need. Claude's Write tool happily produces JSON. The five-field shape is trivial.
- **TTY check is a defensive backstop.** Even if the slash command is correct, someone could still run `aidev charter` from a script and hit the hang. The TTY detection bails with a clear error pointing at `--answers-file`, so that failure mode is now loud instead of silent.
- **Keep the interactive path.** Users running `aidev charter -repo foo` from a real terminal get the same five-question walk-through they had before. No regression. The non-interactive path is additive.
- **Slash command uses Bash tool, not `!`.** The fundamental lesson from the last few PRs: `!` is for 'always run this simple command'. Anything requiring multi-step logic (ask user → write file → run command → read result) needs to be Claude-driven via tool calls. I updated this slash command accordingly; the other slash commands that use `!` are fine as-is because they're single-step.

## After merging — user action required

```sh
cd ~/code/personal/aidev
git pull
go build -o ~/.local/bin/aidev ./cmd/aidev
aidev plugin install --force
```

Then `/aidev-charter ~/code/personal/Company-Site` should work end-to-end without hanging.