### PR TITLE
fix: slash commands use Claude-driven Bash tool, not shell logic in !prefix

### DIFF
--- a/internal/plugin/files/aidev-review.md
+++ b/internal/plugin/files/aidev-review.md
@@ -8,23 +8,31 @@ Run the aidev Reviewer against the patch at `<repo>/.aidev/proposed.patch`
 for the given issue. This is the Boy Scout pass before the user
 commits the change.
 
-The `!` command below uses `set --` to split `$ARGUMENTS` into shell
-positional parameters, then guards on both being non-empty. If either
-is missing, it prints a usage line instead of calling aidev with a
-broken flag.
+STEP 1 — Parse `$ARGUMENTS` into two whitespace-separated tokens:
+  - token 1: the issue URL (https://github.com/owner/repo/issues/N)
+  - token 2: the repo path
 
-!`set -- $ARGUMENTS; if [ -n "$1" ] && [ -n "$2" ]; then aidev review -issue "$1" -repo "$2"; else echo "usage: /aidev-review <issue-url> <repo-path>"; fi`
-
-If the shell above printed a usage line, ask the user for the missing
-values and tell them to re-invoke
+If either is missing or empty, STOP and ask the user for the missing
+values. Tell them to re-invoke
 `/aidev-review <issue-url> <repo-path>`.
 
-Otherwise, the Reviewer has completed. Report to the user:
+Do NOT use `!` shell execution — use the Bash tool directly so this
+slash command can validate its arguments at the Claude layer.
+
+STEP 2 — Once you have both values, use the Bash tool to run:
+
+    aidev review -issue <THE-URL> -repo <THE-PATH>
+
+Interpolate the literal values from `$ARGUMENTS` into the command
+string. Expand `~` to `$HOME` if present. The Bash tool call is
+pre-approved by this slash command's `allowed-tools` frontmatter.
+
+STEP 3 — After the review completes, report to the user:
   - the **verdict** prominently (approve / changes_requested / comment)
   - any **blockers** the Reviewer found — these MUST be addressed
     before merge
   - any **follow-up issues** the Reviewer proposed — ask the user
     whether they want to file any of them with
     `aidev followups --file-issues` or by hand via `gh issue create`
-  - the follow-ups are also persisted to `<repo>/.aidev/followups.md`
-    for later triage
+  - note that the follow-ups are also persisted to
+    `<repo>/.aidev/followups.md` for later triage

--- a/internal/plugin/files/aidev-run.md
+++ b/internal/plugin/files/aidev-run.md
@@ -8,27 +8,43 @@ You are driving `aidev`, the multi-agent coding tool. The user invoked
 this slash command expecting two arguments in `$ARGUMENTS`: a GitHub
 issue URL and a local repository path.
 
-The `!` command below uses `set --` to split `$ARGUMENTS` into shell
-positional parameters, then guards on both being non-empty. If either
-is missing, it prints a usage line instead of calling aidev with a
-broken flag.
+STEP 1 — Parse `$ARGUMENTS` into two whitespace-separated tokens:
+  - token 1: the issue URL (https://github.com/owner/repo/issues/N)
+  - token 2: the repo path (absolute, or starting with `~`)
 
-!`set -- $ARGUMENTS; if [ -n "$1" ] && [ -n "$2" ]; then aidev -headless -auto -sketch 1 -issue "$1" -repo "$2"; else echo "usage: /aidev-run <issue-url> <repo-path>"; fi`
+If either is missing or empty, STOP and ask the user for the missing
+values. Do NOT proceed with partial input. Do NOT guess a repo path
+from the current working directory — the user is invoking from inside
+Claude Code, so cwd is almost never the intended aidev target. Tell
+them to re-invoke `/aidev-run <issue-url> <repo-path>`.
 
-If the shell above printed a usage line, ask the user for the missing
-values and tell them to re-invoke
-`/aidev-run <issue-url> <repo-path>`. Do NOT try to re-run the command
-yourself with guessed arguments — the user decides which issue to
-work on.
+Do NOT use `!` shell execution in this slash command. `!` runs before
+the prompt body is processed, and that means Claude Code can't
+validate the arguments first. Use the Bash tool directly instead.
 
-Otherwise, the full pipeline has run. Summarise the output for the
+STEP 2 — Once you have both values, use the Bash tool to run ONE
+aidev command with the two arguments interpolated into the command
+string at the Claude layer (not as shell variables):
+
+    aidev -headless -auto -sketch 1 -issue <THE-URL> -repo <THE-PATH>
+
+Where `<THE-URL>` and `<THE-PATH>` are the literal strings you parsed
+from `$ARGUMENTS`, with `~` expanded to `$HOME` if present. Wrap the
+path in double quotes if it contains spaces or shell-special
+characters.
+
+The Bash tool call itself is pre-approved by this slash command's
+`allowed-tools: Bash(aidev:*)` frontmatter, so it will not trip the
+permission layer as long as the command starts with `aidev`.
+
+STEP 3 — After the command finishes, summarise the output for the
 user:
-  - what the Critic recommended
+  - what the Critic recommended (build / defer / kill / unclear)
   - how many sketches the Architect produced
   - whether the Implementer wrote a patch at
     `<repo>/.aidev/proposed.patch`
-  - any warnings from the doctor
+  - any doctor warnings
 
 If the Critic recommended `kill` or `defer`, stop and report the
 rationale. Don't push the user to proceed against the Critic's
-judgement.
+judgement — that's the entire point of the Critic.

--- a/internal/plugin/files/aidev-test.md
+++ b/internal/plugin/files/aidev-test.md
@@ -7,20 +7,28 @@ allowed-tools: Bash(aidev:*)
 Run `aidev test` against the repository the user specifies via
 `$ARGUMENTS`.
 
-The `!` command below includes a shell-level guard — if the user
-invoked `/aidev-test` with no arguments, it prints a usage line
-instead of calling aidev with a broken flag.
+STEP 1 — Validate `$ARGUMENTS`. If it's empty, STOP and ask the user
+which repository they want to test. Do not default to the current
+directory — the user is invoking from inside Claude Code and cwd is
+usually the Claude project, not the aidev target. Tell them to
+re-invoke `/aidev-test <repo-path>`.
 
-!`if [ -n "$ARGUMENTS" ]; then aidev test -repo "$ARGUMENTS"; else echo "usage: /aidev-test <repo-path>"; fi`
+Do NOT use `!` shell execution — use the Bash tool directly so the
+argument check happens at the Claude layer.
 
-If the shell above printed a usage line, ask the user which
-repository they want to test and tell them to re-invoke
-`/aidev-test <path>`. Do not default to the current directory — the
-user is invoking from inside Claude Code and the cwd is usually the
-Claude project, not the aidev target.
+STEP 2 — Once you have a valid repo path, use the Bash tool to run:
 
-Otherwise, aidev has detected and run the project's test suite
-(go/cargo/python/node/gradle/maven/just/make). If the run failed,
-surface the 3-sentence LLM failure summary at the top of your response
-so the user sees the likely cause immediately. The full output is
-available for follow-up questions.
+    aidev test -repo <THE-PATH>
+
+Interpolate the literal value from `$ARGUMENTS`. Expand `~` to
+`$HOME` if present. Wrap the path in double quotes if it contains
+spaces.
+
+STEP 3 — After the test run completes, report to the user:
+  - whether the run **passed** or **failed**
+  - the command aidev detected and ran (from the output's
+    `command:` line)
+  - if the run failed, the 3-sentence LLM failure summary — surface
+    this at the top of your response so the user sees the likely
+    cause immediately
+  - offer to show the full output if they want more detail

--- a/plugin/aidev/commands/aidev-review.md
+++ b/plugin/aidev/commands/aidev-review.md
@@ -8,23 +8,31 @@ Run the aidev Reviewer against the patch at `<repo>/.aidev/proposed.patch`
 for the given issue. This is the Boy Scout pass before the user
 commits the change.
 
-The `!` command below uses `set --` to split `$ARGUMENTS` into shell
-positional parameters, then guards on both being non-empty. If either
-is missing, it prints a usage line instead of calling aidev with a
-broken flag.
+STEP 1 — Parse `$ARGUMENTS` into two whitespace-separated tokens:
+  - token 1: the issue URL (https://github.com/owner/repo/issues/N)
+  - token 2: the repo path
 
-!`set -- $ARGUMENTS; if [ -n "$1" ] && [ -n "$2" ]; then aidev review -issue "$1" -repo "$2"; else echo "usage: /aidev-review <issue-url> <repo-path>"; fi`
-
-If the shell above printed a usage line, ask the user for the missing
-values and tell them to re-invoke
+If either is missing or empty, STOP and ask the user for the missing
+values. Tell them to re-invoke
 `/aidev-review <issue-url> <repo-path>`.
 
-Otherwise, the Reviewer has completed. Report to the user:
+Do NOT use `!` shell execution — use the Bash tool directly so this
+slash command can validate its arguments at the Claude layer.
+
+STEP 2 — Once you have both values, use the Bash tool to run:
+
+    aidev review -issue <THE-URL> -repo <THE-PATH>
+
+Interpolate the literal values from `$ARGUMENTS` into the command
+string. Expand `~` to `$HOME` if present. The Bash tool call is
+pre-approved by this slash command's `allowed-tools` frontmatter.
+
+STEP 3 — After the review completes, report to the user:
   - the **verdict** prominently (approve / changes_requested / comment)
   - any **blockers** the Reviewer found — these MUST be addressed
     before merge
   - any **follow-up issues** the Reviewer proposed — ask the user
     whether they want to file any of them with
     `aidev followups --file-issues` or by hand via `gh issue create`
-  - the follow-ups are also persisted to `<repo>/.aidev/followups.md`
-    for later triage
+  - note that the follow-ups are also persisted to
+    `<repo>/.aidev/followups.md` for later triage

--- a/plugin/aidev/commands/aidev-run.md
+++ b/plugin/aidev/commands/aidev-run.md
@@ -8,27 +8,43 @@ You are driving `aidev`, the multi-agent coding tool. The user invoked
 this slash command expecting two arguments in `$ARGUMENTS`: a GitHub
 issue URL and a local repository path.
 
-The `!` command below uses `set --` to split `$ARGUMENTS` into shell
-positional parameters, then guards on both being non-empty. If either
-is missing, it prints a usage line instead of calling aidev with a
-broken flag.
+STEP 1 — Parse `$ARGUMENTS` into two whitespace-separated tokens:
+  - token 1: the issue URL (https://github.com/owner/repo/issues/N)
+  - token 2: the repo path (absolute, or starting with `~`)
 
-!`set -- $ARGUMENTS; if [ -n "$1" ] && [ -n "$2" ]; then aidev -headless -auto -sketch 1 -issue "$1" -repo "$2"; else echo "usage: /aidev-run <issue-url> <repo-path>"; fi`
+If either is missing or empty, STOP and ask the user for the missing
+values. Do NOT proceed with partial input. Do NOT guess a repo path
+from the current working directory — the user is invoking from inside
+Claude Code, so cwd is almost never the intended aidev target. Tell
+them to re-invoke `/aidev-run <issue-url> <repo-path>`.
 
-If the shell above printed a usage line, ask the user for the missing
-values and tell them to re-invoke
-`/aidev-run <issue-url> <repo-path>`. Do NOT try to re-run the command
-yourself with guessed arguments — the user decides which issue to
-work on.
+Do NOT use `!` shell execution in this slash command. `!` runs before
+the prompt body is processed, and that means Claude Code can't
+validate the arguments first. Use the Bash tool directly instead.
 
-Otherwise, the full pipeline has run. Summarise the output for the
+STEP 2 — Once you have both values, use the Bash tool to run ONE
+aidev command with the two arguments interpolated into the command
+string at the Claude layer (not as shell variables):
+
+    aidev -headless -auto -sketch 1 -issue <THE-URL> -repo <THE-PATH>
+
+Where `<THE-URL>` and `<THE-PATH>` are the literal strings you parsed
+from `$ARGUMENTS`, with `~` expanded to `$HOME` if present. Wrap the
+path in double quotes if it contains spaces or shell-special
+characters.
+
+The Bash tool call itself is pre-approved by this slash command's
+`allowed-tools: Bash(aidev:*)` frontmatter, so it will not trip the
+permission layer as long as the command starts with `aidev`.
+
+STEP 3 — After the command finishes, summarise the output for the
 user:
-  - what the Critic recommended
+  - what the Critic recommended (build / defer / kill / unclear)
   - how many sketches the Architect produced
   - whether the Implementer wrote a patch at
     `<repo>/.aidev/proposed.patch`
-  - any warnings from the doctor
+  - any doctor warnings
 
 If the Critic recommended `kill` or `defer`, stop and report the
 rationale. Don't push the user to proceed against the Critic's
-judgement.
+judgement — that's the entire point of the Critic.

--- a/plugin/aidev/commands/aidev-test.md
+++ b/plugin/aidev/commands/aidev-test.md
@@ -7,20 +7,28 @@ allowed-tools: Bash(aidev:*)
 Run `aidev test` against the repository the user specifies via
 `$ARGUMENTS`.
 
-The `!` command below includes a shell-level guard — if the user
-invoked `/aidev-test` with no arguments, it prints a usage line
-instead of calling aidev with a broken flag.
+STEP 1 — Validate `$ARGUMENTS`. If it's empty, STOP and ask the user
+which repository they want to test. Do not default to the current
+directory — the user is invoking from inside Claude Code and cwd is
+usually the Claude project, not the aidev target. Tell them to
+re-invoke `/aidev-test <repo-path>`.
 
-!`if [ -n "$ARGUMENTS" ]; then aidev test -repo "$ARGUMENTS"; else echo "usage: /aidev-test <repo-path>"; fi`
+Do NOT use `!` shell execution — use the Bash tool directly so the
+argument check happens at the Claude layer.
 
-If the shell above printed a usage line, ask the user which
-repository they want to test and tell them to re-invoke
-`/aidev-test <path>`. Do not default to the current directory — the
-user is invoking from inside Claude Code and the cwd is usually the
-Claude project, not the aidev target.
+STEP 2 — Once you have a valid repo path, use the Bash tool to run:
 
-Otherwise, aidev has detected and run the project's test suite
-(go/cargo/python/node/gradle/maven/just/make). If the run failed,
-surface the 3-sentence LLM failure summary at the top of your response
-so the user sees the likely cause immediately. The full output is
-available for follow-up questions.
+    aidev test -repo <THE-PATH>
+
+Interpolate the literal value from `$ARGUMENTS`. Expand `~` to
+`$HOME` if present. Wrap the path in double quotes if it contains
+spaces.
+
+STEP 3 — After the test run completes, report to the user:
+  - whether the run **passed** or **failed**
+  - the command aidev detected and ran (from the output's
+    `command:` line)
+  - if the run failed, the 3-sentence LLM failure summary — surface
+    this at the top of your response so the user sees the likely
+    cause immediately
+  - offer to show the full output if they want more detail


### PR DESCRIPTION
## Summary

@crisscross82 ran `/aidev-run https://github.com/AiSU-AI/Company-Site/issues/533 .` and hit:

```
Error: Shell command permission check failed for pattern "!set -- https://github.com/AiSU-AI/Company-Site/issues/533 .; if [ -n "." ] && [ -n "" ]; then aidev -headless -auto -sketch 1 -issue "." -repo ""; else echo "usage: /aidev-run <issue-url> <repo-path>"; fi": This Bash command contains multiple operations. The following part requires approval: set -- https://github.com/AiSU-AI/Company-Site/issues/533 .
```

Two things wrong, both rooted in misunderstanding how Claude Code's slash command `!` execution interacts with its permission layer and variable substitution.

## Bug 1: Claude Code decomposes compound shell commands for permission checks

`allowed-tools: Bash(aidev:*)` pre-approves commands STARTING with `aidev`. Claude Code's permission system is smart enough to break down a compound command like `set -- ...; if [...]; then aidev ...; else echo ...; fi` and check each operation separately. `set --`, `if`, `[`, `echo` are all separate operations that aren't covered by `Bash(aidev:*)`, so the whole compound trips the check.

## Bug 2: Claude Code pre-substitutes `$1` and `$2` before the shell sees them

Look at the rendered command in the error:

```
set -- https://github.com/... .; if [ -n "." ] && [ -n "" ]; then aidev ... -issue "." -repo ""
```

After Claude Code's substitution, `$1` became `"."` and `$2` became `""`. The `set --` command inside the shell never got to run because the positional params were already expanded at the Claude Code layer. My assumption in PR #22 that `set -- $ARGUMENTS` inside `!` would correctly populate `$1`/`$2` was wrong — Claude Code tokenises its own positional params from `$ARGUMENTS` and substitutes them before the shell gets anywhere.

## Fix

Apply the same pattern I used for `/aidev-charter` in PR #24: remove `!` execution entirely from multi-argument slash commands and let Claude drive the Bash tool directly. Claude reads the prompt body, parses `$ARGUMENTS` itself, validates the arguments, and then invokes the Bash tool with a pre-constructed `aidev ...` command string. The Bash tool call matches `Bash(aidev:*)` and passes the permission check cleanly because it's a single aidev invocation with no surrounding shell logic.

### Commands rewritten

- `plugin/aidev/commands/aidev-run.md` — two-arg (issue URL + repo path). Claude parses, validates, invokes Bash tool.
- `plugin/aidev/commands/aidev-review.md` — two-arg (issue URL + repo path). Same pattern.
- `plugin/aidev/commands/aidev-test.md` — single-arg (repo path). Rewritten for consistency and to avoid any future failure mode with the `if`/`echo` guard.
- `internal/plugin/files/*.md` — embedded copies mirrored.

### Commands unchanged

- `plugin/aidev/commands/aidev-doctor.md` — still uses `!aidev doctor`. No argument validation needed, no shell logic, single command starting with `aidev` — passes the permission check trivially.
- `plugin/aidev/commands/aidev-charter.md` — already rewritten in PR #24 to the Claude-driven pattern.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all passing (plugin tests verify embed-sync)
- [ ] **Manual on @crisscross82's Mac:**
  - `git pull && go build -o ~/.local/bin/aidev ./cmd/aidev && aidev plugin install --force`
  - `/aidev-run https://github.com/AiSU-AI/Company-Site/issues/533 ~/code/personal/Company-Site` — should parse both args at the Claude layer, invoke aidev via the Bash tool, run the full pipeline
  - `/aidev-run` (no args) — Claude should ask for the missing values
  - `/aidev-run https://github.com/x/y/issues/1` (one arg) — Claude should ask for the repo path
  - Same validation behaviour expected for `/aidev-test` and `/aidev-review`

## Lessons learned (for future slash commands)

Claude Code slash command `!` execution has two limitations I've now hit three times:

1. **It happens before Claude reads the prompt body.** Prompt-body guards ("if $ARGUMENTS is empty, stop and ask") are useless because `!` has already fired.
2. **Compound shell logic inside `!` trips the permission layer piece-by-piece.** Only plain `!cmd <args>` (single command starting with an approved prefix) reliably passes.

The rule I'm now settling on:

- **Zero-arg commands** → `!` is fine (e.g. `!aidev doctor`)
- **Everything else** → Claude-driven Bash tool pattern. Parse args in the prompt body, invoke Bash tool with a single aidev command.

Documenting this here so the next slash command I write doesn't repeat the mistake.