### PR TITLE
feat(critic): interview the user on unclear/defer instead of halting

### DIFF
--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -196,7 +196,7 @@ func main() {
 	}
 
 	if *headless {
-		runHeadless(ctx, orch, *autoRun, *pickSketch)
+		runHeadless(ctx, orch, cfg, absRepo, *autoRun, *pickSketch)
 		return
 	}
 
@@ -779,7 +779,15 @@ func discoverConfigDir() string {
 // recommends "build", so a CI pipeline can get the sketches in one pass.
 // With -sketch N, it additionally runs the Implementer against the chosen
 // sketch and prints the resulting patch.
-func runHeadless(ctx context.Context, orch *orchestrator.Orchestrator, auto bool, pickSketch int) {
+//
+// When the Critic returns "unclear" or "defer" AND stdin is a TTY,
+// runHeadless launches an in-line Clarifier interview instead of
+// halting. It asks the Critic's own sharp questions via the Clarifier,
+// collects stdin answers, writes them to .aidev/clarifier.md, and
+// re-runs the Critic. Up to 2 interview rounds total — if the Critic
+// still refuses, we halt and report the latest verdict. A "kill"
+// verdict always halts without an interview; killing is explicit.
+func runHeadless(ctx context.Context, orch *orchestrator.Orchestrator, cfg *config.Config, absRepo string, auto bool, pickSketch int) {
 	for ev := range orch.Run(ctx) {
 		if ev.Err != nil {
 			fatal(ev.Err.Error())
@@ -803,6 +811,14 @@ func runHeadless(ctx context.Context, orch *orchestrator.Orchestrator, auto bool
 		fmt.Println(rpt.Markdown)
 		fmt.Println()
 		fmt.Printf("RECOMMENDATION: %s\n", rpt.Recommendation)
+	}
+
+	// Interview loop on unclear/defer. Skipped when -auto is off
+	// (caller is a CI pipeline, not a human), when there's no TTY on
+	// stdin (headless without interactivity), or when the verdict is
+	// build/kill (nothing to clarify).
+	if auto && rpt != nil && doctor.IsTTY() {
+		rpt = runInterviewLoop(ctx, orch, cfg, absRepo, rpt)
 	}
 
 	if !auto || rpt == nil || rpt.Recommendation != "build" {
@@ -847,6 +863,158 @@ func runHeadless(ctx context.Context, orch *orchestrator.Orchestrator, auto bool
 			fmt.Printf("\n_Patch also written to %s_\n", p.Path)
 		}
 	}
+}
+
+// runInterviewLoop drives up to maxInterviewRounds Clarifier
+// interviews against a Critic that came back unclear/defer. Each round:
+//
+//  1. Run the Clarifier agent on the current Context to extract a
+//     structured QuestionGraph from the Critic's own sharp questions.
+//  2. Walk the graph in dependency-aware waves, collecting free-form
+//     stdin answers from the developer.
+//  3. Persist the session to .aidev/clarifier.md so downstream runs
+//     pick it up via the Scout.
+//  4. Stash the same markdown on ctx.ClarifierNotes and call
+//     orch.Recritique(ctx) to get a fresh verdict.
+//
+// Returns the latest Critic report (which the caller compares against
+// "build" to decide whether to proceed). Any fatal error along the
+// way short-circuits via fatal() just like the rest of main.go — the
+// user sees a clear message and the process exits.
+//
+// Design notes:
+//
+//   - kill is NEVER interviewed. A kill verdict is the Critic saying
+//     "this is a bad idea, full stop". The interview is for
+//     ambiguity, not for overriding rejection.
+//
+//   - build stops the loop immediately — no more questions to ask.
+//
+//   - If the Clarifier returns an empty question graph (nothing
+//     ambiguous) the loop terminates: we have no way to move the
+//     needle without inventing questions.
+//
+//   - Max 2 rounds. Past that, we print the latest verdict and let
+//     the developer decide out-of-band whether to override.
+const maxInterviewRounds = 2
+
+func runInterviewLoop(
+	ctx context.Context,
+	orch *orchestrator.Orchestrator,
+	cfg *config.Config,
+	absRepo string,
+	initial *agents.Report,
+) *agents.Report {
+	rpt := initial
+	if rpt == nil {
+		return nil
+	}
+
+	router, err := llm.NewRouter(cfg)
+	if err != nil {
+		fatal(fmt.Sprintf("router: %v", err))
+	}
+	clarifier, err := agents.NewClarifier(router)
+	if err != nil {
+		fatal(fmt.Sprintf("clarifier: %v", err))
+	}
+	reader := bufio.NewReader(os.Stdin)
+
+	for round := 1; round <= maxInterviewRounds; round++ {
+		if rpt.Recommendation == "build" || rpt.Recommendation == "kill" {
+			return rpt
+		}
+
+		fmt.Println()
+		fmt.Printf("## Clarifier interview (round %d of %d — Critic said %q)\n\n",
+			round, maxInterviewRounds, rpt.Recommendation)
+		fmt.Fprintln(os.Stderr, "aidev: Critic returned "+rpt.Recommendation+". Running Clarifier to turn its sharp questions into an interview...")
+
+		graph, err := clarifier.Run(ctx, orch.AgentContext())
+		if err != nil {
+			fatal(fmt.Sprintf("clarifier: %v", err))
+		}
+		if len(graph.Questions) == 0 {
+			fmt.Fprintln(os.Stderr, "aidev: Clarifier produced no questions — nothing unambiguous to ask about. Halting with the current verdict.")
+			return rpt
+		}
+
+		waves := agents.BatchByDependencies(graph)
+		answers := make([]agents.Answer, 0, len(graph.Questions))
+		fmt.Fprintf(os.Stderr, "\n%d question(s) in %d wave(s). Answer each, then press enter. Leave blank to skip.\n\n",
+			len(graph.Questions), len(waves))
+		for wi, wave := range waves {
+			fmt.Fprintf(os.Stderr, "— Wave %d (%d question(s)) —\n\n", wi+1, len(wave))
+			for _, q := range wave {
+				fmt.Fprintf(os.Stderr, "%s: %s\n> ", q.ID, q.Text)
+				line, readErr := reader.ReadString('\n')
+				if readErr != nil && line == "" {
+					fatal(fmt.Sprintf("read answer: %v", readErr))
+				}
+				answers = append(answers, agents.Answer{
+					ID:   q.ID,
+					Text: strings.TrimRight(line, "\n"),
+				})
+			}
+			fmt.Fprintln(os.Stderr)
+		}
+
+		path, err := agents.WriteClarifierMarkdown(absRepo, graph, answers)
+		if err != nil {
+			fatal(fmt.Sprintf("write clarifier: %v", err))
+		}
+		fmt.Fprintf(os.Stderr, "aidev: wrote clarifier session to %s\n", path)
+
+		orch.AgentContext().ClarifierNotes = formatClarifierNotes(graph, answers)
+
+		fmt.Fprintln(os.Stderr, "aidev: re-running Critic with clarifier answers...")
+		for ev := range orch.Recritique(ctx) {
+			if ev.Err != nil {
+				fatal(ev.Err.Error())
+			}
+		}
+		rpt = orch.CriticReport()
+		if rpt == nil {
+			fmt.Fprintln(os.Stderr, "aidev: Recritique returned no report; halting.")
+			return nil
+		}
+
+		fmt.Println()
+		fmt.Printf("## Critic report (round %d, after clarifier)\n\n", round)
+		fmt.Println(rpt.Markdown)
+		fmt.Println()
+		fmt.Printf("RECOMMENDATION: %s\n", rpt.Recommendation)
+	}
+
+	return rpt
+}
+
+// formatClarifierNotes renders a Clarifier session (graph + answers)
+// as compact markdown suitable for embedding in the Critic prompt.
+// Skips unanswered questions so the Critic doesn't mistake blanks for
+// negative signal. Walks in dependency wave order so the prose reads
+// top-down the same way the user typed it.
+func formatClarifierNotes(g *agents.QuestionGraph, answers []agents.Answer) string {
+	if g == nil || len(g.Questions) == 0 {
+		return ""
+	}
+	byID := make(map[string]string, len(answers))
+	for _, a := range answers {
+		byID[a.ID] = strings.TrimSpace(a.Text)
+	}
+	var b strings.Builder
+	waves := agents.BatchByDependencies(g)
+	for _, wave := range waves {
+		for _, q := range wave {
+			ans := byID[q.ID]
+			if ans == "" {
+				continue
+			}
+			fmt.Fprintf(&b, "- **Q (%s):** %s\n", q.ID, q.Text)
+			fmt.Fprintf(&b, "  **A:** %s\n", ans)
+		}
+	}
+	return b.String()
 }
 
 func fatal(msg string) {

--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -32,6 +32,18 @@ type Context struct {
 	ScoutReport  string   // filled in after Scout runs
 	CriticReport string   // filled in after Critic runs
 	Sketches     []Sketch // filled in after Architect runs
+
+	// ClarifierNotes holds a compact markdown rendering of a Clarifier
+	// session (the Critic's sharp questions plus the human's answers)
+	// collected in the CURRENT orchestrator run. When non-empty it is
+	// threaded into the Critic prompt so a second pass can reach a
+	// verdict with the ambiguities resolved.
+	//
+	// This is distinct from Snapshot.ClarifierContent, which is the
+	// durable `.aidev/clarifier.md` file on disk. ClarifierNotes is
+	// authoritative for the in-memory re-critique loop; the on-disk
+	// file is what downstream runs pick up.
+	ClarifierNotes string
 }
 
 // Principle is re-exported so agent code doesn't need to import the config

--- a/internal/agents/critic.go
+++ b/internal/agents/critic.go
@@ -70,7 +70,14 @@ You MUST:
    or  RECOMMENDATION: unclear
 
 Do NOT hedge the recommendation. If the evidence is mixed, choose "unclear"
-and say what evidence would move you.`
+and say what evidence would move you.
+
+If a "Clarifier session" section is present in the input below, it contains
+the human's direct answers to sharp questions YOU raised in a prior pass.
+Treat those answers as authoritative: they are ground truth about intent,
+scope, and environment that overrides any assumption you might otherwise
+make. Re-decide the verdict in light of them — do NOT re-ask the same
+questions unless the answers themselves raised new ambiguities.`
 
 	// Marshal the principles into a compact, quotable block.
 	var principles strings.Builder
@@ -85,6 +92,10 @@ and say what evidence would move you.`
 	user.WriteString(cc.ScoutReport)
 	user.WriteString("\n\n## Engineering principles\n\n")
 	user.WriteString(principles.String())
+	if strings.TrimSpace(cc.ClarifierNotes) != "" {
+		user.WriteString("\n\n## Clarifier session (human answers to your previous sharp questions — authoritative)\n\n")
+		user.WriteString(cc.ClarifierNotes)
+	}
 
 	resp, err := c.Provider.Complete(ctx, llm.Request{
 		System: system,

--- a/internal/agents/critic_test.go
+++ b/internal/agents/critic_test.go
@@ -1,6 +1,27 @@
 package agents
 
-import "testing"
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aisu-ai/aidev/internal/github"
+	"github.com/aisu-ai/aidev/internal/llm"
+)
+
+// capturingProvider records the last Request it was asked to
+// complete and returns a canned Response. Tests use it to assert
+// prompt-assembly behaviour without a real model.
+type capturingProvider struct {
+	req   llm.Request
+	reply string
+}
+
+func (p *capturingProvider) Name() string { return "capturing" }
+func (p *capturingProvider) Complete(_ context.Context, req llm.Request) (llm.Response, error) {
+	p.req = req
+	return llm.Response{Content: p.reply}, nil
+}
 
 func TestExtractRecommendation(t *testing.T) {
 	cases := []struct {
@@ -20,5 +41,60 @@ func TestExtractRecommendation(t *testing.T) {
 		if got != c.want {
 			t.Errorf("%s: extractRecommendation = %q, want %q", c.name, got, c.want)
 		}
+	}
+}
+
+// TestCriticPromptIncludesClarifierNotes verifies that when
+// Context.ClarifierNotes is non-empty, the Critic embeds it into the
+// user-message under the "Clarifier session" heading so the model
+// sees the human's authoritative answers on its second pass. This is
+// the regression guard for the headless interview loop — without it,
+// clarifying wouldn't actually change the Critic's verdict on
+// re-critique.
+func TestCriticPromptIncludesClarifierNotes(t *testing.T) {
+	p := &capturingProvider{reply: "body\nRECOMMENDATION: build\n"}
+	c := &Critic{Provider: p}
+	cc := &Context{
+		Issue: &github.Issue{
+			Owner: "aisu-ai", Repo: "aidev", Number: 1,
+			Title: "T", Body: "issue body",
+		},
+		ScoutReport:    "scout brief body",
+		ClarifierNotes: "- **Q (q1):** is this a pipeline exercise?\n  **A:** yes, fix the drift only\n",
+	}
+	if _, err := c.Run(context.Background(), cc); err != nil {
+		t.Fatalf("Critic.Run error: %v", err)
+	}
+	userMsg := p.req.Messages[0].Content
+	if !strings.Contains(userMsg, "## Clarifier session") {
+		t.Errorf("critic user message missing '## Clarifier session' heading; got:\n%s", userMsg)
+	}
+	if !strings.Contains(userMsg, "is this a pipeline exercise?") {
+		t.Errorf("critic user message missing the clarifier Q text; got:\n%s", userMsg)
+	}
+	if !strings.Contains(userMsg, "yes, fix the drift only") {
+		t.Errorf("critic user message missing the clarifier A text; got:\n%s", userMsg)
+	}
+}
+
+// TestCriticPromptOmitsClarifierSectionWhenEmpty is the negative
+// case: if ClarifierNotes is empty, the user message must NOT contain
+// the Clarifier heading (otherwise we'd be teaching the model to
+// expect authoritative human input that isn't there).
+func TestCriticPromptOmitsClarifierSectionWhenEmpty(t *testing.T) {
+	p := &capturingProvider{reply: "body\nRECOMMENDATION: unclear\n"}
+	c := &Critic{Provider: p}
+	cc := &Context{
+		Issue: &github.Issue{
+			Owner: "aisu-ai", Repo: "aidev", Number: 1,
+			Title: "T", Body: "issue body",
+		},
+		ScoutReport: "scout brief body",
+	}
+	if _, err := c.Run(context.Background(), cc); err != nil {
+		t.Fatalf("Critic.Run error: %v", err)
+	}
+	if strings.Contains(p.req.Messages[0].Content, "## Clarifier session") {
+		t.Error("critic user message should not contain '## Clarifier session' when ClarifierNotes is empty")
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -490,6 +490,55 @@ func (o *Orchestrator) Run(ctx context.Context) <-chan Event {
 	return out
 }
 
+// Recritique re-runs ONLY the Critic stage against the current agent
+// context. The expected caller is the headless interview loop: it has
+// just collected Clarifier answers, stashed them on
+// ctx.ClarifierNotes, and now wants a fresh verdict informed by those
+// answers — without re-running Scout (the repo hasn't changed).
+//
+// Recritique is only valid when the orchestrator is sitting at
+// StateAwaitUser. It overwrites the stored critic report and leaves
+// the state at StateAwaitUser so the caller can decide what to do
+// next (proceed to Continue, or interview again, or bail). Emits one
+// event on the returned channel and closes.
+func (o *Orchestrator) Recritique(ctx context.Context) <-chan Event {
+	out := make(chan Event, 4)
+	go func() {
+		defer close(out)
+
+		if o.state != StateAwaitUser {
+			o.emit(ctx, out, Event{
+				State: StateError,
+				Err:   fmt.Errorf("orchestrator: Recritique called from state %q, expected await_user", o.state),
+			})
+			o.state = StateError
+			return
+		}
+		if o.ctx == nil || o.ctx.ScoutReport == "" {
+			o.emit(ctx, out, Event{
+				State: StateError,
+				Err:   errors.New("orchestrator: Recritique requires a prior Scout+Critic pass"),
+			})
+			o.state = StateError
+			return
+		}
+
+		o.state = StateCritiquing
+		o.emit(ctx, out, Event{State: o.state, Message: "Critic re-evaluating with clarifier answers..."})
+		rpt, err := o.critic.Run(ctx, o.ctx)
+		if err != nil {
+			o.state = StateError
+			o.emit(ctx, out, Event{State: o.state, Err: err})
+			return
+		}
+		o.critRpt = rpt
+
+		o.state = StateAwaitUser
+		o.emit(ctx, out, Event{State: o.state, Message: "Critic recommends: " + rpt.Recommendation})
+	}()
+	return out
+}
+
 // emit fans an event out to both the TUI channel and the Reporter. It
 // stamps the event with a pointer to the current agents.Context so the
 // Reporter can read downstream artifacts (ScoutReport, CriticReport,

--- a/internal/orchestrator/recritique_test.go
+++ b/internal/orchestrator/recritique_test.go
@@ -1,0 +1,55 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aisu-ai/aidev/internal/agents"
+)
+
+// TestRecritiqueRefusesFromWrongState verifies that Recritique is a
+// strict state-machine transition from StateAwaitUser. If a caller
+// somehow invokes it mid-scout or after a kill, we must fail loudly
+// rather than silently re-running the Critic at the wrong point in
+// the pipeline.
+func TestRecritiqueRefusesFromWrongState(t *testing.T) {
+	cases := []State{StateInit, StateScouting, StateCritiquing, StateArchitecting, StateSketchesReady, StateDone, StateKilled}
+	for _, s := range cases {
+		o := &Orchestrator{state: s, ctx: &agents.Context{}}
+		ch := o.Recritique(context.Background())
+		var saw bool
+		for ev := range ch {
+			if ev.Err != nil && ev.State == StateError {
+				saw = true
+			}
+		}
+		if !saw {
+			t.Errorf("state=%q: expected Recritique to emit an error event", s)
+		}
+		if o.state != StateError {
+			t.Errorf("state=%q: expected Orchestrator.state=error after rejected Recritique, got %q", s, o.state)
+		}
+	}
+}
+
+// TestRecritiqueRequiresPriorScoutReport is the sanity guard for the
+// normal state (await_user) but with an empty agent context: even
+// though the state is right, there's nothing to critique. The method
+// should error, not crash.
+func TestRecritiqueRequiresPriorScoutReport(t *testing.T) {
+	o := &Orchestrator{
+		state: StateAwaitUser,
+		ctx:   &agents.Context{}, // no ScoutReport
+	}
+	ch := o.Recritique(context.Background())
+	var gotErr bool
+	for ev := range ch {
+		if ev.Err != nil {
+			gotErr = true
+		}
+	}
+	if !gotErr {
+		t.Error("expected Recritique to error when ScoutReport is empty")
+	}
+}
+

--- a/internal/plugin/files/aidev-run.md
+++ b/internal/plugin/files/aidev-run.md
@@ -1,7 +1,7 @@
 ---
 description: Run the full aidev agent pipeline on a GitHub issue
 argument-hint: <issue-number-or-url> [repo-path]
-allowed-tools: Bash(aidev:*)
+allowed-tools: Bash(aidev:*), Write
 ---
 
 You are driving `aidev`, the multi-agent coding tool.
@@ -38,15 +38,72 @@ The Bash call matches `Bash(aidev:*)` and passes the permission
 layer cleanly because it's a single `aidev` invocation with no
 surrounding shell logic.
 
-STEP 3 — After the command finishes, summarise the output for the
-user:
-  - what the Critic recommended (build / defer / kill / unclear)
-  - how many sketches the Architect produced (if build)
+STEP 3 — Read the Critic verdict from the output.
+
+  - **build** → proceed to STEP 5.
+  - **kill** → STOP. The Critic killed the proposal on principle;
+    looping is not the answer. Report the rationale verbatim and let
+    the user decide whether to override out-of-band.
+  - **unclear** or **defer** → do NOT stop. Go to STEP 4.
+
+STEP 4 (interview) — The Critic has sharp questions that need human
+input before a build verdict is reachable. Your job is to interview
+the user, persist their answers where aidev can see them, and re-run
+the pipeline.
+
+Sub-step 4a: Extract the Critic's sharp questions from the report.
+They're in a section titled roughly "Sharp questions" or numbered
+1/2/3 under the FOR/AGAINST arguments. There are usually 2–3 of
+them.
+
+Sub-step 4b: Ask the user each question, one at a time, using the
+`AskUserQuestion` tool. Keep the question text short and close to
+the Critic's own wording. If a question is multi-part, split it.
+Give the user an "escape" option ("let me think / stop pipeline")
+on every question so they're never forced into an answer.
+
+Sub-step 4c: Once you have answers, WRITE them to
+`<repo>/.aidev/clarifier.md` using the Write tool with this exact
+shape — aidev's Scout already knows how to pick up this file on the
+next run:
+
+    # Clarifier session
+
+    _Recorded by Claude Code._
+
+    ## Wave 1
+
+    ### q1 — <the first question you asked>
+
+    **Answer:** <the user's answer>
+
+    ### q2 — <the second question>
+
+    **Answer:** <the user's answer>
+
+    ...
+
+Use `q1`, `q2`, … as IDs. If a question depended on an earlier
+answer, put it in a `## Wave 2` section instead.
+
+Sub-step 4d: Re-invoke the SAME aidev command from STEP 2. The new
+run will pick up `.aidev/clarifier.md` automatically via the Scout
+and the Critic will re-decide with the human's answers as
+authoritative input.
+
+After the second run, go back to STEP 3. Do this at most TWICE
+(i.e. up to two interview rounds). If the Critic still refuses
+after two rounds, stop and report the latest verdict verbatim —
+the Critic is telling you something real.
+
+STEP 5 — Once the Critic says **build** and the Architect +
+Implementer have run, summarise the final state for the user:
+  - what the Critic recommended
+  - how many sketches the Architect produced
   - whether the Implementer wrote a patch at
     `<repo>/.aidev/proposed.patch`
   - any doctor warnings
 
-If the Critic recommended `kill` or `defer`, stop and report the
-rationale verbatim. Surface the Critic's sharp questions to the user
-and ask how they want to proceed. Don't push them to override the
-Critic — that's the entire point of the tool.
+Never push the user to override a `kill` verdict; that is the entire
+point of the tool. A `defer` or `unclear` verdict, however, is an
+invitation to dialogue — which is exactly what STEP 4 is for.

--- a/plugin/aidev/commands/aidev-run.md
+++ b/plugin/aidev/commands/aidev-run.md
@@ -1,7 +1,7 @@
 ---
 description: Run the full aidev agent pipeline on a GitHub issue
 argument-hint: <issue-number-or-url> [repo-path]
-allowed-tools: Bash(aidev:*)
+allowed-tools: Bash(aidev:*), Write
 ---
 
 You are driving `aidev`, the multi-agent coding tool.
@@ -38,15 +38,72 @@ The Bash call matches `Bash(aidev:*)` and passes the permission
 layer cleanly because it's a single `aidev` invocation with no
 surrounding shell logic.
 
-STEP 3 — After the command finishes, summarise the output for the
-user:
-  - what the Critic recommended (build / defer / kill / unclear)
-  - how many sketches the Architect produced (if build)
+STEP 3 — Read the Critic verdict from the output.
+
+  - **build** → proceed to STEP 5.
+  - **kill** → STOP. The Critic killed the proposal on principle;
+    looping is not the answer. Report the rationale verbatim and let
+    the user decide whether to override out-of-band.
+  - **unclear** or **defer** → do NOT stop. Go to STEP 4.
+
+STEP 4 (interview) — The Critic has sharp questions that need human
+input before a build verdict is reachable. Your job is to interview
+the user, persist their answers where aidev can see them, and re-run
+the pipeline.
+
+Sub-step 4a: Extract the Critic's sharp questions from the report.
+They're in a section titled roughly "Sharp questions" or numbered
+1/2/3 under the FOR/AGAINST arguments. There are usually 2–3 of
+them.
+
+Sub-step 4b: Ask the user each question, one at a time, using the
+`AskUserQuestion` tool. Keep the question text short and close to
+the Critic's own wording. If a question is multi-part, split it.
+Give the user an "escape" option ("let me think / stop pipeline")
+on every question so they're never forced into an answer.
+
+Sub-step 4c: Once you have answers, WRITE them to
+`<repo>/.aidev/clarifier.md` using the Write tool with this exact
+shape — aidev's Scout already knows how to pick up this file on the
+next run:
+
+    # Clarifier session
+
+    _Recorded by Claude Code._
+
+    ## Wave 1
+
+    ### q1 — <the first question you asked>
+
+    **Answer:** <the user's answer>
+
+    ### q2 — <the second question>
+
+    **Answer:** <the user's answer>
+
+    ...
+
+Use `q1`, `q2`, … as IDs. If a question depended on an earlier
+answer, put it in a `## Wave 2` section instead.
+
+Sub-step 4d: Re-invoke the SAME aidev command from STEP 2. The new
+run will pick up `.aidev/clarifier.md` automatically via the Scout
+and the Critic will re-decide with the human's answers as
+authoritative input.
+
+After the second run, go back to STEP 3. Do this at most TWICE
+(i.e. up to two interview rounds). If the Critic still refuses
+after two rounds, stop and report the latest verdict verbatim —
+the Critic is telling you something real.
+
+STEP 5 — Once the Critic says **build** and the Architect +
+Implementer have run, summarise the final state for the user:
+  - what the Critic recommended
+  - how many sketches the Architect produced
   - whether the Implementer wrote a patch at
     `<repo>/.aidev/proposed.patch`
   - any doctor warnings
 
-If the Critic recommended `kill` or `defer`, stop and report the
-rationale verbatim. Surface the Critic's sharp questions to the user
-and ask how they want to proceed. Don't push them to override the
-Critic — that's the entire point of the tool.
+Never push the user to override a `kill` verdict; that is the entire
+point of the tool. A `defer` or `unclear` verdict, however, is an
+invitation to dialogue — which is exactly what STEP 4 is for.


### PR DESCRIPTION
## Summary

Previously when the Critic returned `unclear` or `defer`, the pipeline halted with a list of sharp questions but no way to answer them. The user was dropped back to the shell. This change makes aidev interview the developer instead.

## Two complementary interview paths

### 1. In-process TTY interview (direct shell usage)

When `aidev -headless -auto` runs from a terminal with a real TTY:

- Calls the existing `Clarifier` agent to turn the Critic’s sharp questions into a dependency-aware `QuestionGraph`
- Walks the graph in waves, collecting stdin answers (same `bufio.Reader` pattern as `aidev clarify`)
- Persists the session to `.aidev/clarifier.md`
- Stashes the answers on `agents.Context.ClarifierNotes`
- Calls a new `Orchestrator.Recritique()` which re-runs ONLY the Critic (no Scout rework; the repo did not change)
- Loops up to 2 rounds before giving up

`kill` always halts without an interview; looping on a rejection is not useful. `build` stops the loop.

### 2. Claude-Code-driven interview (`/aidev-run` slash command)

The slash command runs under Claude Code’s Bash tool, which does NOT provide a TTY, so the in-process path above never fires for that workflow. Updated `aidev-run.md` so Claude drives the interview directly:

1. Extract the Critic’s sharp questions from the first run’s output
2. Ask them one at a time via `AskUserQuestion` (with an escape option)
3. Write answers to `<repo>/.aidev/clarifier.md` in the shape the Scout already reads
4. Re-invoke `aidev` for a second pass
5. Up to 2 rounds

## Plumbing

- `agents.Context` gains `ClarifierNotes string` (ephemeral, current run only; distinct from `Snapshot.ClarifierContent` which is the on-disk durable copy)
- `critic.go` threads `ClarifierNotes` into the user prompt under a `## Clarifier session` heading and teaches the system prompt to treat those answers as authoritative
- `orchestrator.go` adds `Recritique()` — a strict state-machine transition from `StateAwaitUser` with guard errors for wrong state and missing scout report

## Tests

- `TestCriticPromptIncludesClarifierNotes` / `TestCriticPromptOmitsClarifierSectionWhenEmpty` — prompt threading regression guards
- `TestRecritiqueRefusesFromWrongState` / `TestRecritiqueRequiresPriorScoutReport` — state-machine guards

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Rebuild and run `/aidev-run 533` on issue #533, let the Critic return defer/unclear, confirm Claude walks the interview and the second pass reaches build
- [ ] Run `aidev -headless -auto` directly from a shell (TTY present) against the same issue and confirm the in-process interview drives Recritique