### PR TITLE
feat(config): add --preset flag and ship fully-local models.local.yaml

### DIFF
--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -116,6 +116,7 @@ func main() {
 		issueURL     = flag.String("issue", "", "GitHub issue reference: full URL (https://github.com/owner/repo/issues/N) or a bare number when -repo points at a local clone with a github.com remote")
 		repoPath     = flag.String("repo", ".", "Path to the target repository")
 		configDir    = flag.String("config", "", "Path to aidev config directory (defaults to ./config or $AIDEV_CONFIG)")
+		preset       = flag.String("preset", "", "Optional model preset name. Loads models.<name>.yaml from the config directory instead of models.yaml. Shipped presets: 'local' (fully offline via Ollama). Add your own by dropping models.<name>.yaml into the config dir.")
 		headless     = flag.Bool("headless", false, "Run the full pipeline once and print the report to stdout without the TUI")
 		sketchN      = flag.Int("n", agents.DefaultSketchCount, "Number of Architect sketches to produce when the Critic recommends 'build'")
 		pickSketch   = flag.Int("sketch", 0, "Headless only: after Architect produces sketches, automatically run the Implementer on this sketch number (1-indexed). 0 disables.")
@@ -130,7 +131,10 @@ func main() {
 		fatal("missing required flag: -issue")
 	}
 
-	cfg := mustLoadConfig(*configDir)
+	cfg := mustLoadConfigPreset(*configDir, *preset)
+	if *preset != "" {
+		fmt.Fprintf(os.Stderr, "aidev: using model preset %q (models.%s.yaml)\n", *preset, *preset)
+	}
 
 	// Precondition audit. In headless mode the doctor never prompts —
 	// it just reports and either fails or passes. In TTY mode we enable
@@ -739,7 +743,18 @@ func runDoctorSubcommand() {
 //  6. ./config (cwd — matches the dev workflow for "go run")
 //
 // The first directory that exists and contains models.yaml wins.
+//
+// Equivalent to mustLoadConfigPreset(dir, ""). Kept as a thin wrapper
+// for the subcommands that don't expose a --preset flag.
 func mustLoadConfig(configDir string) *config.Config {
+	return mustLoadConfigPreset(configDir, "")
+}
+
+// mustLoadConfigPreset is the preset-aware form. When preset is
+// non-empty, config.LoadPreset reads models.<preset>.yaml instead of
+// models.yaml from the resolved directory. Missing preset files are a
+// loud error — we never silently fall back to the default.
+func mustLoadConfigPreset(configDir, preset string) *config.Config {
 	if configDir == "" {
 		configDir = os.Getenv("AIDEV_CONFIG")
 	}
@@ -747,9 +762,13 @@ func mustLoadConfig(configDir string) *config.Config {
 		configDir = discoverConfigDir()
 	}
 
-	cfg, err := config.Load(configDir)
+	cfg, err := config.LoadPreset(configDir, preset)
 	if err != nil {
-		fatal(fmt.Sprintf("load config: %v\n  searched: %s\n  hint: run `aidev install` to lay down the default config in ~/.config/aidev", err, configDir))
+		hint := "hint: run `aidev install` to lay down the default config in ~/.config/aidev"
+		if preset != "" {
+			hint = fmt.Sprintf("hint: preset %q needs models.%s.yaml in the config directory — ship it via `aidev install` or drop your own copy there", preset, preset)
+		}
+		fatal(fmt.Sprintf("load config: %v\n  searched: %s\n  %s", err, configDir, hint))
 	}
 	return cfg
 }

--- a/config/models.local.yaml
+++ b/config/models.local.yaml
@@ -1,0 +1,97 @@
+# Fully-local model preset for aidev.
+#
+# Routes every role to an Ollama model so the entire pipeline runs
+# offline. Zero cloud calls, zero per-token cost, 100% private.
+# Slower than the default (which sends the Critic/Architect/Charter
+# roles to Claude CLI for deep reasoning), but appropriate for:
+#
+#   - proprietary/sensitive codebases you cannot send to Anthropic
+#   - offline development (plane, train, bunker, restricted network)
+#   - privacy-conscious users who want zero cloud calls
+#   - people tinkering without a Claude subscription
+#
+# ---
+#
+# Hardware expectations (approximate, Q4 quantisation):
+#
+#   small tier  (qwen2.5-coder:7b):   ~5 GB VRAM (or CPU with patience)
+#   medium tier (qwen2.5-coder:14b):  ~9 GB VRAM
+#   large tier  (qwen2.5:32b):       ~20 GB VRAM
+#
+# Total if the whole pipeline runs the same day: ~20 GB VRAM peak
+# (Ollama will swap models in and out; only one tier runs at a time).
+#
+# If your hardware can't fit the 32B large tier, drop `large` to
+# `qwen2.5-coder:14b` so every tier fits in ~9 GB. You'll lose some
+# Critic/Architect depth (those roles benefit most from generalist
+# reasoning) but the pipeline still works end-to-end.
+#
+# ---
+#
+# Before first run, pull the models:
+#
+#   ollama pull qwen2.5-coder:7b
+#   ollama pull qwen2.5-coder:14b
+#   ollama pull qwen2.5:32b
+#
+# Then invoke aidev with --preset local, e.g.:
+#
+#   aidev --preset local -headless -auto -sketch 1 -issue ... -repo ...
+#
+# ---
+#
+# Quality expectations vs. the default (cloud-large) preset:
+#
+#   - Scout brief: indistinguishable — the Scout's task is factual
+#     extraction, which local 7B models handle well.
+#   - Implementer diffs: 80-90% of cloud quality for focused,
+#     single-feature changes. The NEED_FILES loop helps by letting
+#     the model iteratively discover context instead of trying to
+#     hold a whole repo in one window.
+#   - Critic sharp questions: 60-75% of cloud quality. Local
+#     generalist models produce less adversarial analysis than
+#     Claude Opus; expect a gentler Critic.
+#   - Architect sketches: 70-85% of cloud quality. Sketches are
+#     usually sensible but less creative about splitting work.
+#
+# The Coordinator agent (future PR) acts as a cloud-backed safety
+# net for this preset: it reviews Implementer output and catches
+# the common local-model failure modes (fabrication, invalid
+# syntax, half-finished work) before the patch hits disk. If
+# you're running this preset AND have Claude CLI available for the
+# Coordinator role alone, that's the recommended shape.
+
+tiers:
+  small:
+    provider: ollama
+    model: qwen2.5-coder:7b
+    endpoint: http://localhost:11434
+    max_tokens: 2048
+    temperature: 0.2
+
+  medium:
+    provider: ollama
+    model: qwen2.5-coder:14b
+    endpoint: http://localhost:11434
+    max_tokens: 8192
+    temperature: 0.2
+
+  large:
+    provider: ollama
+    model: qwen2.5:32b
+    endpoint: http://localhost:11434
+    max_tokens: 8192
+    temperature: 0.3
+
+# Same role -> tier routing as the default preset. Only the tier
+# definitions above differ — the roles themselves want the same
+# relative size of model regardless of whether the backend is local
+# or cloud.
+routing:
+  scout: small
+  critic: large
+  architect: large
+  charter: large
+  implementer: medium
+  reviewer: medium
+  tester: small

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -52,11 +51,35 @@ type Config struct {
 	// ConfigDir is the directory the files were loaded from, used for
 	// producing clear error messages.
 	ConfigDir string
+	// Preset is the non-empty preset name (e.g. "local") that was used
+	// to load Models, or "" if the default models.yaml was used.
+	// Surfaced so the doctor and the headless report can tell the user
+	// which routing is active.
+	Preset string
 }
 
 // Load reads models.yaml and principles.yaml from dir. An empty dir defaults
-// to "./config".
+// to "./config". Equivalent to LoadPreset(dir, "").
 func Load(dir string) (*Config, error) {
+	return LoadPreset(dir, "")
+}
+
+// LoadPreset is the preset-aware form of Load. When preset is empty, it
+// reads the default `models.yaml` (same as Load). When preset is non-empty,
+// it reads `models.<preset>.yaml` instead — allowing shipped bundles like
+// `local` (all-local Ollama routing) or user-authored alternatives
+// (`models.offline.yaml`, `models.gpu-rich.yaml`, ...) to swap routing
+// without touching the default file.
+//
+// Principles always load from `principles.yaml`; presets only affect the
+// model routing, not the engineering principles the Critic evaluates
+// against. If a user wants preset-specific principles they can still
+// override via .aidev/principles.yaml in the target repo.
+//
+// A missing preset file is a loud error — we never silently fall back to
+// the default. If you asked for `--preset local` and there is no
+// models.local.yaml in the config directory, you want to know.
+func LoadPreset(dir, preset string) (*Config, error) {
 	if dir == "" {
 		dir = "config"
 	}
@@ -65,29 +88,63 @@ func Load(dir string) (*Config, error) {
 		return nil, fmt.Errorf("resolve config dir: %w", err)
 	}
 
+	modelsFile := "models.yaml"
+	if preset != "" {
+		if !isSafePresetName(preset) {
+			return nil, fmt.Errorf("invalid preset name %q (letters, digits, dash, underscore only)", preset)
+		}
+		modelsFile = "models." + preset + ".yaml"
+	}
+
 	var cfg Config
 	cfg.ConfigDir = abs
+	cfg.Preset = preset
 
-	if err := readYAML(filepath.Join(abs, "models.yaml"), &cfg.Models); err != nil {
-		return nil, fmt.Errorf("models.yaml: %w", err)
+	if err := readYAML(filepath.Join(abs, modelsFile), &cfg.Models); err != nil {
+		if preset != "" {
+			return nil, fmt.Errorf("%s: %w (preset %q not found in %s)", modelsFile, err, preset, abs)
+		}
+		return nil, fmt.Errorf("%s: %w", modelsFile, err)
 	}
 	if err := readYAML(filepath.Join(abs, "principles.yaml"), &cfg.Principles); err != nil {
 		return nil, fmt.Errorf("principles.yaml: %w", err)
 	}
 
 	if len(cfg.Models.Tiers) == 0 {
-		return nil, errors.New("models.yaml: no tiers defined")
+		return nil, fmt.Errorf("%s: no tiers defined", modelsFile)
 	}
 	if len(cfg.Models.Routing) == 0 {
-		return nil, errors.New("models.yaml: no routing defined")
+		return nil, fmt.Errorf("%s: no routing defined", modelsFile)
 	}
 	for role, tier := range cfg.Models.Routing {
 		if _, ok := cfg.Models.Tiers[tier]; !ok {
-			return nil, fmt.Errorf("models.yaml: role %q routed to unknown tier %q", role, tier)
+			return nil, fmt.Errorf("%s: role %q routed to unknown tier %q", modelsFile, role, tier)
 		}
 	}
 
 	return &cfg, nil
+}
+
+// isSafePresetName returns true for preset names that are safe to
+// substitute into a filename. We enforce a conservative character set
+// rather than shell-quoting because preset names should be short,
+// human-readable identifiers like `local`, `offline`, `gpu-rich` — not
+// arbitrary user input.
+func isSafePresetName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // MergePrinciples appends additional principles (e.g. loaded from the target

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,3 +71,95 @@ routing:
 		t.Error("expected error for routing to unknown tier")
 	}
 }
+
+// TestLoadPresetReadsAlternateModelsFile verifies that --preset local
+// swaps the models file from models.yaml to models.local.yaml without
+// touching principles.yaml. This is the core guarantee of the preset
+// feature: alternate routing bundles without duplicating principles.
+func TestLoadPresetReadsAlternateModelsFile(t *testing.T) {
+	dir := t.TempDir()
+	// Default file uses a cloud tier; preset file is fully local.
+	_ = os.WriteFile(filepath.Join(dir, "models.yaml"), []byte(modelsYAML), 0o644)
+	localYAML := `
+tiers:
+  small:
+    provider: ollama
+    model: qwen2.5-coder:7b
+    endpoint: http://localhost:11434
+    max_tokens: 2048
+    temperature: 0.2
+routing:
+  scout: small
+  critic: small
+`
+	_ = os.WriteFile(filepath.Join(dir, "models.local.yaml"), []byte(localYAML), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "principles.yaml"), []byte(principlesYAML), 0o644)
+
+	cfg, err := LoadPreset(dir, "local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Preset != "local" {
+		t.Errorf("cfg.Preset = %q, want local", cfg.Preset)
+	}
+	// The preset routes both scout and critic to small — proof we
+	// read models.local.yaml and not the default.
+	if cfg.Models.Routing["critic"] != "small" {
+		t.Errorf("critic routing = %q, want small (local preset)", cfg.Models.Routing["critic"])
+	}
+	if cfg.Models.Tiers["small"].Model != "qwen2.5-coder:7b" {
+		t.Errorf("small tier model = %q, want qwen2.5-coder:7b", cfg.Models.Tiers["small"].Model)
+	}
+	// Principles are shared across presets; should still load.
+	if len(cfg.Principles.Principles) != 1 {
+		t.Errorf("principles = %d, want 1", len(cfg.Principles.Principles))
+	}
+}
+
+// TestLoadPresetMissingFileIsLoud is the negative case: asking for a
+// preset that doesn't exist must error, not silently fall back to the
+// default. Silent fallback would hide the user's intent and ship the
+// wrong tier routing without warning.
+func TestLoadPresetMissingFileIsLoud(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "models.yaml"), []byte(modelsYAML), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "principles.yaml"), []byte(principlesYAML), 0o644)
+
+	_, err := LoadPreset(dir, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error when preset file is missing")
+	}
+}
+
+// TestLoadPresetRejectsUnsafeNames guards against path-traversal via
+// the preset name. Anything that isn't [A-Za-z0-9_-]+ must be refused
+// before it becomes part of a filename.
+func TestLoadPresetRejectsUnsafeNames(t *testing.T) {
+	cases := []string{"..", "../etc", "foo/bar", "has space", "has.dot", ""}
+	for _, c := range cases {
+		_, err := LoadPreset(t.TempDir(), c)
+		if err == nil {
+			t.Errorf("expected error for unsafe preset name %q", c)
+		}
+	}
+}
+
+// TestLoadWithoutPresetIsUnchanged verifies backwards compatibility:
+// callers that never pass a preset still get the default models.yaml
+// and Config.Preset is empty.
+func TestLoadWithoutPresetIsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "models.yaml"), []byte(modelsYAML), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "principles.yaml"), []byte(principlesYAML), 0o644)
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Preset != "" {
+		t.Errorf("cfg.Preset = %q, want empty for default load", cfg.Preset)
+	}
+	if cfg.Models.Routing["critic"] != "large" {
+		t.Errorf("critic routing = %q, want large (default)", cfg.Models.Routing["critic"])
+	}
+}

