### PR TITLE
feat(implementer): NEED_FILES loop + teammate-not-checklist-writer prompt

### DIFF
--- a/internal/agents/implementer.go
+++ b/internal/agents/implementer.go
@@ -56,23 +56,53 @@ type Patch struct {
 // Size and count limits for the file-content loading pass. These keep
 // the second-turn prompt bounded regardless of what the first-turn
 // file picker returns.
+//
+// maxFileBytes is 128 KiB — large enough to fit a full locale JSON, a
+// large React component, or a non-trivial Go source file without
+// truncation. Truncation was the root cause of the v0.3a.1
+// "placeholder non-English translations" regression: the Implementer
+// saw a clipped copy of en/common.json and couldn't resolve the
+// canonical "Contact Sales" value in any other locale, so it
+// fabricated placeholders instead. 128 KiB eliminates that failure
+// mode for every realistic source file we've seen; anything beyond
+// that almost certainly shouldn't be in a single diff anyway.
+//
+// maxRequestedFiles is 40 — raised from 15 so a consolidation task
+// across N locales + M call sites still fits in the picker's budget.
+// Taskes that need more than 40 files should almost certainly be
+// split by the Architect into multiple sketches.
+//
+// maxNeedFilesRounds is the cap on the iterative NEED_FILES loop
+// (see generateDiff). Two extra rounds beyond the initial picker
+// means up to 3 generateDiff LLM calls per implementer run in the
+// worst case, which keeps cost predictable while giving the model
+// enough headroom to discover it needs files the picker missed.
 const (
-	maxRequestedFiles = 15
-	maxFileBytes      = 10 * 1024 // 10 KiB per file
+	maxRequestedFiles  = 40
+	maxFileBytes       = 128 * 1024
+	maxNeedFilesRounds = 2
 )
 
 // Run asks the LLM to produce a unified diff that implements the chosen
-// Sketch. v0.3a.1 drives a **two-turn conversation**:
+// Sketch. v0.3a.2 drives an **iterative agentic loop** on top of the
+// existing single-shot Provider interface:
 //
 //	Turn 1: send the full context chain plus a file inventory and ask
 //	        the model to list (as a JSON array) the files it needs to
 //	        see the contents of to write a correct patch.
 //	Turn 2: read those files from disk, embed their contents in the
 //	        prompt, and ask for the unified diff.
+//	Turn 2b (up to maxNeedFilesRounds times): if the model responds
+//	        with `NEED_FILES: [...]` instead of a diff, load those
+//	        files, merge them with the already-loaded contents, and
+//	        re-ask. This is the poor-man's tool-use loop aidev uses
+//	        until the llm.Provider interface gains native tool calls.
 //
-// This dramatically improves diff quality compared to v0.3a, which only
-// sent file names and not contents — the resulting diffs often failed
-// to apply cleanly because the model guessed at context lines.
+// The loop is bounded — no runaway cost, no accidental hallucination
+// of fresh requests — and every response must eventually terminate at
+// either `diff --git` (success) or `ERROR:` (hard fail). Silent punts
+// like `# no-op`, placeholder strings, or "I wrote a TODO.md for you"
+// are not allowed by the prompt and are rejected by the validator.
 //
 // chosen must be non-nil and must be one of the sketches already
 // produced by the Architect (live in c.Sketches). The caller is
@@ -100,8 +130,46 @@ func (i *Implementer) Run(ctx context.Context, c *Context, chosen *Sketch) (*Pat
 	// aborting — the model can still work with partial information.
 	contents := readFiles(c.Snapshot.Root, wanted)
 
-	// Turn 2: produce the diff with real file contents in hand.
-	return i.generateDiff(ctx, c, chosen, contents)
+	// Turn 2 (with up to maxNeedFilesRounds additional rounds): ask
+	// for the diff. If the model comes back with NEED_FILES instead,
+	// load the requested paths and retry with the expanded context.
+	for round := 0; round <= maxNeedFilesRounds; round++ {
+		patch, need, err := i.generateDiff(ctx, c, chosen, contents)
+		if err != nil {
+			return nil, err
+		}
+		if patch != nil {
+			return patch, nil
+		}
+		// The model responded with NEED_FILES. If we're already at
+		// the loop cap, fail loudly instead of quietly returning a
+		// half-cooked diff — the prompt promised a real diff and
+		// we're not going to let it slide.
+		if round == maxNeedFilesRounds {
+			return nil, fmt.Errorf("implementer: NEED_FILES limit reached (%d rounds) — model still requesting %v", maxNeedFilesRounds, need)
+		}
+		// De-duplicate against files already loaded so the model can't
+		// just keep asking for the same path over and over.
+		fresh := make([]string, 0, len(need))
+		for _, p := range need {
+			if _, have := contents[p]; have {
+				continue
+			}
+			fresh = append(fresh, p)
+		}
+		if len(fresh) == 0 {
+			return nil, fmt.Errorf("implementer: NEED_FILES requested only files that were already provided: %v", need)
+		}
+		more := readFiles(c.Snapshot.Root, fresh)
+		if len(more) == 0 {
+			return nil, fmt.Errorf("implementer: NEED_FILES requested %v but none of those paths exist on disk", fresh)
+		}
+		for p, body := range more {
+			contents[p] = body
+		}
+	}
+	// Unreachable — the loop above either returns a patch or errors.
+	return nil, errors.New("implementer: loop fell through unexpectedly")
 }
 
 // fileSelectionJSONRe extracts a JSON array from a potentially messy
@@ -292,17 +360,24 @@ func readFiles(repoRoot string, paths []string) map[string]string {
 	return out
 }
 
-// generateDiff is turn 2. Same prompt shape as the old single-turn
-// Run() but with the requested file contents embedded. Kept separate
-// from selectFiles so tests and callers can exercise the two phases
-// independently.
-func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sketch, contents map[string]string) (*Patch, error) {
+// generateDiff is turn 2. Returns (patch, nil, nil) on success, or
+// (nil, neededPaths, nil) if the model asked for more files via the
+// NEED_FILES protocol, or (nil, nil, err) on any hard failure. The
+// Run() loop interprets the three-way return to decide whether to
+// retry with expanded file context or surface a terminal error.
+//
+// Kept separate from selectFiles so tests and callers can exercise
+// the two phases independently.
+func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sketch, contents map[string]string) (*Patch, []string, error) {
 
 	system := "You are the Implementer for aidev, a multi-agent coding tool.\n" +
 		"\n" +
-		"The developer has chosen one of the Architect's sketches. Your job is to\n" +
-		"produce a UNIFIED GIT DIFF that implements the sketch against the target\n" +
-		"repository.\n" +
+		"You are a senior engineer pairing with a teammate. The developer has\n" +
+		"chosen one of the Architect's sketches and is asking you to do the\n" +
+		"work — not to write a checklist, not to hand back a draft for the\n" +
+		"human to finish, not to file a TODO. Produce a UNIFIED GIT DIFF\n" +
+		"that implements the sketch against the target repository, and make\n" +
+		"it complete, valid, and ready to apply.\n" +
 		"\n" +
 		"REQUIREMENTS:\n" +
 		"\n" +
@@ -321,9 +396,11 @@ func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sket
 		"2. Use the EXACT file paths the target repository already uses. Do not\n" +
 		"   invent directories. Do not prefix with './' — use bare paths.\n" +
 		"\n" +
-		"3. Keep the diff MINIMAL. Only include files the chosen sketch actually\n" +
-		"   needs to touch. Do not reformat unrelated code. Follow the Boy Scout\n" +
-		"   Rule but stay inside the boundary of the change.\n" +
+		"3. Keep the diff MINIMAL in SCOPE but COMPLETE in EXECUTION. Only\n" +
+		"   include files the chosen sketch actually needs to touch, but\n" +
+		"   within that scope do the whole job — do not leave dangling\n" +
+		"   references, half-migrated call sites, or unfinished locale\n" +
+		"   rollouts. A diff that covers 8 of 9 locales is a regression.\n" +
 		"\n" +
 		"4. Include docstrings / comments where the sketch implies new public\n" +
 		"   API. Follow the repository's existing conventions (go doc comments,\n" +
@@ -332,31 +409,83 @@ func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sket
 		"5. Include tests for every meaningful behaviour the diff adds. Tests\n" +
 		"   belong in the same diff, not a follow-up.\n" +
 		"\n" +
-		"6. Do NOT wrap the diff in a Markdown code fence. Do NOT prefix the diff\n" +
-		"   with commentary. The first line of your response MUST be\n" +
-		"   'diff --git'. There is no opt-out. If the sketch genuinely\n" +
-		"   requires no code changes (e.g. a pure doc-only task), you still\n" +
-		"   produce a real diff against a doc file — silence is not an\n" +
-		"   acceptable answer.\n" +
+		"6. Do NOT wrap the diff in a Markdown code fence. Do NOT prefix the\n" +
+		"   diff with commentary. The first line of your response MUST be\n" +
+		"   EXACTLY ONE of:\n" +
 		"\n" +
-		"7. If you are unsure about a file's current content and need more\n" +
-		"   context, do your best with what you know and annotate uncertain\n" +
-		"   regions with '# TODO(aidev): verify ...' inside the diff content.\n" +
-		"   A partially-correct starting point is strictly more useful than\n" +
-		"   an empty response; the user will review and fix the rough edges.\n" +
+		"     'diff --git'     (the common case — a real patch)\n" +
+		"     'NEED_FILES:'    (see rule 7)\n" +
+		"     'ERROR:'         (see rule 8)\n" +
 		"\n" +
-		"8. ESCAPE HATCH (use sparingly): if and only if you cannot produce\n" +
-		"   ANY diff because the request is fundamentally impossible from\n" +
-		"   the context provided (e.g. the sketch references files that\n" +
-		"   don't exist and no reasonable substitute is visible), emit a\n" +
-		"   single line starting with 'ERROR: ' followed by a one-sentence\n" +
-		"   explanation of exactly what blocked you. Do NOT use this to\n" +
-		"   sidestep uncertainty — uncertainty is what the TODO annotations\n" +
-		"   in rule 7 are for.\n" +
+		"   Silence, prose apologies, # no-op sentinels, and 'here's a\n" +
+		"   starting point' drafts are all rejected by the validator.\n" +
 		"\n" +
-		"Stay realistic. The user will apply this diff with 'git apply' and\n" +
-		"review it; a partially-correct starting point is more useful than an\n" +
-		"attempt at a whole-repo rewrite."
+		"7. NEED_FILES protocol. If you cannot write a COMPLETE, VALID diff\n" +
+		"   from the files you've already been shown because the real\n" +
+		"   content of some other file is required (for example: you need\n" +
+		"   the canonical translation string from fr/common.json to copy\n" +
+		"   into a new key, or you need to see the actual call site in a\n" +
+		"   .tsx component to anchor the patch correctly), emit the\n" +
+		"   following exactly:\n" +
+		"\n" +
+		"     NEED_FILES: [\"path/one.json\", \"path/two.tsx\"]\n" +
+		"\n" +
+		"   on a single line — a JSON array of repo-relative paths after\n" +
+		"   the 'NEED_FILES:' marker, no prose, no code fence. The harness\n" +
+		"   will load those files and re-invoke you with the expanded\n" +
+		"   context. You get up to two NEED_FILES rounds, so plan ahead:\n" +
+		"   request everything you need in one go, not one file at a time.\n" +
+		"\n" +
+		"   NEED_FILES is NOT an opt-out from doing the work. It is an\n" +
+		"   opt-in to seeing MORE of the codebase before you do the work.\n" +
+		"   Do not use it to defer writing the diff entirely.\n" +
+		"\n" +
+		"8. ERROR escape hatch. If the task is genuinely impossible\n" +
+		"   (required files don't exist on disk, the sketch contradicts\n" +
+		"   itself, the chosen approach would require migrations outside\n" +
+		"   this repository), emit a single line starting with 'ERROR: '\n" +
+		"   followed by a one-sentence explanation. The orchestrator will\n" +
+		"   surface the reason verbatim.\n" +
+		"\n" +
+		"9. FORBIDDEN OUTPUTS — the following are failure modes, not\n" +
+		"   acceptable compromises. Prefer NEED_FILES or ERROR over any of\n" +
+		"   them:\n" +
+		"\n" +
+		"   9a. Creating auxiliary checklist/notes files alongside the real\n" +
+		"       change (AIDEV_TODO_*.md, NOTES.md, CHECKLIST.md,\n" +
+		"       HUMAN_FOLLOWUP.md). The diff is the work. If a human has\n" +
+		"       to finish the job from your output, you have failed. Do\n" +
+		"       NOT create helper markdown files to track work you\n" +
+		"       decided not to do.\n" +
+		"\n" +
+		"   9b. Comments in file formats that don't support them. JSON\n" +
+		"       does NOT have comments — '// TODO' or '/* ... */' lines\n" +
+		"       inside a .json hunk produce invalid JSON and the diff\n" +
+		"       won't apply. If you think you need to annotate a JSON\n" +
+		"       region, you either request the real content via\n" +
+		"       NEED_FILES or emit ERROR. Check the file extension before\n" +
+		"       adding any kind of comment. TOML, YAML, Python, Go, TS,\n" +
+		"       JS allow comments; JSON, JSON5 (mostly), and CSV do not.\n" +
+		"\n" +
+		"   9c. Placeholder or fabricated string values. If the diff\n" +
+		"       needs a specific translation, brand name, API key name,\n" +
+		"       or any content-bearing literal, READ the real value from\n" +
+		"       the repo — via the files you already have or via\n" +
+		"       NEED_FILES. Never invent 'Kontakt Vertrieb' as a stand-in\n" +
+		"       for a German translation that already exists elsewhere in\n" +
+		"       the repo. If you genuinely cannot find the real value,\n" +
+		"       emit ERROR and explain which file you looked for it in.\n" +
+		"\n" +
+		"   9d. 'Partial starting points' that expect the human to finish\n" +
+		"       the job. You are not generating homework. Finish the\n" +
+		"       scope the sketch asked for, end to end. If the scope is\n" +
+		"       too large for a clean diff, emit ERROR and explain what\n" +
+		"       needs to be split — do not silently hand back half the\n" +
+		"       work.\n" +
+		"\n" +
+		"Stay realistic: the user will apply this diff with 'git apply'\n" +
+		"and review it. A diff that applies cleanly and finishes the\n" +
+		"scope is worth ten drafts that need human cleanup."
 
 	// Assemble the user message. v0.3a.1 includes the CONTENTS of the
 	// files the first turn's picker asked for, so the model can anchor
@@ -384,7 +513,7 @@ func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sket
 		for _, p := range paths {
 			fmt.Fprintf(&user, "### %s\n\n```\n%s\n```\n\n", p, contents[p])
 		}
-		user.WriteString("Only the files above are shown. If you need others to write a correct diff, annotate TODOs in your response — the user can re-run after adding them to the Scout's file inventory.\n")
+		user.WriteString("Only the files above have been loaded for you. If you need to read additional repo-relative files to produce a COMPLETE and VALID diff — for example to copy a canonical translation value from another locale, or to see the exact call site of a function you're rewriting — respond with `NEED_FILES: [\"path/a.json\", \"path/b.tsx\"]` per rule 7 and the harness will load them and call you again. Do NOT fabricate values, annotate TODOs inside the diff, or hand back a partial starting point.\n")
 	} else {
 		// Fallback to the v0.3a behaviour (paths only) when the picker
 		// returned nothing useful. Degrades gracefully.
@@ -411,35 +540,82 @@ func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sket
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("implementer: %w", err)
+		return nil, nil, fmt.Errorf("implementer: %w", err)
 	}
 
