### PR TITLE
fix(critic): converge clarifier paths, harden re-ask discipline, add escape hatch

### DIFF
--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -120,6 +120,7 @@ func main() {
 		sketchN      = flag.Int("n", agents.DefaultSketchCount, "Number of Architect sketches to produce when the Critic recommends 'build'")
 		pickSketch   = flag.Int("sketch", 0, "Headless only: after Architect produces sketches, automatically run the Implementer on this sketch number (1-indexed). 0 disables.")
 		autoRun      = flag.Bool("auto", false, "Headless only: automatically run the Architect when the Critic recommends 'build' (otherwise stop at Critic)")
+		forceVerdict = flag.String("force-verdict", "", "Headless only: ESCAPE HATCH. After running Scout+Critic (and any interview rounds), override the Critic's verdict with this value: build|defer|kill. Use ONLY when you have answered the Critic's questions and the Critic is still hedging. Always logged loudly so you can see when the override fired.")
 		skipDoctor   = flag.Bool("skip-doctor", false, "Skip the startup precondition check (not recommended)")
 		noAuditTrail = flag.Bool("no-audit-trail", false, "Disable posting aidev progress + artifacts to the GitHub issue")
 	)
@@ -196,7 +197,16 @@ func main() {
 	}
 
 	if *headless {
-		runHeadless(ctx, orch, cfg, absRepo, *autoRun, *pickSketch)
+		// Validate -force-verdict early so a typo fails fast instead of
+		// silently being treated as "no override". Empty string means
+		// the flag isn't set; otherwise it must be a recognised verdict.
+		switch *forceVerdict {
+		case "", "build", "defer", "kill":
+			// ok
+		default:
+			fatal(fmt.Sprintf("invalid -force-verdict %q (must be build, defer, or kill)", *forceVerdict))
+		}
+		runHeadless(ctx, orch, cfg, absRepo, *autoRun, *pickSketch, *forceVerdict)
 		return
 	}
 
