### PR TITLE
feat(coordinator): Gate-1 diff review agent with implementer retry loop

### DIFF
--- a/config/models.local.yaml
+++ b/config/models.local.yaml
@@ -87,11 +87,21 @@ tiers:
 # definitions above differ — the roles themselves want the same
 # relative size of model regardless of whether the backend is local
 # or cloud.
+#
+# Note: in this fully-local preset, the Coordinator also runs on a
+# local model (qwen2.5:32b). If you have Claude CLI available and
+# want the "local horse, cloud jockey" shape — local Implementer
+# with a cloud-backed Coordinator that catches fabrication and
+# invalid-syntax failures — create your own `models.local-mixed.yaml`
+# with `coordinator` routed to a `cloud_large` tier that uses
+# `provider: claude-cli`. This preset is intentionally 100% offline
+# to serve the air-gapped / privacy-first use case.
 routing:
   scout: small
   critic: large
   architect: large
   charter: large
+  coordinator: large
   implementer: medium
   reviewer: medium
   tester: small

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -40,14 +40,24 @@ tiers:
     temperature: 0.3
 
 # Role -> tier routing. Roles that need deep reasoning (critic,
-# architect, charter, reviewer) use the large tier. Implementer uses
-# medium. Scout and tester are routed to the small local tier for speed
-# and cost.
+# architect, charter, coordinator) use the large tier. Implementer
+# and reviewer use medium. Scout and tester are routed to the small
+# local tier for speed and cost.
+#
+# coordinator is aidev's Gate-1 safety net: it reviews the
+# Implementer's diff before it's written to disk and catches common
+# failure modes (fabrication, invalid syntax for the file format,
+# auxiliary TODO files, partial scope). It runs on the large tier
+# because catching those failures is a judgment task — the same
+# reason the Critic runs there. If you're running a local
+# Implementer (see models.local.yaml), keeping the Coordinator on a
+# cloud tier is the recommended "local horse, cloud jockey" shape.
 routing:
   scout: small
   critic: large
   architect: large
   charter: large
+  coordinator: large
   implementer: medium
   reviewer: medium
   tester: small

--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -44,6 +44,16 @@ type Context struct {
 	// authoritative for the in-memory re-critique loop; the on-disk
 	// file is what downstream runs pick up.
 	ClarifierNotes string
+
+	// CoordinatorFeedback is a bullet list of concrete, actionable
+	// issues the Coordinator found in the Implementer's previous
+	// attempt at this sketch. Set by the orchestrator's Gate-1 loop
+	// between the Coordinator's review and the next Implementer run;
+	// read by the Implementer's generateDiff prompt assembly so the
+	// retry has specific guidance to address. Always empty on the
+	// first attempt. Cleared between orchestrator runs so stale
+	// feedback from a previous issue can't leak into a new one.
+	CoordinatorFeedback string
 }
 
 // Principle is re-exported so agent code doesn't need to import the config