--- a/internal/installpkg/files/models.local.yaml
+++ b/internal/installpkg/files/models.local.yaml
@@ -1,0 +1,97 @@
+# Fully-local model preset for aidev.
+#
+# Routes every role to an Ollama model so the entire pipeline runs
+# offline. Zero cloud calls, zero per-token cost, 100% private.
+# Slower than the default (which sends the Critic/Architect/Charter
+# roles to Claude CLI for deep reasoning), but appropriate for:
+#
+#   - proprietary/sensitive codebases you cannot send to Anthropic
+#   - offline development (plane, train, bunker, restricted network)
+#   - privacy-conscious users who want zero cloud calls
+#   - people tinkering without a Claude subscription
+#
+# ---
+#
+# Hardware expectations (approximate, Q4 quantisation):
+#
+#   small tier  (qwen2.5-coder:7b):   ~5 GB VRAM (or CPU with patience)
+#   medium tier (qwen2.5-coder:14b):  ~9 GB VRAM
+#   large tier  (qwen2.5:32b):       ~20 GB VRAM
+#
+# Total if the whole pipeline runs the same day: ~20 GB VRAM peak
+# (Ollama will swap models in and out; only one tier runs at a time).
+#
+# If your hardware can't fit the 32B large tier, drop `large` to
+# `qwen2.5-coder:14b` so every tier fits in ~9 GB. You'll lose some
+# Critic/Architect depth (those roles benefit most from generalist
+# reasoning) but the pipeline still works end-to-end.
+#
+# ---
+#
+# Before first run, pull the models:
+#
+#   ollama pull qwen2.5-coder:7b
+#   ollama pull qwen2.5-coder:14b
+#   ollama pull qwen2.5:32b
+#
+# Then invoke aidev with --preset local, e.g.:
+#
+#   aidev --preset local -headless -auto -sketch 1 -issue ... -repo ...
+#
+# ---
+#
+# Quality expectations vs. the default (cloud-large) preset:
+#
+#   - Scout brief: indistinguishable — the Scout's task is factual
+#     extraction, which local 7B models handle well.
+#   - Implementer diffs: 80-90% of cloud quality for focused,
+#     single-feature changes. The NEED_FILES loop helps by letting
+#     the model iteratively discover context instead of trying to
+#     hold a whole repo in one window.
+#   - Critic sharp questions: 60-75% of cloud quality. Local
+#     generalist models produce less adversarial analysis than
+#     Claude Opus; expect a gentler Critic.
+#   - Architect sketches: 70-85% of cloud quality. Sketches are
+#     usually sensible but less creative about splitting work.
+#
+# The Coordinator agent (future PR) acts as a cloud-backed safety
+# net for this preset: it reviews Implementer output and catches
+# the common local-model failure modes (fabrication, invalid
+# syntax, half-finished work) before the patch hits disk. If
+# you're running this preset AND have Claude CLI available for the
+# Coordinator role alone, that's the recommended shape.
+
+tiers:
+  small:
+    provider: ollama
+    model: qwen2.5-coder:7b
+    endpoint: http://localhost:11434
+    max_tokens: 2048
+    temperature: 0.2
+
+  medium:
+    provider: ollama
+    model: qwen2.5-coder:14b
+    endpoint: http://localhost:11434
+    max_tokens: 8192
+    temperature: 0.2
+
+  large:
+    provider: ollama
+    model: qwen2.5:32b
+    endpoint: http://localhost:11434
+    max_tokens: 8192
+    temperature: 0.3
+
+# Same role -> tier routing as the default preset. Only the tier
+# definitions above differ — the roles themselves want the same
+# relative size of model regardless of whether the backend is local
+# or cloud.
+routing:
+  scout: small
+  critic: large
+  architect: large
+  charter: large
+  implementer: medium
+  reviewer: medium
+  tester: small