@@ -787,7 +797,13 @@ func discoverConfigDir() string {
 // re-runs the Critic. Up to 2 interview rounds total — if the Critic
 // still refuses, we halt and report the latest verdict. A "kill"
 // verdict always halts without an interview; killing is explicit.
-func runHeadless(ctx context.Context, orch *orchestrator.Orchestrator, cfg *config.Config, absRepo string, auto bool, pickSketch int) {
+//
+// forceVerdict ("build" / "defer" / "kill" / "") is the escape hatch
+// for cases where the Critic keeps hedging despite answered questions.
+// When non-empty it overrides the Critic's recommendation AFTER the
+// normal pipeline (and any interview rounds) have run, and the
+// override is logged loudly so the user always sees it fired.
+func runHeadless(ctx context.Context, orch *orchestrator.Orchestrator, cfg *config.Config, absRepo string, auto bool, pickSketch int, forceVerdict string) {
 	for ev := range orch.Run(ctx) {
 		if ev.Err != nil {
 			fatal(ev.Err.Error())
@@ -819,6 +835,23 @@ func runHeadless(ctx context.Context, orch *orchestrator.Orchestrator, cfg *conf
 	// build/kill (nothing to clarify).
 	if auto && rpt != nil && doctor.IsTTY() {
 		rpt = runInterviewLoop(ctx, orch, cfg, absRepo, rpt)
+	}
+
+	// Apply the user's escape-hatch override AFTER the natural Critic
+	// + interview pipeline has run. We always run the Critic first so
+	// the override is informed (you see what the Critic actually said
+	// before you overrule it), and so the on-disk audit trail and any
+	// downstream tooling that reads o.CriticReport() still has the
+	// real verdict for context.
+	if forceVerdict != "" && rpt != nil && rpt.Recommendation != forceVerdict {
+		fmt.Println()
+		fmt.Printf("## Verdict overridden by user\n\n")
+		fmt.Printf("Critic recommended **%s**.\n", rpt.Recommendation)
+		fmt.Printf("User passed `-force-verdict %s`. Proceeding as if the Critic had said %s.\n",
+			forceVerdict, forceVerdict)
+		fmt.Println()
+		fmt.Println("This is the escape hatch. The Critic's report above is the audit trail; the override is your call and your responsibility.")
+		rpt.Recommendation = forceVerdict
 	}
 
 	if !auto || rpt == nil || rpt.Recommendation != "build" {

--- a/internal/agents/critic.go
+++ b/internal/agents/critic.go
@@ -72,17 +72,53 @@ You MUST:
 Do NOT hedge the recommendation. If the evidence is mixed, choose "unclear"
 and say what evidence would move you.
 
-If a "Clarifier session" section is present in the input below, it contains
-the human's direct answers to sharp questions YOU raised in a prior pass.
-Treat those answers as authoritative: they are ground truth about intent,
-scope, and environment that overrides any assumption you might otherwise
-make. Re-decide the verdict in light of them — do NOT re-ask the same
-questions unless the answers themselves raised new ambiguities.`
+If a "Clarifier session" section is present in the input below, it
+contains the human's direct answers to sharp questions YOU raised in a
+prior pass. Treat those answers as AUTHORITATIVE GROUND TRUTH:
+
+  - The user has decided. Their answers are not a starting point for
+    further interrogation.
+  - You may NOT re-ask any question that has already been answered in
+    the Clarifier session, even in a slightly rephrased form. If you
+    find yourself wanting to demand more evidence for an answered
+    question, the answer itself IS the evidence — that is the entire
+    point of the Clarifier loop.
+  - You may still raise NEW questions that the existing answers
+    surfaced — but only if those questions could not have been
+    foreseen from the original sharp questions you raised.
+  - If the Clarifier section materially resolves the ambiguity that
+    drove a prior 'unclear' or 'defer' verdict, your new verdict
+    SHOULD be 'build' (or, if the answers reveal a fatal flaw, 'kill').
+    Re-emitting 'unclear' or 'defer' after the user has answered is a
+    failure mode: it means the loop made no progress and the user is
+    stuck. Avoid it unless the answers literally created NEW
+    ambiguity.`
 
 	// Marshal the principles into a compact, quotable block.
 	var principles strings.Builder
 	for _, p := range cc.Principles {
 		fmt.Fprintf(&principles, "- **%s** — %s\n  %s\n", p.Name, p.Summary, oneLine(p.Description))
+	}
+
+	// Resolve the Clarifier content for this run. Two sources can supply
+	// it and they MUST converge on the same authoritative section in
+	// the prompt — otherwise the slash-command flow (which writes
+	// .aidev/clarifier.md to disk) would silently bypass the
+	// "treat as authoritative" plumbing the in-process TTY interview
+	// goes through:
+	//
+	//  1. cc.ClarifierNotes — set by the in-process headless TTY
+	//     interview right before calling Recritique. Highest priority
+	//     because it reflects the answers collected in THIS run.
+	//
+	//  2. cc.Snapshot.ClarifierContent — the persisted .aidev/clarifier.md
+	//     file on disk, populated by the repo Scout snapshot. This is
+	//     how Claude Code's slash-command interview hands answers to
+	//     aidev: it writes the file, then re-invokes us. Used only when
+	//     ClarifierNotes is empty so the in-memory copy always wins.
+	clarifier := strings.TrimSpace(cc.ClarifierNotes)
+	if clarifier == "" && cc.Snapshot != nil {
+		clarifier = strings.TrimSpace(cc.Snapshot.ClarifierContent)
 	}
 
 	var user strings.Builder
@@ -92,9 +128,9 @@ questions unless the answers themselves raised new ambiguities.`
 	user.WriteString(cc.ScoutReport)
 	user.WriteString("\n\n## Engineering principles\n\n")
 	user.WriteString(principles.String())
-	if strings.TrimSpace(cc.ClarifierNotes) != "" {
-		user.WriteString("\n\n## Clarifier session (human answers to your previous sharp questions — authoritative)\n\n")
-		user.WriteString(cc.ClarifierNotes)
+	if clarifier != "" {
+		user.WriteString("\n\n## Clarifier session (human answers to your previous sharp questions — AUTHORITATIVE GROUND TRUTH)\n\n")
+		user.WriteString(clarifier)
 	}
 
 	resp, err := c.Provider.Complete(ctx, llm.Request{

--- a/internal/agents/critic_test.go
+++ b/internal/agents/critic_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aisu-ai/aidev/internal/github"
 	"github.com/aisu-ai/aidev/internal/llm"
+	"github.com/aisu-ai/aidev/internal/repo"
 )
 
 // capturingProvider records the last Request it was asked to
@@ -78,9 +79,10 @@ func TestCriticPromptIncludesClarifierNotes(t *testing.T) {
 }
 
 // TestCriticPromptOmitsClarifierSectionWhenEmpty is the negative
-// case: if ClarifierNotes is empty, the user message must NOT contain
-// the Clarifier heading (otherwise we'd be teaching the model to
-// expect authoritative human input that isn't there).
+// case: if both in-memory ClarifierNotes AND the on-disk
+// Snapshot.ClarifierContent are empty, the user message must NOT
+// contain the Clarifier heading (otherwise we'd be teaching the
+// model to expect authoritative human input that isn't there).
 func TestCriticPromptOmitsClarifierSectionWhenEmpty(t *testing.T) {
 	p := &capturingProvider{reply: "body\nRECOMMENDATION: unclear\n"}
 	c := &Critic{Provider: p}
@@ -96,5 +98,73 @@ func TestCriticPromptOmitsClarifierSectionWhenEmpty(t *testing.T) {
 	}
 	if strings.Contains(p.req.Messages[0].Content, "## Clarifier session") {
 		t.Error("critic user message should not contain '## Clarifier session' when ClarifierNotes is empty")
+	}
+}
+
+// TestCriticPromptFallsBackToSnapshotClarifier is the regression
+// guard for the slash-command interview path: when the user's Claude
+// session writes .aidev/clarifier.md and re-invokes aidev, the
+// Snapshot will contain ClarifierContent but ClarifierNotes will be
+// empty. The Critic must still surface the disk-loaded clarifier
+// under the AUTHORITATIVE GROUND TRUTH heading — otherwise the
+// authoritative-input plumbing only fires for the in-process TTY
+// flow and the slash-command path silently bypasses it.
+func TestCriticPromptFallsBackToSnapshotClarifier(t *testing.T) {
+	p := &capturingProvider{reply: "body\nRECOMMENDATION: build\n"}
+	c := &Critic{Provider: p}
+	cc := &Context{
+		Issue: &github.Issue{
+			Owner: "aisu-ai", Repo: "aidev", Number: 1,
+			Title: "T", Body: "issue body",
+		},
+		ScoutReport: "scout brief body",
+		Snapshot: &repo.Snapshot{
+			ClarifierContent: "## Wave 1\n\n### q1 — is contactSales body copy?\n\n**Answer:** yes, body copy, exclude from refactor",
+		},
+		// ClarifierNotes intentionally left empty.
+	}
+	if _, err := c.Run(context.Background(), cc); err != nil {
+		t.Fatalf("Critic.Run error: %v", err)
+	}
+	userMsg := p.req.Messages[0].Content
+	if !strings.Contains(userMsg, "## Clarifier session") {
+		t.Errorf("critic user message missing '## Clarifier session' heading despite Snapshot fallback; got:\n%s", userMsg)
+	}
+	if !strings.Contains(userMsg, "is contactSales body copy?") {
+		t.Errorf("critic user message missing the snapshot clarifier Q text; got:\n%s", userMsg)
+	}
+	if !strings.Contains(userMsg, "exclude from refactor") {
+		t.Errorf("critic user message missing the snapshot clarifier A text; got:\n%s", userMsg)
+	}
+}
+
+// TestCriticPromptInMemoryClarifierWinsOverSnapshot guards the
+// priority: when both sources are present (e.g. an in-process
+// interview happens in the same run that already had a stale
+// .aidev/clarifier.md on disk), the in-memory copy reflects the
+// latest answers and MUST take precedence.
+func TestCriticPromptInMemoryClarifierWinsOverSnapshot(t *testing.T) {
+	p := &capturingProvider{reply: "body\nRECOMMENDATION: build\n"}
+	c := &Critic{Provider: p}
+	cc := &Context{
+		Issue: &github.Issue{
+			Owner: "aisu-ai", Repo: "aidev", Number: 1,
+			Title: "T", Body: "issue body",
+		},
+		ScoutReport: "scout brief body",
+		Snapshot: &repo.Snapshot{
+			ClarifierContent: "STALE-DISK-COPY",
+		},
+		ClarifierNotes: "FRESH-IN-MEMORY-ANSWERS",
+	}
+	if _, err := c.Run(context.Background(), cc); err != nil {
+		t.Fatalf("Critic.Run error: %v", err)
+	}
+	userMsg := p.req.Messages[0].Content
+	if !strings.Contains(userMsg, "FRESH-IN-MEMORY-ANSWERS") {
+		t.Errorf("critic user message missing in-memory clarifier; got:\n%s", userMsg)
+	}
+	if strings.Contains(userMsg, "STALE-DISK-COPY") {
+		t.Errorf("critic user message should not contain stale disk copy when in-memory is set; got:\n%s", userMsg)
 	}
 }

--- a/internal/plugin/files/aidev-run.md
+++ b/internal/plugin/files/aidev-run.md
@@ -1,7 +1,7 @@
 ---
 description: Run the full aidev agent pipeline on a GitHub issue
 argument-hint: <issue-number-or-url> [repo-path]
-allowed-tools: Bash(aidev:*), Write
+allowed-tools: Bash(aidev:*), Read, Grep, Glob, Write, AskUserQuestion
 ---
 
 You are driving `aidev`, the multi-agent coding tool.
@@ -34,38 +34,50 @@ Where `<ISSUE>` is the literal first token from `$ARGUMENTS` and
 `<PATH>` is the literal second token (or `.` if unset). Expand `~`
 to `$HOME`. Wrap the path in double quotes if it contains spaces.
 
-The Bash call matches `Bash(aidev:*)` and passes the permission
-layer cleanly because it's a single `aidev` invocation with no
-surrounding shell logic.
-
 STEP 3 — Read the Critic verdict from the output.
 
-  - **build** → proceed to STEP 5.
+  - **build** → proceed to STEP 6.
   - **kill** → STOP. The Critic killed the proposal on principle;
     looping is not the answer. Report the rationale verbatim and let
     the user decide whether to override out-of-band.
   - **unclear** or **defer** → do NOT stop. Go to STEP 4.
 
-STEP 4 (interview) — The Critic has sharp questions that need human
-input before a build verdict is reachable. Your job is to interview
-the user, persist their answers where aidev can see them, and re-run
-the pipeline.
+STEP 4 (self-research) — Before bothering the user, try to answer
+the Critic's sharp questions yourself by reading the codebase. You
+have `Read`, `Grep`, and `Glob`. Most Critic questions fall into two
+buckets:
 
-Sub-step 4a: Extract the Critic's sharp questions from the report.
-They're in a section titled roughly "Sharp questions" or numbered
-1/2/3 under the FOR/AGAINST arguments. There are usually 2–3 of
-them.
+  - **Evidence questions** — "are there other consumers of X?",
+    "is this a button label or body copy?", "does the existing
+    namespace already include Y?", "what is the blast radius of
+    deleting Z?". These are answerable from the repo. Run the greps
+    and reads YOURSELF and produce concrete findings: file paths,
+    line numbers, snippets. The user should not be asked things you
+    can verify in a few seconds.
 
-Sub-step 4b: Ask the user each question, one at a time, using the
-`AskUserQuestion` tool. Keep the question text short and close to
-the Critic's own wording. If a question is multi-part, split it.
+  - **Judgment questions** — "should we ship now or split into a
+    follow-up?", "do non-English locales need native-reviewer
+    signoff?", "is this the right priority?". These need the human.
+    Save them for STEP 5.
+
+When you classify a Critic question as "evidence", run the actual
+investigation (Grep across the WHOLE repo, not just one subdir;
+Read the actual call sites; Glob the file types the Critic is
+worried about including markdown, MDX, JSON, generated types,
+storybooks, tests, analytics events). Capture the literal output
+you got — file paths and line numbers count, hand-waving doesn't.
+
+STEP 5 (judgment interview) — For the questions that survived STEP 4
+(human-judgment questions only), ask the user one at a time using
+the `AskUserQuestion` tool. Keep the question text short and close
+to the Critic's wording. If a question is multi-part, split it.
 Give the user an "escape" option ("let me think / stop pipeline")
 on every question so they're never forced into an answer.
 
-Sub-step 4c: Once you have answers, WRITE them to
-`<repo>/.aidev/clarifier.md` using the Write tool with this exact
-shape — aidev's Scout already knows how to pick up this file on the
-next run:
+After collecting answers, WRITE the full clarifier session to
+`<repo>/.aidev/clarifier.md` using the Write tool. Include BOTH
+the evidence findings from STEP 4 AND the user's answers from
+STEP 5. The on-disk format aidev's Scout reads:
 
     # Clarifier session
 
@@ -73,32 +85,50 @@ next run:
 
     ## Wave 1
 
-    ### q1 — <the first question you asked>
+    ### q1 — <question>
 
-    **Answer:** <the user's answer>
+    **Answer:** <evidence finding from STEP 4 OR user answer from STEP 5>
 
-    ### q2 — <the second question>
+    ### q2 — <question>
 
-    **Answer:** <the user's answer>
+    **Answer:** <...>
 
     ...
 
-Use `q1`, `q2`, … as IDs. If a question depended on an earlier
-answer, put it in a `## Wave 2` section instead.
+Use `q1`, `q2`, … as IDs. Mark each Answer as either
+`(evidence — Claude Code)` or `(user)` so the audit trail makes
+clear which findings came from research vs. from the developer.
 
-Sub-step 4d: Re-invoke the SAME aidev command from STEP 2. The new
-run will pick up `.aidev/clarifier.md` automatically via the Scout
-and the Critic will re-decide with the human's answers as
-authoritative input.
+Then re-invoke the SAME aidev command from STEP 2. aidev's Critic
+will pick up `.aidev/clarifier.md` and re-decide with both your
+research and the user's judgment as authoritative input.
 
-After the second run, go back to STEP 3. Do this at most TWICE
-(i.e. up to two interview rounds). If the Critic still refuses
-after two rounds, stop and report the latest verdict verbatim —
-the Critic is telling you something real.
+Do this STEP 4 → STEP 5 → re-invoke loop AT MOST TWICE.
 
-STEP 5 — Once the Critic says **build** and the Architect +
-Implementer have run, summarise the final state for the user:
-  - what the Critic recommended
+STEP 5b (escape hatch — only after 2 full interview rounds) — If
+after two rounds the Critic is STILL hedging and the user has
+genuinely answered every question that requires human judgment,
+ask the user ONE final question via `AskUserQuestion`:
+
+  > "The Critic is still hedging despite the answers we collected.
+  > Would you like to force aidev to proceed to Architect + Implementer
+  > anyway? The Critic's report stays in the audit trail."
+
+Options: "Force build" / "Stop here". On "Force build", re-invoke
+aidev one more time with the additional flag:
+
+    aidev -headless -auto -sketch 1 -force-verdict build -issue <ISSUE> -repo <PATH>
+
+This is a hard escape hatch. It logs loudly in aidev's output so
+the override is always visible in the run history. Do NOT reach for
+it before the two interview rounds — it bypasses the entire point
+of the Critic. Use it only when you're confident the Critic is
+spinning on questions the human has already resolved.
+
+STEP 6 — Once the Critic says **build** (or the user has forced
+build) and the Architect + Implementer have run, summarise the
+final state for the user:
+  - what the Critic recommended (and whether it was overridden)
   - how many sketches the Architect produced
   - whether the Implementer wrote a patch at
     `<repo>/.aidev/proposed.patch`
@@ -106,4 +136,4 @@ Implementer have run, summarise the final state for the user:
 
 Never push the user to override a `kill` verdict; that is the entire
 point of the tool. A `defer` or `unclear` verdict, however, is an
-invitation to dialogue — which is exactly what STEP 4 is for.
+invitation to dialogue — which is exactly what STEPS 4 and 5 are for.

--- a/plugin/aidev/commands/aidev-run.md
+++ b/plugin/aidev/commands/aidev-run.md
@@ -1,7 +1,7 @@
 ---
 description: Run the full aidev agent pipeline on a GitHub issue
 argument-hint: <issue-number-or-url> [repo-path]
-allowed-tools: Bash(aidev:*), Write
+allowed-tools: Bash(aidev:*), Read, Grep, Glob, Write, AskUserQuestion
 ---
 
 You are driving `aidev`, the multi-agent coding tool.
@@ -34,38 +34,50 @@ Where `<ISSUE>` is the literal first token from `$ARGUMENTS` and
 `<PATH>` is the literal second token (or `.` if unset). Expand `~`
 to `$HOME`. Wrap the path in double quotes if it contains spaces.
 
-The Bash call matches `Bash(aidev:*)` and passes the permission
-layer cleanly because it's a single `aidev` invocation with no
-surrounding shell logic.
-
 STEP 3 — Read the Critic verdict from the output.
 
-  - **build** → proceed to STEP 5.
+  - **build** → proceed to STEP 6.
   - **kill** → STOP. The Critic killed the proposal on principle;
     looping is not the answer. Report the rationale verbatim and let
     the user decide whether to override out-of-band.
   - **unclear** or **defer** → do NOT stop. Go to STEP 4.
 
-STEP 4 (interview) — The Critic has sharp questions that need human
-input before a build verdict is reachable. Your job is to interview
-the user, persist their answers where aidev can see them, and re-run
-the pipeline.
+STEP 4 (self-research) — Before bothering the user, try to answer
+the Critic's sharp questions yourself by reading the codebase. You
+have `Read`, `Grep`, and `Glob`. Most Critic questions fall into two
+buckets:
 
-Sub-step 4a: Extract the Critic's sharp questions from the report.
-They're in a section titled roughly "Sharp questions" or numbered
-1/2/3 under the FOR/AGAINST arguments. There are usually 2–3 of
-them.
+  - **Evidence questions** — "are there other consumers of X?",
+    "is this a button label or body copy?", "does the existing
+    namespace already include Y?", "what is the blast radius of
+    deleting Z?". These are answerable from the repo. Run the greps
+    and reads YOURSELF and produce concrete findings: file paths,
+    line numbers, snippets. The user should not be asked things you
+    can verify in a few seconds.
 
-Sub-step 4b: Ask the user each question, one at a time, using the
-`AskUserQuestion` tool. Keep the question text short and close to
-the Critic's own wording. If a question is multi-part, split it.
+  - **Judgment questions** — "should we ship now or split into a
+    follow-up?", "do non-English locales need native-reviewer
+    signoff?", "is this the right priority?". These need the human.
+    Save them for STEP 5.
+
+When you classify a Critic question as "evidence", run the actual
+investigation (Grep across the WHOLE repo, not just one subdir;
+Read the actual call sites; Glob the file types the Critic is
+worried about including markdown, MDX, JSON, generated types,
+storybooks, tests, analytics events). Capture the literal output
+you got — file paths and line numbers count, hand-waving doesn't.
+
+STEP 5 (judgment interview) — For the questions that survived STEP 4
+(human-judgment questions only), ask the user one at a time using
+the `AskUserQuestion` tool. Keep the question text short and close
+to the Critic's wording. If a question is multi-part, split it.
 Give the user an "escape" option ("let me think / stop pipeline")
 on every question so they're never forced into an answer.
 
-Sub-step 4c: Once you have answers, WRITE them to
-`<repo>/.aidev/clarifier.md` using the Write tool with this exact
-shape — aidev's Scout already knows how to pick up this file on the
-next run:
+After collecting answers, WRITE the full clarifier session to
+`<repo>/.aidev/clarifier.md` using the Write tool. Include BOTH
+the evidence findings from STEP 4 AND the user's answers from
+STEP 5. The on-disk format aidev's Scout reads:
 
     # Clarifier session
 
@@ -73,32 +85,50 @@ next run:
 
     ## Wave 1
 
-    ### q1 — <the first question you asked>
+    ### q1 — <question>
 
-    **Answer:** <the user's answer>
+    **Answer:** <evidence finding from STEP 4 OR user answer from STEP 5>
 
-    ### q2 — <the second question>
+    ### q2 — <question>
 
-    **Answer:** <the user's answer>
+    **Answer:** <...>
 
     ...
 
-Use `q1`, `q2`, … as IDs. If a question depended on an earlier
-answer, put it in a `## Wave 2` section instead.
+Use `q1`, `q2`, … as IDs. Mark each Answer as either
+`(evidence — Claude Code)` or `(user)` so the audit trail makes
+clear which findings came from research vs. from the developer.
 
-Sub-step 4d: Re-invoke the SAME aidev command from STEP 2. The new
-run will pick up `.aidev/clarifier.md` automatically via the Scout
-and the Critic will re-decide with the human's answers as
-authoritative input.
+Then re-invoke the SAME aidev command from STEP 2. aidev's Critic
+will pick up `.aidev/clarifier.md` and re-decide with both your
+research and the user's judgment as authoritative input.
 
-After the second run, go back to STEP 3. Do this at most TWICE
-(i.e. up to two interview rounds). If the Critic still refuses
-after two rounds, stop and report the latest verdict verbatim —
-the Critic is telling you something real.
+Do this STEP 4 → STEP 5 → re-invoke loop AT MOST TWICE.
 
-STEP 5 — Once the Critic says **build** and the Architect +
-Implementer have run, summarise the final state for the user:
-  - what the Critic recommended
+STEP 5b (escape hatch — only after 2 full interview rounds) — If
+after two rounds the Critic is STILL hedging and the user has
+genuinely answered every question that requires human judgment,
+ask the user ONE final question via `AskUserQuestion`:
+
+  > "The Critic is still hedging despite the answers we collected.
+  > Would you like to force aidev to proceed to Architect + Implementer
+  > anyway? The Critic's report stays in the audit trail."
+
+Options: "Force build" / "Stop here". On "Force build", re-invoke
+aidev one more time with the additional flag:
+
+    aidev -headless -auto -sketch 1 -force-verdict build -issue <ISSUE> -repo <PATH>
+
+This is a hard escape hatch. It logs loudly in aidev's output so
+the override is always visible in the run history. Do NOT reach for
+it before the two interview rounds — it bypasses the entire point
+of the Critic. Use it only when you're confident the Critic is
+spinning on questions the human has already resolved.
+
+STEP 6 — Once the Critic says **build** (or the user has forced
+build) and the Architect + Implementer have run, summarise the
+final state for the user:
+  - what the Critic recommended (and whether it was overridden)
   - how many sketches the Architect produced
   - whether the Implementer wrote a patch at
     `<repo>/.aidev/proposed.patch`
@@ -106,4 +136,4 @@ Implementer have run, summarise the final state for the user:
 
 Never push the user to override a `kill` verdict; that is the entire
 point of the tool. A `defer` or `unclear` verdict, however, is an
-invitation to dialogue — which is exactly what STEP 4 is for.
+invitation to dialogue — which is exactly what STEPS 4 and 5 are for.


### PR DESCRIPTION
## Summary

Three bugs surfaced when the user ran the slash-command interview flow against a stubborn Critic and watched it loop without converging.

### 1. Slash-command interview path bypassed authoritative-input plumbing
When Claude Code writes `.aidev/clarifier.md` and re-invokes aidev, the file lands in `Snapshot.ClarifierContent`. But `Critic.Run` only consumed the new in-memory `Context.ClarifierNotes`, which is set ONLY by the in-process TTY interview path. The slash-command flow delivered the clarifier indirectly via the Scout brief and never under the dedicated AUTHORITATIVE GROUND TRUTH heading that exists specifically to override Critic skepticism.

**Fix**: in `Critic.Run`, fall back to `Snapshot.ClarifierContent` when `ClarifierNotes` is empty. Both interview paths now converge on the same authoritative-input mechanism. In-memory wins when both are present so the freshest answers always take precedence.

### 2. Critic prompt did not forbid re-asking answered questions
The user saw the Critic spinning on the same sharp questions across two interview rounds even after explicit answers. Strengthened the system prompt with explicit rules: the user answers ARE the evidence, re-asking is a failure mode, the verdict SHOULD move to build (or kill) when ambiguity is materially resolved.

### 3. No escape hatch when the Critic kept hedging
The user explicitly answered "force build, answers stand" and the tool had no way to honor that. The Critic was sovereign by design, but the design fails when the user has accepted residual risk and the loop has stalled.

**Fix**: added `-force-verdict <build|defer|kill>`. Runs the normal Critic + interview pipeline first (so the audit trail captures what the Critic actually said), then overrides the recommendation in-place. The override is logged loudly under `## Verdict overridden by user` so it is always visible.

## Slash command updates

- **New STEP 4 (self-research)**: before bothering the user, Claude classifies each Critic question as evidence (answerable from the codebase via Read/Grep/Glob) vs. judgment (needs the human). It runs the greps itself and embeds findings in `clarifier.md` tagged `(evidence Claude Code)`. The user only gets asked questions they actually need to answer.
- **New STEP 5b (escape hatch)**: after two full interview rounds with no convergence, Claude offers the user a final 'force build' option that re-invokes aidev with `-force-verdict build`.

## Tests

- `TestCriticPromptFallsBackToSnapshotClarifier` regression guard for the slash-command path delivering authoritative input.
- `TestCriticPromptInMemoryClarifierWinsOverSnapshot` priority guard so a stale on-disk file never shadows the in-memory answers from the current run.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Rebuild + re-run `/aidev-run 533` against the CTA consolidation issue. Expect: Claude self-researches the grep questions, only asks the user about ship-now-vs-bundled and signoff, second pass converges on build (or, in the worst case, the user reaches the round-3 force-build escape hatch).