-	diff := strings.TrimSpace(resp.Content)
-	if diff == "" {
-		return nil, errors.New("implementer: empty response")
+	raw := strings.TrimSpace(resp.Content)
+	if raw == "" {
+		return nil, nil, errors.New("implementer: empty response")
 	}
 	// Strip a leading markdown code fence if the model ignored the
 	// "no code fence" instruction — we've seen it happen in practice.
-	diff = stripCodeFence(diff)
+	raw = stripCodeFence(raw)
 
-	if strings.HasPrefix(diff, "ERROR:") {
+	switch {
+	case strings.HasPrefix(raw, "NEED_FILES:"):
+		// Iterative file request. Parse the JSON array that follows
+		// the marker. The caller (Run) loads those files and re-asks.
+		need, parseErr := parseNeedFiles(raw)
+		if parseErr != nil {
+			return nil, nil, fmt.Errorf("implementer: NEED_FILES parse: %w", parseErr)
+		}
+		if len(need) == 0 {
+			return nil, nil, errors.New("implementer: NEED_FILES directive had no paths")
+		}
+		return nil, need, nil
+
+	case strings.HasPrefix(raw, "ERROR:"):
 		// Hard-fail escape hatch. The Implementer has declared it cannot
 		// produce a diff at all. Surface the reason verbatim to the
 		// orchestrator so the user sees exactly what blocked it.
-		reason := strings.TrimSpace(strings.TrimPrefix(firstLine(diff), "ERROR:"))
+		reason := strings.TrimSpace(strings.TrimPrefix(firstLine(raw), "ERROR:"))
 		if reason == "" {
 			reason = "(no reason given)"
 		}
-		return nil, fmt.Errorf("implementer: declared ERROR: %s", reason)
-	}
-	if !strings.HasPrefix(diff, "diff --git") {
-		return nil, fmt.Errorf("implementer: expected 'diff --git', got %q", firstLine(diff))
-	}
+		return nil, nil, fmt.Errorf("implementer: declared ERROR: %s", reason)
 
-	return &Patch{
-		Diff:         diff,
-		FilesTouched: parseFilesFromDiff(diff),
-	}, nil
+	case strings.HasPrefix(raw, "diff --git"):
+		return &Patch{
+			Diff:         raw,
+			FilesTouched: parseFilesFromDiff(raw),
+		}, nil, nil
+
+	default:
+		return nil, nil, fmt.Errorf("implementer: expected 'diff --git', 'NEED_FILES:', or 'ERROR:', got %q", firstLine(raw))
+	}
+}
+
+// needFilesJSONRe matches the `[...]` JSON array that follows a
+// `NEED_FILES:` marker line. Shared with parseFileSelection in spirit
+// but kept separate so the grammar is clear: `NEED_FILES:` is a
+// dedicated protocol, not a general-purpose JSON extractor.
+var needFilesJSONRe = regexp.MustCompile(`(?s)\[.*\]`)
+
+// parseNeedFiles extracts the repo-relative paths the Implementer
+// asked for from a `NEED_FILES: [...]` response. Tolerates:
+//
+//   - extra whitespace before/after the JSON array
+//   - a single trailing newline or prose after the array (we match the
+//     first bracketed block only)
+//
+// Rejects malformed or unsafe paths the same way cleanFileList does.
+// Exported indirectly via tests in implementer_test.go.
+func parseNeedFiles(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimPrefix(raw, "NEED_FILES:")
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, errors.New("empty NEED_FILES directive")
+	}
+	match := needFilesJSONRe.FindString(raw)
+	if match == "" {
+		return nil, fmt.Errorf("no JSON array in NEED_FILES directive: %q", firstLine(raw))
+	}
+	var arr []string
+	if err := json.Unmarshal([]byte(match), &arr); err != nil {
+		return nil, fmt.Errorf("parse NEED_FILES JSON: %w", err)
+	}
+	return cleanFileList(arr), nil
 }
 
 // WriteTo persists a Patch to a file (default: `<repo>/.aidev/proposed.patch`).