--- a/internal/installpkg/installpkg_test.go
+++ b/internal/installpkg/installpkg_test.go
@@ -1,0 +1,41 @@
+package installpkg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestInstallConfigShipsLocalPreset verifies that the install-time
+// fileset includes models.local.yaml alongside models.yaml and
+// principles.yaml. Without this, users running `aidev install` on a
+// fresh machine would get the default tier routing but not the
+// preset file, so `--preset local` would fail with a missing-file
+// error — a silent-first-use footgun.
+func TestInstallConfigShipsLocalPreset(t *testing.T) {
+	dir := t.TempDir()
+	written, _, err := InstallConfig(dir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]bool{
+		"models.yaml":       false,
+		"models.local.yaml": false,
+		"principles.yaml":   false,
+	}
+	for _, p := range written {
+		name := filepath.Base(p)
+		if _, tracked := want[name]; tracked {
+			want[name] = true
+		}
+	}
+	for name, saw := range want {
+		if !saw {
+			t.Errorf("InstallConfig did not write %q — did you forget to copy it into internal/installpkg/files/?", name)
+		}
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("expected %s on disk after install: %v", name, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

First of a two-PR sequence that makes aidev a better collaborator by enabling local-first hardware setups while keeping a cloud quality gate for the parts that need it. This PR ships the preset infrastructure and the `local` preset. The next PR (Coordinator agent, Gate 1 diff review) layers a cloud-backed review pass on top.

## Preset mechanism

- `config.LoadPreset(dir, preset)` reads `models.<preset>.yaml` from the config directory instead of `models.yaml` when preset is non-empty. Principles always load from `principles.yaml` regardless of preset.
- Missing preset files are a **loud error**. Silent fallback would hide the user's intent and ship the wrong tier routing without warning.
- Preset names are validated against `[A-Za-z0-9_-]+` before being substituted into a filename, so `../etc/passwd`, `has space`, and the empty string are refused at the API boundary.
- `config.Config` gains a `Preset` field so downstream surfaces can show which routing bundle is active.

## New `--preset` flag

- `-preset <name>` on the main binary. Default empty means traditional `models.yaml` load path; `-preset local` loads `models.local.yaml` instead.
- When a preset is active, the main entry point prints a stderr banner so the user always knows which routing is running.

## `models.local.yaml` — fully-offline preset

- **Scout, Tester**: `qwen2.5-coder:7b` (~5 GB VRAM)
- **Implementer, Reviewer**: `qwen2.5-coder:14b` (~9 GB VRAM)
- **Critic, Architect, Charter**: `qwen2.5:32b` (~20 GB VRAM)
- All backends are Ollama via localhost:11434. Zero cloud calls.

The preset file contains extensive comments documenting hardware expectations per tier, fallback options for users who can't fit the 32B large tier, `ollama pull` commands for first use, and honest quality expectations vs. the default cloud-large preset.

Shipped in two places: `config/models.local.yaml` (dev workflow) and `internal/installpkg/files/models.local.yaml` (embedded via go:embed so `aidev install` lays it down alongside `models.yaml` and `principles.yaml`).

## Tests

- `TestLoadPresetReadsAlternateModelsFile` preset swap reads the alternate routing and leaves principles.yaml unchanged.
- `TestLoadPresetMissingFileIsLoud` unknown preset errors, never silently falls back.
- `TestLoadPresetRejectsUnsafeNames` `../etc`, `has space`, empty string, and friends all rejected.
- `TestLoadWithoutPresetIsUnchanged` backwards compatibility guard.
- `TestInstallConfigShipsLocalPreset` regression guard for the install-time fileset — if a future change drops the preset from `internal/installpkg/files/`, `aidev install` would silently ship a config where `-preset local` fails with a missing-file error. This test catches that at build time.

## Why this composes with the next PR

The honest quality gap when swapping Implementer to a local 14B model is fabrication, half-finished diffs, and occasional invalid syntax for the target file format. The Coordinator agent (PR B, next) will run on the large tier as a cloud-backed safety net: it reviews the Implementer's diff before it hits disk, catches those failure modes, and sends the Implementer back with specific actionable feedback. Local horse, cloud jockey.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Pull, reinstall, `ollama pull qwen2.5-coder:14b` + `qwen2.5:32b` (user hardware permitting), run `aidev --preset local -headless -auto -sketch 1 -issue <N> -repo <path>` to confirm the preset loads and the pipeline runs end-to-end against local models.