--- a/internal/agents/coordinator.go
+++ b/internal/agents/coordinator.go
@@ -1,0 +1,273 @@
+// Coordinator is aidev's Gate-1 quality safety net. It sits between
+// the Implementer and the patch write-to-disk step, reviews the diff
+// the Implementer just produced, and decides whether to approve it or
+// send it back with specific actionable feedback.
+//
+// The Coordinator is especially valuable when the Implementer runs on
+// a local model (see `models.local.yaml`): local coder models are
+// strong at line-level transformation but weak at noticing when they
+// fabricated a value, used invalid syntax for the target file format,
+// or left a half-finished consolidation. A cloud-backed Coordinator
+// catches those failure modes and surfaces them as concrete feedback
+// the Implementer can address on the next attempt.
+//
+// Gate 1 is deliberately the only gate the Coordinator runs at for
+// now. Pre-Architect skip and post-Reviewer follow-up triage are
+// possible later additions but the diff-review gate delivers the
+// most value per LLM call and is the easiest to scope well.
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aisu-ai/aidev/internal/llm"
+)
+
+// Coordinator is the Gate-1 reviewer agent.
+type Coordinator struct {
+	Provider llm.Provider
+}
+
+// NewCoordinator builds a Coordinator from the router's
+// RoleCoordinator mapping. Routing falls back to RoleCritic's tier
+// when no coordinator routing is configured (see router.For) so
+// users on older models.yaml files don't break.
+func NewCoordinator(router *llm.Router) (*Coordinator, error) {
+	p, err := router.For(llm.RoleCoordinator)
+	if err != nil {
+		return nil, err
+	}
+	return &Coordinator{Provider: p}, nil
+}
+
+// CoordinatorReview is the structured output of a single review
+// pass. Approved==true means proceed; Approved==false means send the
+// diff back to the Implementer with Feedback as the concrete list of
+// issues to address.
+type CoordinatorReview struct {
+	// Approved is true when the diff is ready to hit disk.
+	Approved bool
+
+	// Feedback is the markdown-bulleted list of concerns when
+	// Approved is false. Empty when Approved is true. Format:
+	// "- <concrete issue with file:line context and what to do>".
+	// The list is the exact text the Implementer sees as its
+	// CoordinatorFeedback on the retry.
+	Feedback string
+
+	// Rationale is a one-line summary of WHY the Coordinator
+	// reached its verdict. On approval it reads like a commit
+	// message; on rejection it reads like a one-sentence code
+	// review summary. Used in headless output and reporter
+	// artifacts so the user can see the Coordinator's reasoning
+	// without reading every bullet.
+	Rationale string
+
+	// Raw is the verbatim markdown response from the model, kept
+	// for debugging and for the headless output's advisory block
+	// when the retry cap is reached but the diff is still useful.
+	Raw string
+}
+
+// Review asks the Coordinator to evaluate the given patch against
+// the issue, sketch, scout brief, and principles in cc. Returns a
+// CoordinatorReview or an error from the underlying Provider.
+//
+// The caller (orchestrator.Implement) is responsible for the retry
+// loop: on Approved==true proceed to WriteTo; on Approved==false
+// stash Feedback onto cc.CoordinatorFeedback and call
+// implementer.Run again, bounded by a retry cap.
+func (co *Coordinator) Review(ctx context.Context, cc *Context, chosen *Sketch, patch *Patch) (*CoordinatorReview, error) {
+	if co == nil || co.Provider == nil {
+		return nil, errors.New("coordinator: nil provider")
+	}
+	if cc == nil || cc.Issue == nil {
+		return nil, errors.New("coordinator: missing issue")
+	}
+	if chosen == nil {
+		return nil, errors.New("coordinator: missing chosen sketch")
+	}
+	if patch == nil || strings.TrimSpace(patch.Diff) == "" {
+		return nil, errors.New("coordinator: empty patch")
+	}
+
+	system := "You are the Coordinator for aidev, a multi-agent coding tool.\n" +
+		"\n" +
+		"You are a senior engineer reviewing a unified git diff that the\n" +
+		"Implementer just produced. The diff has NOT been written to disk\n" +
+		"yet — your review decides whether it ships as-is or goes back to\n" +
+		"the Implementer with feedback. The developer trusts you as the\n" +
+		"last line of defense against the Implementer's most common\n" +
+		"failure modes. Be strict but constructive.\n" +
+		"\n" +
+		"REVIEW RUBRIC — look for:\n" +
+		"\n" +
+		"1. FABRICATION. Any content-bearing literal (translation\n" +
+		"   string, brand name, URL, API identifier, user-visible copy)\n" +
+		"   that the Implementer invented rather than copied from a real\n" +
+		"   source in the repo. If a diff adds 'Kontakt Vertrieb' as a\n" +
+		"   German translation and you can't see the Implementer was\n" +
+		"   shown the existing German file with that exact value, flag\n" +
+		"   it — the Implementer should have used NEED_FILES.\n" +
+		"\n" +
+		"2. INVALID SYNTAX FOR FILE FORMAT. JSON hunks containing // or\n" +
+		"   /* */ comments (JSON has no comments). YAML hunks with tab\n" +
+		"   indentation (YAML requires spaces). TOML hunks with trailing\n" +
+		"   commas. CSV hunks with unescaped commas in values. Check the\n" +
+		"   file extension against the hunk content.\n" +
+		"\n" +
+		"3. AUXILIARY TODO/CHECKLIST FILES. AIDEV_TODO_*.md, NOTES.md,\n" +
+		"   CHECKLIST.md, HUMAN_FOLLOWUP.md, or any markdown file that\n" +
+		"   reads like 'here's what the human still needs to do'. These\n" +
+		"   are NEVER acceptable. The diff IS the work. If the Implementer\n" +
+		"   thought it needed a companion file to track unfinished work,\n" +
+		"   the work is unfinished and the diff should be rejected with\n" +
+		"   feedback to finish it.\n" +
+		"\n" +
+		"4. PARTIAL SCOPE. A diff that touches 8 of 9 locales, 3 of 5\n" +
+		"   call sites, or half a migration. Consolidation tasks must be\n" +
+		"   complete within their scope. Half-done is a regression, not\n" +
+		"   a starting point.\n" +
+		"\n" +
+		"5. DANGLING REFERENCES. The diff deletes a key/function/import\n" +
+		"   but leaves one or more call sites using the deleted name.\n" +
+		"   The diff won't compile or will fail at runtime.\n" +
+		"\n" +
+		"6. MISSING TESTS. A diff that adds new behaviour without tests\n" +
+		"   in the same diff — unless the change is purely configuration,\n" +
+		"   documentation, or a truly trivial edit (a typo fix, a\n" +
+		"   rename). Tests are not optional follow-ups.\n" +
+		"\n" +
+		"7. SCOPE CREEP. The diff reformats unrelated code, 'fixes' a\n" +
+		"   nearby bug, or bundles a refactor the sketch didn't ask for.\n" +
+		"   Stay inside the sketch's boundary.\n" +
+		"\n" +
+		"NON-ISSUES — do NOT reject for:\n" +
+		"\n" +
+		"  - Stylistic preferences the sketch didn't mandate\n" +
+		"  - Suboptimal (but correct) algorithmic choices\n" +
+		"  - Variable naming that isn't actively wrong\n" +
+		"  - Things that are already tracked in .aidev/followups.md\n" +
+		"\n" +
+		"OUTPUT FORMAT — the first line of your response MUST be EXACTLY\n" +
+		"ONE of:\n" +
+		"\n" +
+		"   APPROVED: <one-sentence rationale>\n" +
+		"\n" +
+		"   CONCERNS: <one-sentence summary>\n" +
+		"\n" +
+		"If you emit CONCERNS:, follow with a blank line and a bullet\n" +
+		"list — one bullet per concrete issue, each with a file path\n" +
+		"and what the Implementer should change. Example:\n" +
+		"\n" +
+		"   CONCERNS: German and French locale values are fabricated placeholders.\n" +
+		"\n" +
+		"   - locales/de/common.json: the value \"Kontakt Vertrieb\" for\n" +
+		"     cta.contactSales is fabricated. The Implementer needs to\n" +
+		"     NEED_FILES locales/de/common.json and copy the existing\n" +
+		"     hero.sales value verbatim.\n" +
+		"   - locales/fr/common.json: same issue — request and copy\n" +
+		"     the existing French value.\n" +
+		"\n" +
+		"Be specific. 'The diff has problems' is not actionable\n" +
+		"feedback. 'locales/de/common.json line 14 uses a made-up\n" +
+		"German string' is. Every bullet should tell the Implementer\n" +
+		"exactly what to change and why.\n" +
+		"\n" +
+		"Approve eagerly when the diff is good. You are not looking for\n" +
+		"perfection — you are looking for failure modes. When you are\n" +
+		"unsure, prefer approval with a one-line advisory rationale\n" +
+		"over blocking — the Reviewer agent will do a second pass after\n" +
+		"the patch is applied."
+
+	var user strings.Builder
+	fmt.Fprintf(&user, "## Issue %s/%s#%d: %s\n\n", cc.Issue.Owner, cc.Issue.Repo, cc.Issue.Number, cc.Issue.Title)
+	user.WriteString(cc.Issue.Body)
+	user.WriteString("\n\n## Scout brief\n\n")
+	user.WriteString(cc.ScoutReport)
+	if cc.CriticReport != "" {
+		user.WriteString("\n\n## Critic report\n\n")
+		user.WriteString(cc.CriticReport)
+	}
+	fmt.Fprintf(&user, "\n\n## Chosen sketch %d: %s\n\n", chosen.Number, chosen.Title)
+	user.WriteString(chosen.Markdown)
+
+	if len(cc.Principles) > 0 {
+		user.WriteString("\n\n## Engineering principles\n\n")
+		for _, p := range cc.Principles {
+			fmt.Fprintf(&user, "- **%s** — %s\n", p.Name, p.Summary)
+		}
+	}
+
+	user.WriteString("\n\n## Implementer diff under review\n\n")
+	user.WriteString("```diff\n")
+	user.WriteString(patch.Diff)
+	user.WriteString("\n```\n")
+
+	user.WriteString("\n\nApply the rubric above to this diff and emit APPROVED or CONCERNS per the output format.")
+
+	resp, err := co.Provider.Complete(ctx, llm.Request{
+		System: system,
+		Messages: []llm.Message{
+			{Role: "user", Content: user.String()},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("coordinator: %w", err)
+	}
+	return parseCoordinatorReview(resp.Content)
+}
+
+// parseCoordinatorReview extracts an APPROVED or CONCERNS verdict
+// from a raw Coordinator response. Tolerates a stray leading code
+// fence (some models wrap their whole response) and extra blank
+// lines before the verdict. Exported indirectly via tests so the
+// grammar is explicit.
+func parseCoordinatorReview(raw string) (*CoordinatorReview, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, errors.New("coordinator: empty response")
+	}
+	raw = stripCodeFence(raw)
+	raw = strings.TrimSpace(raw)
+
+	lines := strings.SplitN(raw, "\n", 2)
+	first := strings.TrimSpace(lines[0])
+
+	switch {
+	case strings.HasPrefix(first, "APPROVED:"):
+		rationale := strings.TrimSpace(strings.TrimPrefix(first, "APPROVED:"))
+		return &CoordinatorReview{
+			Approved:  true,
+			Rationale: rationale,
+			Raw:       raw,
+		}, nil
+
+	case strings.HasPrefix(first, "CONCERNS:"):
+		rationale := strings.TrimSpace(strings.TrimPrefix(first, "CONCERNS:"))
+		// The body (everything after the first line) is the
+		// feedback bullet list that gets threaded back into the
+		// Implementer's prompt on retry. Trim so a blank line
+		// after CONCERNS: doesn't become leading whitespace in
+		// the feedback.
+		var feedback string
+		if len(lines) > 1 {
+			feedback = strings.TrimSpace(lines[1])
+		}
+		if feedback == "" {
+			return nil, fmt.Errorf("coordinator: CONCERNS verdict with no feedback body — model should have emitted at least one bullet")
+		}
+		return &CoordinatorReview{
+			Approved:  false,
+			Feedback:  feedback,
+			Rationale: rationale,
+			Raw:       raw,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("coordinator: expected 'APPROVED:' or 'CONCERNS:' at start of response, got %q", firstLine(raw))
+	}
+}

--- a/internal/agents/coordinator_test.go
+++ b/internal/agents/coordinator_test.go
@@ -1,0 +1,136 @@
+package agents
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aisu-ai/aidev/internal/github"
+)
+
+func TestParseCoordinatorReviewApproved(t *testing.T) {
+	raw := "APPROVED: diff correctly migrates the 9 locale files and imports.\n"
+	got, err := parseCoordinatorReview(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Approved {
+		t.Errorf("want Approved, got %+v", got)
+	}
+	if !strings.Contains(got.Rationale, "9 locale files") {
+		t.Errorf("rationale = %q", got.Rationale)
+	}
+	if got.Feedback != "" {
+		t.Errorf("approved review should not have feedback; got %q", got.Feedback)
+	}
+}
+
+func TestParseCoordinatorReviewConcerns(t *testing.T) {
+	raw := "CONCERNS: German and French values are fabricated.\n\n- locales/de/common.json: \"Kontakt Vertrieb\" is invented; request the real value via NEED_FILES\n- locales/fr/common.json: same issue\n"
+	got, err := parseCoordinatorReview(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Approved {
+		t.Errorf("expected not Approved, got %+v", got)
+	}
+	if !strings.Contains(got.Rationale, "fabricated") {
+		t.Errorf("rationale = %q", got.Rationale)
+	}
+	if !strings.Contains(got.Feedback, "Kontakt Vertrieb") {
+		t.Errorf("feedback missing de bullet; got:\n%s", got.Feedback)
+	}
+	if !strings.Contains(got.Feedback, "locales/fr") {
+		t.Errorf("feedback missing fr bullet; got:\n%s", got.Feedback)
+	}
+}
+
+func TestParseCoordinatorReviewStripsLeadingFence(t *testing.T) {
+	raw := "```\nAPPROVED: all good.\n```\n"
+	got, err := parseCoordinatorReview(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Approved {
+		t.Error("fence-stripped approved response should still parse")
+	}
+}
+
+func TestParseCoordinatorReviewRejectsUnknownVerdict(t *testing.T) {
+	_, err := parseCoordinatorReview("MAYBE: who knows\n")
+	if err == nil {
+		t.Error("expected error on unknown verdict")
+	}
+}
+
+func TestParseCoordinatorReviewRejectsEmptyConcernsBody(t *testing.T) {
+	_, err := parseCoordinatorReview("CONCERNS: things are bad\n")
+	if err == nil {
+		t.Error("expected error on CONCERNS without a body")
+	}
+}
+
+func TestParseCoordinatorReviewRejectsEmpty(t *testing.T) {
+	_, err := parseCoordinatorReview("")
+	if err == nil {
+		t.Error("expected error on empty")
+	}
+	_, err = parseCoordinatorReview("   \n  \n")
+	if err == nil {
+		t.Error("expected error on whitespace-only")
+	}
+}
+
+// TestCoordinatorReviewPromptIncludesDiff drives an end-to-end
+// Review call with a capturing provider to verify the prompt the
+// model receives includes the diff body under a review heading and
+// echoes the issue/sketch context. This is the regression guard
+// against a refactor that accidentally drops the diff from the
+// prompt — a subtle failure mode where the Coordinator would
+// "review" without actually seeing the code.
+func TestCoordinatorReviewPromptIncludesDiff(t *testing.T) {
+	p := &capturingProvider{reply: "APPROVED: minimal diff, clean change.\n"}
+	co := &Coordinator{Provider: p}
+	cc := &Context{
+		Issue: &github.Issue{
+			Owner: "aisu-ai", Repo: "aidev", Number: 1,
+			Title: "T", Body: "issue body",
+		},
+		ScoutReport:  "scout brief body",
+		CriticReport: "critic body",
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "## Plan\n- x"}
+	patch := &Patch{Diff: "diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-foo\n+bar\n"}
+
+	review, err := co.Review(context.Background(), cc, sketch, patch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !review.Approved {
+		t.Error("expected approval from canned response")
+	}
+	body := p.req.Messages[0].Content
+	for _, want := range []string{
+		"## Implementer diff under review",
+		"diff --git a/x.go b/x.go",
+		"bar",
+		"## Scout brief",
+		"## Chosen sketch 1",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("prompt missing %q; got:\n%s", want, body)
+		}
+	}
+}
+
+func TestCoordinatorRejectsEmptyPatch(t *testing.T) {
+	co := &Coordinator{Provider: &capturingProvider{}}
+	cc := &Context{
+		Issue: &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "T", Body: "b"},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+	_, err := co.Review(context.Background(), cc, sketch, &Patch{Diff: "   "})
+	if err == nil {
+		t.Error("expected error on whitespace-only diff")
+	}
+}

--- a/internal/agents/implementer.go
+++ b/internal/agents/implementer.go
@@ -533,6 +533,18 @@ func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sket
 		fmt.Fprintf(&user, "- **%s** — %s\n", p.Name, p.Summary)
 	}
 
+	// If the Coordinator reviewed a previous attempt at this sketch
+	// and flagged concerns, surface them as the LAST section of the
+	// prompt so they're the most recent thing the model sees. The
+	// feedback is authoritative — it represents the user's quality
+	// bar as enforced by a cloud-backed reviewer — and must be
+	// addressed one-by-one before another response is emitted.
+	if strings.TrimSpace(c.CoordinatorFeedback) != "" {
+		user.WriteString("\n\n## Coordinator feedback on your previous attempt (AUTHORITATIVE — address each item)\n\n")
+		user.WriteString(c.CoordinatorFeedback)
+		user.WriteString("\n\nRe-emit a COMPLETE diff that addresses every concern above. If any concern requires reading additional files, use NEED_FILES. Do NOT re-submit the same diff with minor tweaks — the Coordinator will catch it again.\n")
+	}
+
 	resp, err := i.Provider.Complete(ctx, llm.Request{
 		System: system,
 		Messages: []llm.Message{

--- a/internal/installpkg/files/models.local.yaml
+++ b/internal/installpkg/files/models.local.yaml
@@ -87,11 +87,21 @@ tiers:
 # definitions above differ — the roles themselves want the same
 # relative size of model regardless of whether the backend is local
 # or cloud.
+#
+# Note: in this fully-local preset, the Coordinator also runs on a
+# local model (qwen2.5:32b). If you have Claude CLI available and
+# want the "local horse, cloud jockey" shape — local Implementer
+# with a cloud-backed Coordinator that catches fabrication and
+# invalid-syntax failures — create your own `models.local-mixed.yaml`
+# with `coordinator` routed to a `cloud_large` tier that uses
+# `provider: claude-cli`. This preset is intentionally 100% offline
+# to serve the air-gapped / privacy-first use case.
 routing:
   scout: small
   critic: large
   architect: large
   charter: large
+  coordinator: large
   implementer: medium
   reviewer: medium
   tester: small

--- a/internal/installpkg/files/models.yaml
+++ b/internal/installpkg/files/models.yaml
@@ -40,14 +40,24 @@ tiers:
     temperature: 0.3
 
 # Role -> tier routing. Roles that need deep reasoning (critic,
-# architect, charter, reviewer) use the large tier. Implementer uses
-# medium. Scout and tester are routed to the small local tier for speed
-# and cost.
+# architect, charter, coordinator) use the large tier. Implementer
+# and reviewer use medium. Scout and tester are routed to the small
+# local tier for speed and cost.
+#
+# coordinator is aidev's Gate-1 safety net: it reviews the
+# Implementer's diff before it's written to disk and catches common
+# failure modes (fabrication, invalid syntax for the file format,
+# auxiliary TODO files, partial scope). It runs on the large tier
+# because catching those failures is a judgment task — the same
+# reason the Critic runs there. If you're running a local
+# Implementer (see models.local.yaml), keeping the Coordinator on a
+# cloud tier is the recommended "local horse, cloud jockey" shape.
 routing:
   scout: small
   critic: large
   architect: large
   charter: large
+  coordinator: large
   implementer: medium
   reviewer: medium
   tester: small

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -27,6 +27,13 @@ const (
 	RoleImplementer Role = "implementer"
 	RoleReviewer    Role = "reviewer"
 	RoleTester      Role = "tester"
+	// RoleCoordinator is the cloud-backed safety net that reviews the
+	// Implementer's diff before it hits disk. Wired into the
+	// orchestrator's Implement loop at Gate 1 (post-Implementer,
+	// pre-WriteTo). Typically routed to the large tier because catching
+	// fabrication and invalid-syntax failures is a judgment task — the
+	// same reason the Critic and Architect run there.
+	RoleCoordinator Role = "coordinator"
 )
 
 // Message is a single turn in a conversation. Role is "user" or "assistant".

--- a/internal/llm/router.go
+++ b/internal/llm/router.go
@@ -48,10 +48,27 @@ func buildProvider(t config.Tier) (Provider, error) {
 
 // For returns the Provider assigned to the given role. Unknown roles return
 // an error so callers are forced to update routing when a new agent is added.
+//
+// RoleCoordinator is the one exception: because it was added after users
+// already had models.yaml files on disk, an unrouted Coordinator role
+// transparently falls back to RoleCritic's tier (both are judgment tasks
+// that want the large tier). This keeps older configs working without a
+// config migration step. The fallback is logged nowhere because it's the
+// correct default; users who want a different tier for the Coordinator
+// specifically add 'coordinator: <tier>' to their routing block and the
+// fallback never fires.
 func (r *Router) For(role Role) (Provider, error) {
 	tier, ok := r.routing[string(role)]
 	if !ok {
-		return nil, fmt.Errorf("router: no tier configured for role %q", role)
+		if role == RoleCoordinator {
+			if fallback, haveCritic := r.routing[string(RoleCritic)]; haveCritic {
+				tier = fallback
+				ok = true
+			}
+		}
+		if !ok {
+			return nil, fmt.Errorf("router: no tier configured for role %q", role)
+		}
 	}
 	p, ok := r.tiers[tier]
 	if !ok {

--- a/internal/orchestrator/coordinator_gate_test.go
+++ b/internal/orchestrator/coordinator_gate_test.go
@@ -1,0 +1,293 @@
+package orchestrator
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aisu-ai/aidev/internal/agents"
+	"github.com/aisu-ai/aidev/internal/github"
+	"github.com/aisu-ai/aidev/internal/llm"
+	"github.com/aisu-ai/aidev/internal/repo"
+)
+
+// scriptedProvider replays a fixed sequence of canned responses
+// across successive Complete() calls. Used by the Gate-1 loop tests
+// to drive the Implementer ↔ Coordinator back-and-forth without
+// hitting a real LLM. Not exported — these helpers are deliberately
+// duplicated rather than shared via a testutil package so the public
+// API surface stays minimal.
+type scriptedProvider struct {
+	name      string
+	responses []string
+	calls     int
+}
+
+func (p *scriptedProvider) Name() string { return p.name }
+func (p *scriptedProvider) Complete(_ context.Context, _ llm.Request) (llm.Response, error) {
+	idx := p.calls
+	if idx >= len(p.responses) {
+		idx = len(p.responses) - 1
+	}
+	p.calls++
+	return llm.Response{Content: p.responses[idx]}, nil
+}
+
+func newTestOrchestrator(t *testing.T, dir string, implProvider, coordProvider llm.Provider) *Orchestrator {
+	t.Helper()
+	return &Orchestrator{
+		state: StateSketchesReady,
+		ctx: &agents.Context{
+			Issue: &github.Issue{
+				Owner: "aisu-ai", Repo: "aidev", Number: 1,
+				Title: "T", Body: "test body",
+			},
+			Snapshot: &repo.Snapshot{Root: dir},
+			Sketches: []agents.Sketch{
+				{Number: 1, Title: "test sketch", Markdown: "## Plan\n- do the thing"},
+			},
+		},
+		implementer: &agents.Implementer{Provider: implProvider},
+		coordinator: &agents.Coordinator{Provider: coordProvider},
+		reporterLog: io.Discard,
+	}
+}
+
+// TestImplementGateCoordinatorApprovesFirstRun drives the happy
+// path: Implementer produces a clean diff, Coordinator approves on
+// the first pass, the patch is written to disk and patch_ready is
+// emitted. No retries.
+func TestImplementGateCoordinatorApprovesFirstRun(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	impl := &scriptedProvider{
+		name: "impl",
+		responses: []string{
+			`["x.go"]`, // picker
+			"diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-package x\n+package y\n",
+		},
+	}
+	coord := &scriptedProvider{
+		name: "coord",
+		responses: []string{
+			"APPROVED: minimal rename, correct.\n",
+		},
+	}
+	o := newTestOrchestrator(t, dir, impl, coord)
+
+	var gotPatchReady bool
+	for ev := range o.Implement(context.Background(), 1) {
+		if ev.Err != nil {
+			t.Fatalf("unexpected error: %v", ev.Err)
+		}
+		if ev.State == StatePatchReady {
+			gotPatchReady = true
+			if !strings.Contains(ev.Message, "APPROVED") {
+				t.Errorf("expected APPROVED in message, got %q", ev.Message)
+			}
+		}
+	}
+	if !gotPatchReady {
+		t.Fatal("never reached patch_ready")
+	}
+	if o.Patch() == nil {
+		t.Fatal("orchestrator.Patch() nil after approval")
+	}
+	if o.CoordinatorReview() == nil || !o.CoordinatorReview().Approved {
+		t.Error("CoordinatorReview should be set and approved")
+	}
+	// Implementer ran exactly once (picker + diff = 2 calls); no retry.
+	if impl.calls != 2 {
+		t.Errorf("implementer called %d times, want 2 (picker + diff, no retry)", impl.calls)
+	}
+	if coord.calls != 1 {
+		t.Errorf("coordinator called %d times, want 1", coord.calls)
+	}
+}
+
+// TestImplementGateRetryWithFeedback drives the interesting case:
+// Implementer produces a diff, Coordinator flags concerns, feedback
+// goes back into Context.CoordinatorFeedback, Implementer produces
+// a better diff on the retry, Coordinator approves. Asserts the
+// retry actually happened and the final patch is the second
+// Implementer's output.
+func TestImplementGateRetryWithFeedback(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	impl := &scriptedProvider{
+		name: "impl",
+		responses: []string{
+			// Attempt 1: picker + bad diff (placeholder value)
+			`["x.go"]`,
+			"diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-package x\n+package PLACEHOLDER\n",
+			// Attempt 2: picker + corrected diff
+			`["x.go"]`,
+			"diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-package x\n+package y\n",
+		},
+	}
+	coord := &scriptedProvider{
+		name: "coord",
+		responses: []string{
+			"CONCERNS: PLACEHOLDER is fabricated.\n\n- x.go: 'package PLACEHOLDER' is a fabricated identifier. Use the real package name 'y' per the sketch.\n",
+			"APPROVED: corrected to 'package y' as directed.\n",
+		},
+	}
+	o := newTestOrchestrator(t, dir, impl, coord)
+
+	var messages []string
+	for ev := range o.Implement(context.Background(), 1) {
+		if ev.Err != nil {
+			t.Fatalf("unexpected error: %v", ev.Err)
+		}
+		if ev.Message != "" {
+			messages = append(messages, ev.Message)
+		}
+	}
+
+	if impl.calls != 4 {
+		t.Errorf("implementer called %d times, want 4 (2 attempts × picker+diff)", impl.calls)
+	}
+	if coord.calls != 2 {
+		t.Errorf("coordinator called %d times, want 2 (one CONCERNS + one APPROVED)", coord.calls)
+	}
+	p := o.Patch()
+	if p == nil {
+		t.Fatal("nil patch after successful retry")
+	}
+	if !strings.Contains(p.Diff, "+package y") {
+		t.Errorf("final patch should contain corrected 'package y', got:\n%s", p.Diff)
+	}
+	if strings.Contains(p.Diff, "PLACEHOLDER") {
+		t.Errorf("final patch still contains PLACEHOLDER; retry didn't override first attempt")
+	}
+	// Check that the orchestrator emitted a "re-running with feedback" message.
+	var sawRetry bool
+	for _, m := range messages {
+		if strings.Contains(m, "re-running Implementer with feedback") {
+			sawRetry = true
+		}
+	}
+	if !sawRetry {
+		t.Errorf("expected a 're-running Implementer with feedback' event; got messages:\n%s", strings.Join(messages, "\n---\n"))
+	}
+}
+
+// TestImplementGateCapReachedAdvisoryFallthrough drives the cap
+// path: Coordinator rejects every attempt up to the retry cap. The
+// orchestrator must still write the final patch (teammate mode, not
+// gatekeeper mode) and emit patch_ready with an advisory message
+// that surfaces the Coordinator's concerns.
+func TestImplementGateCapReachedAdvisoryFallthrough(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// maxCoordinatorRounds + 1 attempts total.
+	mkAttempt := func() []string {
+		return []string{
+			`["x.go"]`,
+			"diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-package x\n+package still_wrong\n",
+		}
+	}
+	var implScript []string
+	for i := 0; i <= maxCoordinatorRounds; i++ {
+		implScript = append(implScript, mkAttempt()...)
+	}
+	impl := &scriptedProvider{name: "impl", responses: implScript}
+
+	var coordScript []string
+	for i := 0; i <= maxCoordinatorRounds; i++ {
+		coordScript = append(coordScript, "CONCERNS: still wrong.\n\n- x.go: still not right, try again\n")
+	}
+	coord := &scriptedProvider{name: "coord", responses: coordScript}
+
+	o := newTestOrchestrator(t, dir, impl, coord)
+
+	var finalMsg string
+	for ev := range o.Implement(context.Background(), 1) {
+		if ev.Err != nil {
+			t.Fatalf("unexpected error: %v", ev.Err)
+		}
+		if ev.State == StatePatchReady {
+			finalMsg = ev.Message
+		}
+	}
+
+	if o.Patch() == nil {
+		t.Fatal("patch should still be written in advisory mode, got nil")
+	}
+	if o.CoordinatorReview() == nil || o.CoordinatorReview().Approved {
+		t.Error("coordReview should be set and NOT approved after cap")
+	}
+	if !strings.Contains(finalMsg, "Coordinator still has concerns") {
+		t.Errorf("final patch_ready message should advise on Coordinator concerns; got: %s", finalMsg)
+	}
+	expectedImplCalls := (maxCoordinatorRounds + 1) * 2 // picker+diff per attempt
+	if impl.calls != expectedImplCalls {
+		t.Errorf("implementer called %d times, want %d (%d attempts × picker+diff)", impl.calls, expectedImplCalls, maxCoordinatorRounds+1)
+	}
+}
+
+// TestImplementGateCoordinatorErrorIsNonFatal verifies the safety
+// net: if the Coordinator's own Provider errors (e.g. rate limit,
+// network drop), we log and proceed as if approved. The Coordinator
+// is a safety net, not a hard gate — a broken cloud connection must
+// never block the user's patch.
+func TestImplementGateCoordinatorErrorIsNonFatal(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	impl := &scriptedProvider{
+		name: "impl",
+		responses: []string{
+			`["x.go"]`,
+			"diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-package x\n+package y\n",
+		},
+	}
+	coord := &errorProvider{err: "simulated rate limit"}
+	o := newTestOrchestrator(t, dir, impl, coord)
+
+	var gotPatchReady bool
+	for ev := range o.Implement(context.Background(), 1) {
+		if ev.Err != nil {
+			t.Fatalf("Coordinator error should be non-fatal, got: %v", ev.Err)
+		}
+		if ev.State == StatePatchReady {
+			gotPatchReady = true
+		}
+	}
+	if !gotPatchReady {
+		t.Fatal("patch_ready should still fire when Coordinator errors")
+	}
+	if o.Patch() == nil {
+		t.Fatal("patch should still be produced")
+	}
+	if o.CoordinatorReview() != nil {
+		t.Error("CoordinatorReview should be nil when Coordinator provider errored")
+	}
+}
+
+type errorProvider struct {
+	err string
+}
+
+func (p *errorProvider) Name() string { return "errorProvider" }
+func (p *errorProvider) Complete(_ context.Context, _ llm.Request) (llm.Response, error) {
+	return llm.Response{}, &providerError{msg: p.err}
+}
+
+type providerError struct{ msg string }
+
+func (e *providerError) Error() string { return e.msg }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -80,10 +80,12 @@ type Orchestrator struct {
 	critic      *agents.Critic
 	architect   *agents.Architect
 	implementer *agents.Implementer
+	coordinator *agents.Coordinator
 	tester      *agents.Tester
 	reviewer    *agents.Reviewer
 	critRpt     *agents.Report
 	patch       *agents.Patch
+	coordReview *agents.CoordinatorReview
 	testResult  *agents.TestResult
 	review      *agents.Review
 
@@ -192,6 +194,10 @@ func New(cfg *config.Config, opts ...Option) (*Orchestrator, error) {
 	if err != nil {
 		return nil, err
 	}
+	coordinator, err := agents.NewCoordinator(router)
+	if err != nil {
+		return nil, err
+	}
 	tester, err := agents.NewTester(router)
 	if err != nil {
 		return nil, err
@@ -204,6 +210,7 @@ func New(cfg *config.Config, opts ...Option) (*Orchestrator, error) {
 	o.critic = critic
 	o.architect = architect
 	o.implementer = implementer
+	o.coordinator = coordinator
 	o.tester = tester
 	o.reviewer = reviewer
 	return o, nil
@@ -308,10 +315,38 @@ func passedOrFailed(b bool) string {
 // Patch returns the last Implementer patch, if any.
 func (o *Orchestrator) Patch() *agents.Patch { return o.patch }
 
+// maxCoordinatorRounds is the cap on how many times the Implement
+// loop will send the Implementer back with Coordinator feedback
+// before giving up and writing the patch anyway (advisory mode).
+// Two extra rounds past the initial attempt means up to 3
+// Implementer runs per Implement() call in the worst case, which is
+// bounded cost and enough headroom for the model to respond to
+// specific concerns. If the Coordinator is still rejecting after
+// three rounds, something is wrong that further retries won't fix.
+const maxCoordinatorRounds = 2
+
 // Implement runs the Implementer against the chosen sketch index
 // (1-indexed into c.Sketches). Must be called after StateSketchesReady.
-// Emits a patch_ready event on success and writes the diff to
-// `<repo>/.aidev/proposed.patch` so the user can `git apply` it.
+//
+// The Implement flow is a bounded Implementer <-> Coordinator loop:
+//
+//  1. Implementer produces a diff.
+//  2. Coordinator reviews the diff against the rubric (fabrication,
+//     invalid syntax for the file format, auxiliary TODO files,
+//     partial scope, dangling references, missing tests, scope
+//     creep).
+//  3. If APPROVED, write the patch to disk and emit patch_ready.
+//  4. If CONCERNS and we're under the retry cap, stash the feedback
+//     on ctx.CoordinatorFeedback and call the Implementer again.
+//  5. If CONCERNS and we've hit the cap, write the patch anyway AND
+//     surface the Coordinator's concerns in the patch_ready event's
+//     advisory field. The user sees both the patch and the concerns
+//     and decides. This is the deliberate "teammate, not gatekeeper"
+//     default — we never silently drop work on the floor.
+//
+// Emits a patch_ready event on success (or on cap-reached advisory
+// mode) and writes the diff to `<repo>/.aidev/proposed.patch` so the
+// user can `git apply` it.
 func (o *Orchestrator) Implement(ctx context.Context, sketchNumber int) <-chan Event {
 	out := make(chan Event, 4)
 	go func() {
@@ -342,11 +377,51 @@ func (o *Orchestrator) Implement(ctx context.Context, sketchNumber int) <-chan E
 			Message: fmt.Sprintf("Implementing sketch %d: %s", chosen.Number, chosen.Title),
 		})
 
-		patch, err := o.implementer.Run(ctx, o.ctx, &chosen)
-		if err != nil {
-			o.state = StateError
-			o.emit(ctx, out, Event{State: StateError, Err: err})
-			return
+		// Clear any stale Coordinator feedback from a previous run
+		// so it can't leak into the first attempt of this sketch.
+		o.ctx.CoordinatorFeedback = ""
+		o.coordReview = nil
+
+		var patch *agents.Patch
+		var review *agents.CoordinatorReview
+
+		for round := 0; round <= maxCoordinatorRounds; round++ {
+			p, err := o.implementer.Run(ctx, o.ctx, &chosen)
+			if err != nil {
+				o.state = StateError
+				o.emit(ctx, out, Event{State: StateError, Err: err})
+				return
+			}
+			patch = p
+
+			// Gate 1: Coordinator review. A Coordinator error is
+			// non-fatal — we log it and proceed as if approved.
+			// The Coordinator is a safety net, not a gate; a broken
+			// cloud connection shouldn't block the user's patch.
+			r, cerr := o.coordinator.Review(ctx, o.ctx, &chosen, patch)
+			if cerr != nil {
+				fmt.Fprintf(o.reporterLog, "aidev coordinator: review failed, proceeding without: %v\n", cerr)
+				review = nil
+				break
+			}
+			review = r
+
+			if review.Approved {
+				break
+			}
+
+			// CONCERNS. If we still have retry budget, send the
+			// Implementer back with the feedback.
+			if round == maxCoordinatorRounds {
+				// Cap reached. Fall through with the latest patch
+				// and the latest review so the user sees both.
+				break
+			}
+			o.emit(ctx, out, Event{
+				State:   o.state,
+				Message: fmt.Sprintf("Coordinator flagged concerns (round %d/%d); re-running Implementer with feedback", round+1, maxCoordinatorRounds+1),
+			})
+			o.ctx.CoordinatorFeedback = review.Feedback
 		}
 
 		// Write the patch to disk so the user can git apply it. Failure
@@ -357,16 +432,29 @@ func (o *Orchestrator) Implement(ctx context.Context, sketchNumber int) <-chan E
 			}
 		}
 		o.patch = patch
+		o.coordReview = review
 
 		o.state = StatePatchReady
 		msg := fmt.Sprintf("Patch ready: %d files touched.", len(patch.FilesTouched))
 		if patch.Path != "" {
 			msg += " Saved to " + patch.Path
 		}
+		if review != nil && !review.Approved {
+			msg += "\n\n⚠️ Coordinator still has concerns after " + fmt.Sprint(maxCoordinatorRounds+1) + " attempts — see Coordinator review below. Patch is advisory; review carefully before applying."
+		} else if review != nil && review.Approved {
+			msg += "\nCoordinator: APPROVED — " + review.Rationale
+		}
 		o.emit(ctx, out, Event{State: o.state, Message: msg})
 	}()
 	return out
 }
+
+// CoordinatorReview returns the last Coordinator review, if any.
+// Nil when no Implement() call has run yet or when the Coordinator
+// was unavailable on the most recent attempt (errors are logged, not
+// propagated; the patch is still produced and this method returns
+// nil in that case).
+func (o *Orchestrator) CoordinatorReview() *agents.CoordinatorReview { return o.coordReview }
 
 // Router exposes the router so the TUI can display provider health.
 func (o *Orchestrator) Router() *llm.Router { return o.router }


### PR DESCRIPTION
## Summary

Second half of the 'enable and enhance the collaboration' sequence. #32 shipped the `--preset` flag and fully-local `models.local.yaml`. This PR ships the cloud-backed safety net that catches the failure modes local coder models are most likely to hit, and that the Implementer's own prompt can only partially guard against.

## The shape

Between the Implementer producing a diff and the diff being written to `.aidev/proposed.patch`, the orchestrator now runs a Coordinator review pass. The Coordinator is a senior-engineer-reviewing-PR persona routed to the `large` tier by default. It applies a concrete rubric — fabrication, invalid syntax for the target file format, auxiliary TODO files, partial scope, dangling references, missing tests, scope creep — and emits either:

```
APPROVED: <one-line rationale>
```

or

```
CONCERNS: <summary>

- <bullet with file path and what to change>
- <...>
```

On **APPROVED**, the orchestrator writes the patch to disk and emits `patch_ready` with `Coordinator: APPROVED — <rationale>` in the message.

On **CONCERNS**, the orchestrator stashes the bullet list on `Context.CoordinatorFeedback` and calls the Implementer again. The Implementer's prompt reads the feedback as 'Coordinator feedback on your previous attempt (AUTHORITATIVE — address each item)' and emits a corrected diff (or `NEED_FILES` if the concerns require seeing more files).

Up to `maxCoordinatorRounds = 2` retries. On cap-reached, the orchestrator writes the LATEST patch anyway and emits `patch_ready` with an advisory warning. This is the deliberate teammate-not-gatekeeper default: we surface both views and let the user decide, never silently drop work on the floor.

Coordinator errors (rate limit, network drop) are **non-fatal**. If the Coordinator's own provider returns an error we log it and proceed as if approved. A broken cloud connection must never block the user's patch — the Coordinator is a safety net, not a hard gate.

## Plumbing

- `internal/llm/provider.go` new `RoleCoordinator` constant.
- `internal/llm/router.go` `For(RoleCoordinator)` falls back to the Critic's tier when no explicit coordinator routing is set, so users on older `models.yaml` files don't break on upgrade.
- `internal/agents/agent.go` `Context.CoordinatorFeedback string` field. Cleared at the start of each `Implement()` call so stale feedback from a previous issue can't leak into a new one.
- `internal/agents/implementer.go` `generateDiff` appends the Coordinator feedback as the LAST section of the user prompt when non-empty, with 'address each item' framing.
- `internal/agents/coordinator.go` new `Coordinator` agent, `Review` method, `parseCoordinatorReview` grammar (APPROVED/CONCERNS first-line discriminator, tolerant of a stray leading code fence).
- `internal/orchestrator/orchestrator.go` `Implement()` rewritten as a bounded retry loop; new `CoordinatorReview()` accessor so the TUI and headless report can show the verdict.

## Default routing updates

`config/models.yaml` routes `coordinator -> large` explicitly. `config/models.local.yaml` also routes it to large (the all-local 32b tier) — the preset is intentionally 100% offline for the air-gapped use case, but the file's comments call out the 'local horse, cloud jockey' recipe for users who want a cloud-backed Coordinator alongside a local Implementer.

## Tests

- `TestParseCoordinatorReview{Approved,Concerns,StripsLeadingFence,RejectsUnknownVerdict,RejectsEmptyConcernsBody,RejectsEmpty}` grammar + tolerance.
- `TestCoordinatorReviewPromptIncludesDiff` the prompt sent to the model must actually contain the diff body. Regression guard against a refactor that drops the diff from the prompt — a 'reviews without looking at the code' failure mode.
- `TestCoordinatorRejectsEmptyPatch` API surface guard.
- `TestImplementGateCoordinatorApprovesFirstRun` happy path.
- `TestImplementGateRetryWithFeedback` Implementer produces PLACEHOLDER, Coordinator rejects with specific bullet, Implementer retries with feedback in its prompt and produces corrected diff, Coordinator approves. Asserts the final patch is the second attempt's output (not the first), a 're-running with feedback' event fired, and call counts match exactly.
- `TestImplementGateCapReachedAdvisoryFallthrough` Coordinator rejects `maxCoordinatorRounds+1` times. Patch still written, `patch_ready` fires with advisory warning, `CoordinatorReview()` returns the last (non-approved) review.
- `TestImplementGateCoordinatorErrorIsNonFatal` Coordinator provider errors → log + proceed. Patch still produced, `patch_ready` still fires, `CoordinatorReview()` nil.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all new orchestrator and coordinator tests pass)
- [ ] Rebuild + re-run `/aidev-run 533`. Expect: if the Implementer produces the same kind of output that failed last time (placeholder translations, `AIDEV_TODO_*.md` helper file, `// TODO` in JSON), the Coordinator catches it, feeds back specific bullets, and the Implementer produces a corrected diff on the retry. If the Coordinator still rejects after 2 rounds, the patch is written with an advisory warning surfaced in the headless report.