--- a/internal/agents/implementer_test.go
+++ b/internal/agents/implementer_test.go
@@ -1,11 +1,36 @@
 package agents
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/aisu-ai/aidev/internal/github"
+	"github.com/aisu-ai/aidev/internal/llm"
+	"github.com/aisu-ai/aidev/internal/repo"
 )
+
+// scriptedProvider returns a canned response for each Complete call
+// in order. The last response is used for every call past the end of
+// the script so tests can decouple "how many LLM calls happened" from
+// "what the scripted turns look like" — the loop termination assertion
+// is what we're checking.
+type scriptedProvider struct {
+	responses []string
+	calls     int
+}
+
+func (p *scriptedProvider) Name() string { return "scripted" }
+func (p *scriptedProvider) Complete(_ context.Context, _ llm.Request) (llm.Response, error) {
+	idx := p.calls
+	if idx >= len(p.responses) {
+		idx = len(p.responses) - 1
+	}
+	p.calls++
+	return llm.Response{Content: p.responses[idx]}, nil
+}
 
 func TestParseFilesFromDiff(t *testing.T) {
 	diff := `diff --git a/cmd/main.go b/cmd/main.go
@@ -225,7 +250,10 @@ func TestCleanFileListDropsUnsafePaths(t *testing.T) {
 }
 
 func TestCleanFileListCapsLength(t *testing.T) {
-	in := make([]string, 30)
+	// Generate comfortably more than maxRequestedFiles so the cap is
+	// actually exercised rather than the slice just being the same
+	// size as the limit.
+	in := make([]string, maxRequestedFiles*2)
 	for j := range in {
 		in[j] = "file" + intoa(j) + ".go"
 	}
@@ -313,5 +341,211 @@ func TestSortStrings(t *testing.T) {
 	sortStrings(a)
 	if a[0] != "a" || a[1] != "b" || a[2] != "c" {
 		t.Errorf("sortStrings result: %v", a)
+	}
+}
+
+// parseNeedFiles tests — the NEED_FILES protocol is the
+// Implementer's recourse when the first-turn picker under-specified
+// and the model needs more repo context to produce a valid diff.
+// Tolerance for formatting variations (prose, stray fences, extra
+// whitespace) matters because models don't emit these directives
+// cleanly on every response.
+
+func TestParseNeedFilesBareDirective(t *testing.T) {
+	got, err := parseNeedFiles(`NEED_FILES: ["de/common.json", "fr/common.json"]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "de/common.json" || got[1] != "fr/common.json" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseNeedFilesWithExtraWhitespace(t *testing.T) {
+	got, err := parseNeedFiles("   NEED_FILES:    [\"a.tsx\" , \"b.tsx\"]\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "a.tsx" || got[1] != "b.tsx" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseNeedFilesRejectsMissingArray(t *testing.T) {
+	_, err := parseNeedFiles("NEED_FILES:")
+	if err == nil {
+		t.Error("expected error when the directive has no JSON array")
+	}
+}
+
+func TestParseNeedFilesRejectsBrokenJSON(t *testing.T) {
+	_, err := parseNeedFiles(`NEED_FILES: [not valid json]`)
+	if err == nil {
+		t.Error("expected error on broken JSON")
+	}
+}
+
+func TestParseNeedFilesDropsUnsafePaths(t *testing.T) {
+	got, err := parseNeedFiles(`NEED_FILES: ["../../etc/passwd", "ok.go", "/abs/path"]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "ok.go" {
+		t.Errorf("expected only ok.go to survive sanitisation, got %v", got)
+	}
+}
+
+// TestImplementerRunSucceedsAfterNeedFiles drives the agentic loop:
+// the picker names one file, the first generateDiff turn requests
+// MORE files via NEED_FILES, and the second generateDiff turn emits
+// the real diff. Success means the Run method followed the
+// three-turn dance and came back with a Patch.
+func TestImplementerRunSucceedsAfterNeedFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "locales", "en"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "locales", "fr"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "locales", "en", "common.json"), []byte(`{"contactSales":"Contact Sales"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "locales", "fr", "common.json"), []byte(`{"contactSales":"Contacter les ventes"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &scriptedProvider{
+		responses: []string{
+			// Turn 1 (picker): request the English locale file only.
+			`["locales/en/common.json"]`,
+			// Turn 2 (generateDiff, round 0): model realises it also
+			// needs the French file to copy the canonical translation.
+			`NEED_FILES: ["locales/fr/common.json"]`,
+			// Turn 2 (round 1): real diff now that both files are
+			// loaded.
+			"diff --git a/locales/en/common.json b/locales/en/common.json\n" +
+				"--- a/locales/en/common.json\n" +
+				"+++ b/locales/en/common.json\n" +
+				"@@ -1 +1 @@\n" +
+				"-{\"contactSales\":\"Contact Sales\"}\n" +
+				"+{\"cta\":{\"contactSales\":\"Contact Sales\"}}\n",
+		},
+	}
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue: &github.Issue{
+			Owner: "aisu-ai", Repo: "aidev", Number: 1,
+			Title: "T", Body: "consolidate sales CTA across locales",
+		},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "manual consolidation", Markdown: "## Plan\n- add common.cta.contactSales"}
+
+	patch, err := impl.Run(context.Background(), ctx, sketch)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if patch == nil {
+		t.Fatal("nil patch on success")
+	}
+	if !strings.Contains(patch.Diff, "Contact Sales") {
+		t.Errorf("patch missing canonical value, got:\n%s", patch.Diff)
+	}
+	// Sanity-check the loop ran the expected number of turns: picker
+	// + first generateDiff (NEED_FILES) + second generateDiff (diff).
+	if provider.calls != 3 {
+		t.Errorf("provider called %d times, want 3", provider.calls)
+	}
+}
+
+// TestImplementerRunRejectsInfiniteNeedFiles verifies the loop cap.
+// A model that keeps saying "need more files" forever must eventually
+// trip the maxNeedFilesRounds guard and fail with a clear error
+// rather than ballooning LLM cost.
+func TestImplementerRunRejectsInfiniteNeedFiles(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.go", "b.go", "c.go", "d.go"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("package x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	provider := &scriptedProvider{
+		responses: []string{
+			`["a.go"]`,                   // picker
+			`NEED_FILES: ["b.go"]`,       // round 0
+			`NEED_FILES: ["c.go"]`,       // round 1
+			`NEED_FILES: ["d.go"]`,       // round 2 — should trip the cap
+			`NEED_FILES: ["unused.go"]`,  // never reached
+		},
+	}
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "aisu-ai", Repo: "aidev", Number: 1, Title: "T", Body: "body"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+
+	_, err := impl.Run(context.Background(), ctx, sketch)
+	if err == nil {
+		t.Fatal("expected NEED_FILES-cap error, got nil")
+	}
+	if !strings.Contains(err.Error(), "NEED_FILES limit reached") {
+		t.Errorf("expected NEED_FILES limit error, got: %v", err)
+	}
+}
+
+// TestImplementerRunRejectsRepeatedFileRequests guards against a
+// model that keeps re-requesting paths the harness already loaded.
+// We de-duplicate inside Run; if the model asks for ONLY files that
+// are already in the contents map, the loop short-circuits rather
+// than wasting another LLM round on the same context.
+func TestImplementerRunRejectsRepeatedFileRequests(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &scriptedProvider{
+		responses: []string{
+			`["a.go"]`,            // picker loads a.go
+			`NEED_FILES: ["a.go"]`, // model re-requests the same file
+		},
+	}
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "aisu-ai", Repo: "aidev", Number: 1, Title: "T", Body: "b"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+
+	_, err := impl.Run(context.Background(), ctx, sketch)
+	if err == nil {
+		t.Fatal("expected error on duplicate-only NEED_FILES request")
+	}
+	if !strings.Contains(err.Error(), "already provided") {
+		t.Errorf("expected 'already provided' error, got: %v", err)
+	}
+}
+
+func TestParseNeedFilesCapsLength(t *testing.T) {
+	// parseNeedFiles reuses cleanFileList's cap, so a huge request
+	// still fits within maxRequestedFiles.
+	var b []byte
+	b = append(b, []byte(`NEED_FILES: [`)...)
+	for j := 0; j < maxRequestedFiles*3; j++ {
+		if j > 0 {
+			b = append(b, ',')
+		}
+		b = append(b, []byte(`"f`+intoa(j)+`.go"`)...)
+	}
+	b = append(b, ']')
+	got, err := parseNeedFiles(string(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != maxRequestedFiles {
+		t.Errorf("got %d, want cap at %d", len(got), maxRequestedFiles)
 	}
 }


### PR DESCRIPTION
## Summary

The user's first end-to-end aidev run finally reached the Implementer and produced output, but the output was a checklist masquerading as a patch: placeholder non-English translations, `// TODO` comments inside JSON (invalid syntax), an `AIDEV_TODO_consolidate_sales_cta.md` file the human was expected to finish, and a note from aidev that this 'needs human completion, not a direct git apply'. The user's feedback: **"The whole point of this is to be another dev teammate, not a work assignment bot."**

Three root causes, three fixes.

### 1. Truncation was hiding the data the Implementer needed
`maxFileBytes` was 10 KiB, small enough that a locale `common.json` got clipped and the Implementer literally could not read the canonical 'Contact Sales' value in any non-English locale to copy it forward. It fabricated placeholders instead because its prompt allowed that. Bumped to **128 KiB**. Also bumped `maxRequestedFiles` from 15 to **40** so a consolidation task across many locales + call sites fits in the picker's budget.

### 2. The picker only got one shot
The two-turn Implementer was 'picker, then diff' with no feedback loop. If the picker under-specified, the diff-generation turn had no recourse beyond fabricating or failing.

Introduced the **NEED_FILES protocol** — a poor-man's tool-use loop that stays inside the existing single-shot `llm.Provider` abstraction. On the diff-generation turn, the model may respond with:

- `diff --git ...` (success)
- `NEED_FILES: ["a.json", "b.tsx"]` (request more files)
- `ERROR: <reason>` (hard fail)

The Go harness parses `NEED_FILES`, loads the fresh paths (de-duped against already-loaded contents, size-capped, path-validated), merges them into the contents map, and re-asks. Up to `maxNeedFilesRounds = 2` additional rounds; beyond that the loop trips a hard error instead of ballooning LLM cost. Duplicate-only requests short-circuit immediately.

This is the minimum-viable agentic loop until we refactor `llm.Provider` to support native tool calls across all four backends. It covers most of the value for the most common failure mode (picker under-specification).

### 3. The prompt rewarded punting
Previous rule 7 literally said *"If you are unsure about a file's current content, do your best with what you know and annotate uncertain regions with `# TODO(aidev): verify ...`"*. That was the direct authorisation for every symptom the user hit. Replaced the whole rules section with a **teammate-not-checklist-writer framing** and a **FORBIDDEN OUTPUTS** block:

- **9a** No auxiliary checklist/notes files (`AIDEV_TODO_*.md`, `NOTES.md`, `CHECKLIST.md`, `HUMAN_FOLLOWUP.md`). The diff IS the work.
- **9b** No comments in file formats that don't support them. JSON has no comments; `// TODO` inside a `.json` hunk is invalid syntax.
- **9c** No placeholder/fabricated string values. If the diff needs a specific translation or content-bearing literal, READ the real value via already-loaded files or via NEED_FILES. Never invent 'Kontakt Vertrieb' as a stand-in for a German translation that exists elsewhere in the repo.
- **9d** No 'partial starting points' that expect the human to finish. You are not generating homework.

The system prompt now opens with "You are a senior engineer pairing with a teammate" instead of "Your job is to produce a unified git diff", which frames every subsequent rule the right way.

## Tests

- `TestParseNeedFiles{Bare,WithExtraWhitespace,RejectsMissingArray,RejectsBrokenJSON,DropsUnsafePaths,CapsLength}` grammar + sanitisation guards for the parser.
- `TestImplementerRunSucceedsAfterNeedFiles` end-to-end loop with a scripted provider: picker picks `en/common.json`, first generateDiff emits `NEED_FILES: ["fr/common.json"]`, second generateDiff emits the real diff. Asserts the harness loaded the second-round file, 3 LLM calls total, diff contains canonical value.
- `TestImplementerRunRejectsInfiniteNeedFiles` loop cap guard. A model that keeps saying NEED_FILES forever must trip `maxNeedFilesRounds` and error, not balloon LLM cost.
- `TestImplementerRunRejectsRepeatedFileRequests` de-dup guard. A model that re-requests already-loaded files short-circuits.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Rebuild + re-run `/aidev-run 533`. Expect: the Implementer now (a) sees the full locale files without truncation, (b) uses NEED_FILES to fetch the non-English `common.json` values it needs, (c) produces a real unified diff that applies cleanly with `git apply`, with no `AIDEV_TODO_*.md` companion file.