### PR TITLE
feat: infer issue URL from git remote + gh auth token fallback

### DIFF
--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -113,7 +113,7 @@ func main() {
 	}
 
 	var (
-		issueURL     = flag.String("issue", "", "GitHub issue URL (https://github.com/owner/repo/issues/123)")
+		issueURL     = flag.String("issue", "", "GitHub issue reference: full URL (https://github.com/owner/repo/issues/N) or a bare number when -repo points at a local clone with a github.com remote")
 		repoPath     = flag.String("repo", ".", "Path to the target repository")
 		configDir    = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
 		headless     = flag.Bool("headless", false, "Run the full pipeline once and print the report to stdout without the TUI")
@@ -153,13 +153,23 @@ func main() {
 		fatal(fmt.Sprintf("orchestrator: %v", err))
 	}
 
-	ctx := context.Background()
-	if err := orch.LoadIssue(ctx, *issueURL); err != nil {
-		fatal(fmt.Sprintf("load issue: %v", err))
-	}
+	// Resolve the repo path FIRST because the issue resolver may need
+	// it to turn a bare issue number into a full URL via git remote
+	// inference. Repo-less bare numbers fail loudly instead of silently
+	// running against the wrong target.
 	absRepo, err := filepath.Abs(*repoPath)
 	if err != nil {
 		fatal(fmt.Sprintf("resolve repo path: %v", err))
+	}
+
+	resolvedIssueURL, _, _, _, err := github.ResolveIssueRef(*issueURL, absRepo)
+	if err != nil {
+		fatal(fmt.Sprintf("resolve issue: %v", err))
+	}
+
+	ctx := context.Background()
+	if err := orch.LoadIssue(ctx, resolvedIssueURL); err != nil {
+		fatal(fmt.Sprintf("load issue: %v", err))
 	}
 	if err := orch.LoadRepo(absRepo); err != nil {
 		fatal(fmt.Sprintf("scan repo: %v", err))
@@ -209,7 +219,7 @@ func main() {
 // BEFORE the Architect when the Critic flagged ambiguities.
 func runClarifySubcommand() {
 	var (
-		issueURL  = flag.String("issue", "", "GitHub issue URL (required)")
+		issueURL  = flag.String("issue", "", "GitHub issue reference: full URL or a bare number (resolved against -repo's git remote)")
 		repoPath  = flag.String("repo", ".", "Path to the target repository")
 		configDir = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
 	)
@@ -223,13 +233,17 @@ func runClarifySubcommand() {
 	if err != nil {
 		fatal(fmt.Sprintf("orchestrator: %v", err))
 	}
-	ctx := context.Background()
-	if err := orch.LoadIssue(ctx, *issueURL); err != nil {
-		fatal(fmt.Sprintf("load issue: %v", err))
-	}
 	absRepo, err := filepath.Abs(*repoPath)
 	if err != nil {
 		fatal(fmt.Sprintf("resolve repo: %v", err))
+	}
+	resolvedIssueURL, _, _, _, err := github.ResolveIssueRef(*issueURL, absRepo)
+	if err != nil {
+		fatal(fmt.Sprintf("resolve issue: %v", err))
+	}
+	ctx := context.Background()
+	if err := orch.LoadIssue(ctx, resolvedIssueURL); err != nil {
+		fatal(fmt.Sprintf("load issue: %v", err))
 	}
 	if err := orch.LoadRepo(absRepo); err != nil {
 		fatal(fmt.Sprintf("scan repo: %v", err))
@@ -483,7 +497,7 @@ func runPluginSubcommand() {
 // `<repo>/.aidev/followups.md` for manual triage.
 func runReviewSubcommand() {
 	var (
-		issueURL  = flag.String("issue", "", "GitHub issue URL (required for context)")
+		issueURL  = flag.String("issue", "", "GitHub issue reference: full URL or a bare number (resolved against -repo's git remote)")
 		repoPath  = flag.String("repo", ".", "Path to the target repository")
 		patchPath = flag.String("patch", "", "Path to the patch file to review (default: <repo>/.aidev/proposed.patch)")
 		configDir = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
@@ -498,13 +512,17 @@ func runReviewSubcommand() {
 	if err != nil {
 		fatal(fmt.Sprintf("orchestrator: %v", err))
 	}
-	ctx := context.Background()
-	if err := orch.LoadIssue(ctx, *issueURL); err != nil {
-		fatal(fmt.Sprintf("load issue: %v", err))
-	}
 	absRepo, err := filepath.Abs(*repoPath)
 	if err != nil {
 		fatal(fmt.Sprintf("resolve repo: %v", err))
+	}
+	resolvedIssueURL, _, _, _, err := github.ResolveIssueRef(*issueURL, absRepo)
+	if err != nil {
+		fatal(fmt.Sprintf("resolve issue: %v", err))
+	}
+	ctx := context.Background()
+	if err := orch.LoadIssue(ctx, resolvedIssueURL); err != nil {
+		fatal(fmt.Sprintf("load issue: %v", err))
 	}
 	if err := orch.LoadRepo(absRepo); err != nil {
 		fatal(fmt.Sprintf("scan repo: %v", err))

--- a/internal/github/issue.go
+++ b/internal/github/issue.go
@@ -12,8 +12,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -43,14 +45,48 @@ type Client struct {
 	http    *http.Client
 }
 
-// NewClient constructs a Client against the real github.com API, reading
-// the token from GITHUB_TOKEN.
+// NewClient constructs a Client against the real github.com API.
+// Token resolution is layered so users don't have to manually export
+// GITHUB_TOKEN every time:
+//
+//  1. GITHUB_TOKEN env var (explicit override, highest priority)
+//  2. GH_TOKEN env var (the gh CLI's own canonical variable)
+//  3. `gh auth token` shell-out (when the gh CLI is installed and
+//     logged in — which is the common case on a developer machine)
+//  4. empty string (unauthenticated; public repos still work, private
+//     repos return 404 with a clear remediation message)
+//
+// The gh fallback is the ergonomic win: most developers are already
+// logged in via `gh auth login`, so aidev should just pick up that
+// credential instead of demanding they re-export it.
 func NewClient() *Client {
 	return &Client{
-		token:   os.Getenv("GITHUB_TOKEN"),
+		token:   resolveToken(),
 		baseURL: defaultAPIBase,
 		http:    &http.Client{Timeout: 30 * time.Second},
 	}
+}
+
+// resolveToken walks the credential sources in priority order and
+// returns the first non-empty token found. Silent on gh-lookup
+// failure — we don't want a missing or broken gh install to produce
+// noisy startup output when GITHUB_TOKEN isn't actually needed yet
+// (public-repo reads, doctor, etc.).
+func resolveToken() string {
+	if v := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("GH_TOKEN")); v != "" {
+		return v
+	}
+	if _, err := exec.LookPath("gh"); err != nil {
+		return ""
+	}
+	out, err := exec.Command("gh", "auth", "token").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // NewClientWithEndpoint constructs a Client that talks to baseURL instead

--- a/internal/github/resolve.go
+++ b/internal/github/resolve.go
@@ -1,0 +1,123 @@
+package github
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// ResolveIssueRef turns a user-provided issue reference into a
+// canonical GitHub URL. The reference is either:
+//
+//   - A full GitHub issue URL: https://github.com/owner/repo/issues/N
+//     → returned verbatim (after validation).
+//
+//   - A bare integer: 533
+//     → resolved against the git remote origin URL of repoRoot. The
+//     function shells out to `git -C repoRoot config --get
+//     remote.origin.url`, parses the remote, and constructs the
+//     canonical URL.
+//
+// The second form is the ergonomic win: inside a cloned repo, users
+// can type just `533` and aidev figures out the owner/repo from
+// `.git/config` — no retyping the same URL prefix every invocation.
+//
+// Returns (canonical URL, owner, repo, number, error). On any parse
+// failure, the error contains enough context to point the user at the
+// exact problem (bad URL shape, missing git remote, unrecognised
+// remote format).
+func ResolveIssueRef(ref, repoRoot string) (url, owner, repo string, number int, err error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", "", "", 0, errors.New("github: empty issue reference")
+	}
+
+	// Full URL form.
+	if strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://") {
+		owner, repo, number, err = ParseURL(ref)
+		if err != nil {
+			return "", "", "", 0, err
+		}
+		return ref, owner, repo, number, nil
+	}
+
+	// Bare-number form. repoRoot is required.
+	n, err := strconv.Atoi(ref)
+	if err != nil {
+		return "", "", "", 0, fmt.Errorf("github: %q is neither a URL nor a number", ref)
+	}
+	if n <= 0 {
+		return "", "", "", 0, fmt.Errorf("github: issue number must be positive, got %d", n)
+	}
+	if repoRoot == "" {
+		return "", "", "", 0, errors.New("github: cannot resolve bare issue number without a repo path")
+	}
+
+	owner, repo, err = InferOwnerRepoFromGit(repoRoot)
+	if err != nil {
+		return "", "", "", 0, fmt.Errorf("github: resolve %q via git remote: %w", ref, err)
+	}
+	return fmt.Sprintf("https://github.com/%s/%s/issues/%d", owner, repo, n), owner, repo, n, nil
+}
+
+// InferOwnerRepoFromGit reads the `remote.origin.url` config from the
+// git repository rooted at repoRoot and parses it into owner and repo
+// components. Supports the three canonical remote URL formats:
+//
+//   - https://github.com/owner/repo(.git)
+//   - git@github.com:owner/repo(.git)
+//   - ssh://git@github.com/owner/repo(.git)
+//
+// Other hosts (gitlab, bitbucket, self-hosted) currently return an
+// "unsupported remote" error because aidev's issue URL template is
+// GitHub-specific. Extending to other forges is straightforward when
+// we need it.
+func InferOwnerRepoFromGit(repoRoot string) (owner, repo string, err error) {
+	cmd := exec.Command("git", "-C", repoRoot, "config", "--get", "remote.origin.url")
+	out, cmdErr := cmd.Output()
+	if cmdErr != nil {
+		return "", "", fmt.Errorf("git config remote.origin.url in %s: %w", repoRoot, cmdErr)
+	}
+	return ParseRemoteURL(strings.TrimSpace(string(out)))
+}
+
+// ParseRemoteURL parses a GitHub remote URL into owner + repo.
+// Handles the three canonical formats git emits from `git clone`:
+//
+//	https://github.com/owner/repo          (+ optional .git suffix)
+//	git@github.com:owner/repo              (+ optional .git suffix)
+//	ssh://git@github.com/owner/repo        (+ optional .git suffix)
+//
+// Returns an error for any non-github.com remote so users get a clear
+// "this is only implemented for GitHub" message rather than silent
+// wrong behaviour.
+func ParseRemoteURL(url string) (owner, repo string, err error) {
+	url = strings.TrimSuffix(strings.TrimSpace(url), ".git")
+	if url == "" {
+		return "", "", errors.New("empty remote url")
+	}
+
+	var tail string
+	switch {
+	case strings.HasPrefix(url, "https://github.com/"):
+		tail = strings.TrimPrefix(url, "https://github.com/")
+	case strings.HasPrefix(url, "http://github.com/"):
+		tail = strings.TrimPrefix(url, "http://github.com/")
+	case strings.HasPrefix(url, "git@github.com:"):
+		tail = strings.TrimPrefix(url, "git@github.com:")
+	case strings.HasPrefix(url, "ssh://git@github.com/"):
+		tail = strings.TrimPrefix(url, "ssh://git@github.com/")
+	default:
+		return "", "", fmt.Errorf("unsupported remote url: %q (only github.com is implemented)", url)
+	}
+
+	parts := strings.SplitN(tail, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("malformed github remote url: %q", url)
+	}
+	// Trim any trailing slash or extra path fragments (shouldn't
+	// happen for well-formed remotes but defensive).
+	return parts[0], strings.SplitN(parts[1], "/", 2)[0], nil
+}

--- a/internal/github/resolve_test.go
+++ b/internal/github/resolve_test.go
@@ -1,0 +1,230 @@
+package github
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseRemoteURLHTTPS(t *testing.T) {
+	cases := []struct {
+		in            string
+		wantOwner     string
+		wantRepo      string
+	}{
+		{"https://github.com/aisu-ai/aidev.git", "aisu-ai", "aidev"},
+		{"https://github.com/aisu-ai/aidev", "aisu-ai", "aidev"},
+		{"https://github.com/AiSU-AI/Company-Site.git", "AiSU-AI", "Company-Site"},
+		{"http://github.com/foo/bar", "foo", "bar"},
+	}
+	for _, c := range cases {
+		o, r, err := ParseRemoteURL(c.in)
+		if err != nil {
+			t.Errorf("ParseRemoteURL(%q) err = %v", c.in, err)
+			continue
+		}
+		if o != c.wantOwner || r != c.wantRepo {
+			t.Errorf("ParseRemoteURL(%q) = %q, %q; want %q, %q", c.in, o, r, c.wantOwner, c.wantRepo)
+		}
+	}
+}
+
+func TestParseRemoteURLSSH(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantOwner string
+		wantRepo  string
+	}{
+		{"git@github.com:aisu-ai/aidev.git", "aisu-ai", "aidev"},
+		{"git@github.com:aisu-ai/aidev", "aisu-ai", "aidev"},
+		{"ssh://git@github.com/aisu-ai/aidev.git", "aisu-ai", "aidev"},
+		{"ssh://git@github.com/AiSU-AI/Company-Site", "AiSU-AI", "Company-Site"},
+	}
+	for _, c := range cases {
+		o, r, err := ParseRemoteURL(c.in)
+		if err != nil {
+			t.Errorf("ParseRemoteURL(%q) err = %v", c.in, err)
+			continue
+		}
+		if o != c.wantOwner || r != c.wantRepo {
+			t.Errorf("ParseRemoteURL(%q) = %q, %q; want %q, %q", c.in, o, r, c.wantOwner, c.wantRepo)
+		}
+	}
+}
+
+func TestParseRemoteURLRejectsNonGitHub(t *testing.T) {
+	cases := []string{
+		"https://gitlab.com/foo/bar.git",
+		"git@bitbucket.org:foo/bar.git",
+		"https://example.com/foo.git",
+		"",
+		"nonsense",
+	}
+	for _, c := range cases {
+		_, _, err := ParseRemoteURL(c)
+		if err == nil {
+			t.Errorf("ParseRemoteURL(%q) should have errored", c)
+		}
+	}
+}
+
+func TestParseRemoteURLRejectsMalformed(t *testing.T) {
+	cases := []string{
+		"https://github.com/",
+		"https://github.com/onlyowner",
+		"git@github.com:",
+		"git@github.com:onlyowner",
+	}
+	for _, c := range cases {
+		_, _, err := ParseRemoteURL(c)
+		if err == nil {
+			t.Errorf("ParseRemoteURL(%q) should have errored", c)
+		}
+	}
+}
+
+func TestResolveIssueRefFullURLPassthrough(t *testing.T) {
+	url, owner, repo, num, err := ResolveIssueRef("https://github.com/aisu-ai/aidev/issues/42", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if url != "https://github.com/aisu-ai/aidev/issues/42" {
+		t.Errorf("url = %q", url)
+	}
+	if owner != "aisu-ai" || repo != "aidev" || num != 42 {
+		t.Errorf("got %q/%q#%d", owner, repo, num)
+	}
+}
+
+func TestResolveIssueRefBadURLReturnsError(t *testing.T) {
+	_, _, _, _, err := ResolveIssueRef("https://github.com/onlyowner", "")
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestResolveIssueRefEmpty(t *testing.T) {
+	_, _, _, _, err := ResolveIssueRef("", "")
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestResolveIssueRefBareNumberWithoutRepoErrors(t *testing.T) {
+	_, _, _, _, err := ResolveIssueRef("533", "")
+	if err == nil {
+		t.Error("expected error when repo root is empty")
+	}
+}
+
+func TestResolveIssueRefBareNumberNonNumericErrors(t *testing.T) {
+	_, _, _, _, err := ResolveIssueRef("foo", "/tmp")
+	if err == nil {
+		t.Error("expected error for non-numeric bare ref")
+	}
+}
+
+func TestResolveIssueRefBareNumberNegativeErrors(t *testing.T) {
+	_, _, _, _, err := ResolveIssueRef("0", "/tmp")
+	if err == nil {
+		t.Error("expected error for non-positive issue number")
+	}
+	_, _, _, _, err = ResolveIssueRef("-5", "/tmp")
+	if err == nil {
+		t.Error("expected error for negative issue number")
+	}
+}
+
+// TestResolveIssueRefBareNumberInferFromGit exercises the happy path
+// by creating a throwaway git repo with a real remote and asking
+// ResolveIssueRef to turn "533" into a full URL. Requires git on
+// PATH; skips otherwise (e.g. minimal CI containers).
+func TestResolveIssueRefBareNumberInferFromGit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+
+	dir := t.TempDir()
+
+	// git init, then set an https remote.
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	run("remote", "add", "origin", "https://github.com/aisu-ai/aidev.git")
+
+	url, owner, repo, num, err := ResolveIssueRef("533", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if url != "https://github.com/aisu-ai/aidev/issues/533" {
+		t.Errorf("url = %q", url)
+	}
+	if owner != "aisu-ai" || repo != "aidev" || num != 533 {
+		t.Errorf("got %q/%q#%d", owner, repo, num)
+	}
+}
+
+// TestResolveIssueRefBareNumberSSHRemote verifies the SSH remote
+// form also works for bare-number resolution.
+func TestResolveIssueRefBareNumberSSHRemote(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	run("remote", "add", "origin", "git@github.com:AiSU-AI/Company-Site.git")
+
+	_, owner, repo, num, err := ResolveIssueRef("42", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if owner != "AiSU-AI" || repo != "Company-Site" || num != 42 {
+		t.Errorf("got %q/%q#%d", owner, repo, num)
+	}
+}
+
+func TestInferOwnerRepoFromGitMissingRepoErrors(t *testing.T) {
+	dir := t.TempDir()
+	// Not a git repo at all — git config should fail.
+	_, _, err := InferOwnerRepoFromGit(dir)
+	if err == nil {
+		t.Error("expected error in non-git dir")
+	}
+}
+
+func TestInferOwnerRepoFromGitMissingRemoteErrors(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init", "-q")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	// Repo exists but has no remote.origin.url set.
+	_, _, err := InferOwnerRepoFromGit(dir)
+	if err == nil {
+		t.Error("expected error when remote.origin.url is unset")
+	}
+	// Sanity check that dir is still there and we didn't leak.
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
+		t.Errorf("temp .git dir missing: %v", err)
+	}
+}

--- a/internal/plugin/files/aidev-review.md
+++ b/internal/plugin/files/aidev-review.md
@@ -1,6 +1,6 @@
 ---
 description: Run the aidev Reviewer on the current proposed patch
-argument-hint: <issue-url> <repo-path>
+argument-hint: <issue-number-or-url> [repo-path]
 allowed-tools: Bash(aidev:*)
 ---
 
@@ -8,24 +8,25 @@ Run the aidev Reviewer against the patch at `<repo>/.aidev/proposed.patch`
 for the given issue. This is the Boy Scout pass before the user
 commits the change.
 
-STEP 1 — Parse `$ARGUMENTS` into two whitespace-separated tokens:
-  - token 1: the issue URL (https://github.com/owner/repo/issues/N)
-  - token 2: the repo path
+STEP 1 — Parse `$ARGUMENTS`. The first token is the issue reference
+(URL or bare number). The second token, if present, is the repo
+path. If the repo path is absent, default it to `.` (cwd).
 
-If either is missing or empty, STOP and ask the user for the missing
-values. Tell them to re-invoke
-`/aidev-review <issue-url> <repo-path>`.
+If `$ARGUMENTS` is empty, STOP and ask the user for an issue
+reference.
 
-Do NOT use `!` shell execution — use the Bash tool directly so this
-slash command can validate its arguments at the Claude layer.
+The `-issue` flag accepts either a full URL or a bare number; the
+number is resolved against the repo's git remote. `GITHUB_TOKEN` is
+auto-resolved from `gh auth token` so no manual export is needed.
 
-STEP 2 — Once you have both values, use the Bash tool to run:
+Do NOT use `!` shell execution — use the Bash tool directly.
 
-    aidev review -issue <THE-URL> -repo <THE-PATH>
+STEP 2 — Use the Bash tool to run:
 
-Interpolate the literal values from `$ARGUMENTS` into the command
-string. Expand `~` to `$HOME` if present. The Bash tool call is
-pre-approved by this slash command's `allowed-tools` frontmatter.
+    aidev review -issue <ISSUE> -repo <PATH>
+
+Interpolate the parsed values at the Claude layer. Expand `~` to
+`$HOME` if present.
 
 STEP 3 — After the review completes, report to the user:
   - the **verdict** prominently (approve / changes_requested / comment)

--- a/internal/plugin/files/aidev-run.md
+++ b/internal/plugin/files/aidev-run.md
@@ -1,50 +1,52 @@
 ---
 description: Run the full aidev agent pipeline on a GitHub issue
-argument-hint: <issue-url> <repo-path>
+argument-hint: <issue-number-or-url> [repo-path]
 allowed-tools: Bash(aidev:*)
 ---
 
-You are driving `aidev`, the multi-agent coding tool. The user invoked
-this slash command expecting two arguments in `$ARGUMENTS`: a GitHub
-issue URL and a local repository path.
+You are driving `aidev`, the multi-agent coding tool.
 
-STEP 1 — Parse `$ARGUMENTS` into two whitespace-separated tokens:
-  - token 1: the issue URL (https://github.com/owner/repo/issues/N)
-  - token 2: the repo path (absolute, or starting with `~`)
+STEP 1 — Parse `$ARGUMENTS` into tokens. The first token is the issue
+reference (either a full GitHub URL or a bare issue number). The
+second token, if present, is the repository path. If the repo path
+is absent, default it to `.` (current working directory) — aidev can
+resolve a bare issue number against the cwd's git remote.
 
-If either is missing or empty, STOP and ask the user for the missing
-values. Do NOT proceed with partial input. Do NOT guess a repo path
-from the current working directory — the user is invoking from inside
-Claude Code, so cwd is almost never the intended aidev target. Tell
-them to re-invoke `/aidev-run <issue-url> <repo-path>`.
+If `$ARGUMENTS` is empty, STOP and ask the user for an issue
+reference. Do NOT proceed with no input.
 
-Do NOT use `!` shell execution in this slash command. `!` runs before
-the prompt body is processed, and that means Claude Code can't
-validate the arguments first. Use the Bash tool directly instead.
+aidev's `-issue` flag accepts either form:
+  - full URL: `https://github.com/owner/repo/issues/123`
+  - bare number: `123` (resolved against `-repo`'s git remote origin)
 
-STEP 2 — Once you have both values, use the Bash tool to run ONE
-aidev command with the two arguments interpolated into the command
-string at the Claude layer (not as shell variables):
+aidev's `GITHUB_TOKEN` is auto-resolved from `gh auth token` when the
+env var isn't set, so you do not need to wrap the command with a
+manual credential export. If you see a 'private repo? set
+GITHUB_TOKEN' error anyway, tell the user to run `gh auth login` (or
+export a PAT) and retry.
 
-    aidev -headless -auto -sketch 1 -issue <THE-URL> -repo <THE-PATH>
+STEP 2 — Use the Bash tool to run ONE aidev command with the parsed
+values interpolated at the Claude layer (not as shell variables):
 
-Where `<THE-URL>` and `<THE-PATH>` are the literal strings you parsed
-from `$ARGUMENTS`, with `~` expanded to `$HOME` if present. Wrap the
-path in double quotes if it contains spaces or shell-special
-characters.
+    aidev -headless -auto -sketch 1 -issue <ISSUE> -repo <PATH>
 
-The Bash tool call itself is pre-approved by this slash command's
-`allowed-tools: Bash(aidev:*)` frontmatter, so it will not trip the
-permission layer as long as the command starts with `aidev`.
+Where `<ISSUE>` is the literal first token from `$ARGUMENTS` and
+`<PATH>` is the literal second token (or `.` if unset). Expand `~`
+to `$HOME`. Wrap the path in double quotes if it contains spaces.
+
+The Bash call matches `Bash(aidev:*)` and passes the permission
+layer cleanly because it's a single `aidev` invocation with no
+surrounding shell logic.
 
 STEP 3 — After the command finishes, summarise the output for the
 user:
   - what the Critic recommended (build / defer / kill / unclear)
-  - how many sketches the Architect produced
+  - how many sketches the Architect produced (if build)
   - whether the Implementer wrote a patch at
     `<repo>/.aidev/proposed.patch`
   - any doctor warnings
 
 If the Critic recommended `kill` or `defer`, stop and report the
-rationale. Don't push the user to proceed against the Critic's
-judgement — that's the entire point of the Critic.
+rationale verbatim. Surface the Critic's sharp questions to the user
+and ask how they want to proceed. Don't push them to override the
+Critic — that's the entire point of the tool.

--- a/plugin/aidev/commands/aidev-review.md
+++ b/plugin/aidev/commands/aidev-review.md
@@ -1,6 +1,6 @@
 ---
 description: Run the aidev Reviewer on the current proposed patch
-argument-hint: <issue-url> <repo-path>
+argument-hint: <issue-number-or-url> [repo-path]
 allowed-tools: Bash(aidev:*)
 ---
 
@@ -8,24 +8,25 @@ Run the aidev Reviewer against the patch at `<repo>/.aidev/proposed.patch`
 for the given issue. This is the Boy Scout pass before the user
 commits the change.
 
-STEP 1 — Parse `$ARGUMENTS` into two whitespace-separated tokens:
-  - token 1: the issue URL (https://github.com/owner/repo/issues/N)
-  - token 2: the repo path
+STEP 1 — Parse `$ARGUMENTS`. The first token is the issue reference
+(URL or bare number). The second token, if present, is the repo
+path. If the repo path is absent, default it to `.` (cwd).
 
-If either is missing or empty, STOP and ask the user for the missing
-values. Tell them to re-invoke
-`/aidev-review <issue-url> <repo-path>`.
+If `$ARGUMENTS` is empty, STOP and ask the user for an issue
+reference.
 
-Do NOT use `!` shell execution — use the Bash tool directly so this
-slash command can validate its arguments at the Claude layer.
+The `-issue` flag accepts either a full URL or a bare number; the
+number is resolved against the repo's git remote. `GITHUB_TOKEN` is
+auto-resolved from `gh auth token` so no manual export is needed.
 
-STEP 2 — Once you have both values, use the Bash tool to run:
+Do NOT use `!` shell execution — use the Bash tool directly.
 
-    aidev review -issue <THE-URL> -repo <THE-PATH>
+STEP 2 — Use the Bash tool to run:
 
-Interpolate the literal values from `$ARGUMENTS` into the command
-string. Expand `~` to `$HOME` if present. The Bash tool call is
-pre-approved by this slash command's `allowed-tools` frontmatter.
+    aidev review -issue <ISSUE> -repo <PATH>
+
+Interpolate the parsed values at the Claude layer. Expand `~` to
+`$HOME` if present.
 
 STEP 3 — After the review completes, report to the user:
   - the **verdict** prominently (approve / changes_requested / comment)

--- a/plugin/aidev/commands/aidev-run.md
+++ b/plugin/aidev/commands/aidev-run.md
@@ -1,50 +1,52 @@
 ---
 description: Run the full aidev agent pipeline on a GitHub issue
-argument-hint: <issue-url> <repo-path>
+argument-hint: <issue-number-or-url> [repo-path]
 allowed-tools: Bash(aidev:*)
 ---
 
-You are driving `aidev`, the multi-agent coding tool. The user invoked
-this slash command expecting two arguments in `$ARGUMENTS`: a GitHub
-issue URL and a local repository path.
+You are driving `aidev`, the multi-agent coding tool.
 
-STEP 1 — Parse `$ARGUMENTS` into two whitespace-separated tokens:
-  - token 1: the issue URL (https://github.com/owner/repo/issues/N)
-  - token 2: the repo path (absolute, or starting with `~`)
+STEP 1 — Parse `$ARGUMENTS` into tokens. The first token is the issue
+reference (either a full GitHub URL or a bare issue number). The
+second token, if present, is the repository path. If the repo path
+is absent, default it to `.` (current working directory) — aidev can
+resolve a bare issue number against the cwd's git remote.
 
-If either is missing or empty, STOP and ask the user for the missing
-values. Do NOT proceed with partial input. Do NOT guess a repo path
-from the current working directory — the user is invoking from inside
-Claude Code, so cwd is almost never the intended aidev target. Tell
-them to re-invoke `/aidev-run <issue-url> <repo-path>`.
+If `$ARGUMENTS` is empty, STOP and ask the user for an issue
+reference. Do NOT proceed with no input.
 
-Do NOT use `!` shell execution in this slash command. `!` runs before
-the prompt body is processed, and that means Claude Code can't
-validate the arguments first. Use the Bash tool directly instead.
+aidev's `-issue` flag accepts either form:
+  - full URL: `https://github.com/owner/repo/issues/123`
+  - bare number: `123` (resolved against `-repo`'s git remote origin)
 
-STEP 2 — Once you have both values, use the Bash tool to run ONE
-aidev command with the two arguments interpolated into the command
-string at the Claude layer (not as shell variables):
+aidev's `GITHUB_TOKEN` is auto-resolved from `gh auth token` when the
+env var isn't set, so you do not need to wrap the command with a
+manual credential export. If you see a 'private repo? set
+GITHUB_TOKEN' error anyway, tell the user to run `gh auth login` (or
+export a PAT) and retry.
 
-    aidev -headless -auto -sketch 1 -issue <THE-URL> -repo <THE-PATH>
+STEP 2 — Use the Bash tool to run ONE aidev command with the parsed
+values interpolated at the Claude layer (not as shell variables):
 
-Where `<THE-URL>` and `<THE-PATH>` are the literal strings you parsed
-from `$ARGUMENTS`, with `~` expanded to `$HOME` if present. Wrap the
-path in double quotes if it contains spaces or shell-special
-characters.
+    aidev -headless -auto -sketch 1 -issue <ISSUE> -repo <PATH>
 
-The Bash tool call itself is pre-approved by this slash command's
-`allowed-tools: Bash(aidev:*)` frontmatter, so it will not trip the
-permission layer as long as the command starts with `aidev`.
+Where `<ISSUE>` is the literal first token from `$ARGUMENTS` and
+`<PATH>` is the literal second token (or `.` if unset). Expand `~`
+to `$HOME`. Wrap the path in double quotes if it contains spaces.
+
+The Bash call matches `Bash(aidev:*)` and passes the permission
+layer cleanly because it's a single `aidev` invocation with no
+surrounding shell logic.
 
 STEP 3 — After the command finishes, summarise the output for the
 user:
   - what the Critic recommended (build / defer / kill / unclear)
-  - how many sketches the Architect produced
+  - how many sketches the Architect produced (if build)
   - whether the Implementer wrote a patch at
     `<repo>/.aidev/proposed.patch`
   - any doctor warnings
 
 If the Critic recommended `kill` or `defer`, stop and report the
-rationale. Don't push the user to proceed against the Critic's
-judgement — that's the entire point of the Critic.
+rationale verbatim. Surface the Critic's sharp questions to the user
+and ask how they want to proceed. Don't push them to override the
+Critic — that's the entire point of the tool.


### PR DESCRIPTION
## Summary

Two ergonomic fixes rooted in @crisscross82's insight that aidev should figure out what it can from the environment.

1. **`-issue` accepts a bare issue number** (`533`) and resolves it against the repo's git remote origin URL. No more retyping `https://github.com/AiSU-AI/Company-Site/issues/` for every invocation.
2. **`GITHUB_TOKEN` auto-resolves via `gh auth token`** when the env var isn't set. No more `GITHUB_TOKEN=$(gh auth token) aidev ...` wrapper — if you're logged in via `gh auth login`, aidev picks up the credential automatically.

Both changes are additive. Full URLs still work. Explicit `GITHUB_TOKEN` still wins.

## Files

**new**
- `internal/github/resolve.go` — `ParseRemoteURL` (https/git@/ssh forms), `InferOwnerRepoFromGit` (shells out to `git -C <repo> config --get remote.origin.url`), `ResolveIssueRef` (accepts URL-or-number, returns canonical URL + owner/repo/number tuple).
- `internal/github/resolve_test.go` — 15 tests covering every URL format, .git suffix, non-github rejection, malformed inputs, empty refs, bad numbers, missing git repo, missing remote. Two integration tests spin up real throwaway git repos with `git init` + `git remote add` to verify end-to-end resolution.

**modified**
- `internal/github/issue.go` — new `resolveToken()` with 4-level precedence: `GITHUB_TOKEN` → `GH_TOKEN` → `gh auth token` shell-out → empty. `NewClient()` calls it instead of reading env directly. Silent on gh-lookup failure.
- `cmd/aidev/main.go` — main flow, `aidev clarify`, `aidev review` all now call `github.ResolveIssueRef` before `orch.LoadIssue`. Flag help strings updated.
- `plugin/aidev/commands/aidev-run.md` + `aidev-review.md` — document URL-or-number, repo path optional (defaults to cwd), gh auth token fallback.

## New UX

Before:
```
GITHUB_TOKEN=$(gh auth token) aidev -headless -auto -sketch 1 \
  -issue https://github.com/AiSU-AI/Company-Site/issues/533 \
  -repo ~/code/personal/Company-Site
```

After:
```
cd ~/code/personal/Company-Site
aidev -headless -auto -sketch 1 -issue 533
```

Or from inside Claude Code:
```
/aidev-run 533 ~/code/personal/Company-Site
```

60 characters instead of 170.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all existing tests pass + 15 new resolve tests
- [ ] **Manual on @crisscross82's Mac:**
  - `cd ~/code/personal/Company-Site && aidev -issue 533 -headless` should work without env vars or repo flag
  - `aidev -issue https://github.com/AiSU-AI/Company-Site/issues/533` (full URL) still works
  - From inside Claude Code: `/aidev-run 533 ~/code/personal/Company-Site` should work
  - From a non-git directory, `aidev -issue 533` should fail with a clear 'cannot resolve bare issue number' error

## What this unlocked

Tonight @crisscross82 ran the full pipeline end-to-end against a real private-repo issue for the first time. The Critic recommended `defer` on a cosmetic PR, spotted the real root cause (three hardcoded CTA strings across 9 locales that should be a single shared i18n key), and refused to build. After this PR he can skip the 110-character wrapper.