### PR TITLE
fix(implementer): recover from prose-format violations with a correction retry

### DIFF
--- a/internal/agents/implementer.go
+++ b/internal/agents/implementer.go
@@ -545,10 +545,37 @@ func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sket
 		user.WriteString("\n\nRe-emit a COMPLETE diff that addresses every concern above. If any concern requires reading additional files, use NEED_FILES. Do NOT re-submit the same diff with minor tweaks — the Coordinator will catch it again.\n")
 	}
 
+	// End-of-prompt format reminder. Models attend more strongly to
+	// the most recent context, so repeating the output-format rule
+	// here significantly reduces the chance of a prose response when
+	// the main system prompt is long. This is the first line of
+	// defense; tryGenerateDiff() below adds a format-correction retry
+	// for the remaining cases.
+	user.WriteString("\n\n---\nFORMAT REMINDER: the FIRST LINE of your response MUST be EXACTLY ONE of:\n  diff --git        (a real unified diff)\n  NEED_FILES: [...] (JSON array of repo-relative paths you need to see)\n  ERROR: <reason>   (genuinely impossible, explain why)\nNo prose preamble. No 'Looking at this, I need...'. No 'Here is the diff:'. The first characters of your response MUST match one of those three prefixes.")
+
+	return i.tryGenerateDiff(ctx, system, user.String(), 0)
+}
+
+// maxFormatRetries is how many times we'll nudge the model to use a
+// valid output prefix after it produces prose. One retry is enough
+// in practice — cloud models comply with a direct 'your previous
+// response violated the format, here's what you wrote, here's what
+// to do' follow-up almost always. Past one retry, something is
+// deeply wrong and further retries waste tokens without fixing it.
+const maxFormatRetries = 1
+
+// tryGenerateDiff is the underlying single-shot call. It inspects
+// the model's response against the prefix grammar and, if the model
+// wrote prose instead of a valid prefix, self-corrects by re-calling
+// with a specific follow-up message that quotes the broken response
+// back to the model and tells it to use the format. Bounded at
+// maxFormatRetries so we can't loop on a model that refuses to
+// comply.
+func (i *Implementer) tryGenerateDiff(ctx context.Context, system, userMsg string, retries int) (*Patch, []string, error) {
 	resp, err := i.Provider.Complete(ctx, llm.Request{
 		System: system,
 		Messages: []llm.Message{
-			{Role: "user", Content: user.String()},
+			{Role: "user", Content: userMsg},
 		},
 	})
 	if err != nil {
@@ -593,7 +620,29 @@ func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sket
 		}, nil, nil
 
 	default:
-		return nil, nil, fmt.Errorf("implementer: expected 'diff --git', 'NEED_FILES:', or 'ERROR:', got %q", firstLine(raw))
+		// Format violation — the model wrote prose instead of one of
+		// the three required prefixes. This is a common failure mode
+		// when the model wants to request more files but phrases the
+		// intent in natural language ("Looking at this, I need the
+		// TSX call sites...") instead of `NEED_FILES: [...]`.
+		//
+		// Recover by re-sending with a specific correction that
+		// quotes the broken response back and tells the model
+		// exactly how to fix it. Bounded at maxFormatRetries so we
+		// can't loop forever on a non-compliant model.
+		if retries >= maxFormatRetries {
+			return nil, nil, fmt.Errorf("implementer: expected 'diff --git', 'NEED_FILES:', or 'ERROR:' after %d format-correction attempts, got %q", retries, firstLine(raw))
+		}
+		corrected := userMsg +
+			"\n\n---\n## YOUR PREVIOUS RESPONSE VIOLATED THE OUTPUT FORMAT\n\n" +
+			"You wrote:\n\n> " + firstLine(raw) + "\n\n" +
+			"This is not one of the three valid prefixes. You MUST respond with EXACTLY ONE of:\n\n" +
+			"  diff --git        — if you can produce a complete unified diff now\n" +
+			"  NEED_FILES: [...] — if you need to read more repo files first (JSON array of paths)\n" +
+			"  ERROR: <reason>   — if the task is genuinely impossible\n\n" +
+			"Reading your previous response, it looks like you wanted to request more files. Re-emit your response as a literal `NEED_FILES: [\"path/one.tsx\", \"path/two.tsx\"]` directive (a single line, JSON array of repo-relative paths). No prose. The harness will load those files and call you again with the expanded context.\n\n" +
+			"If you do NOT need more files and can produce the diff directly, re-emit starting with `diff --git` on the first line and no prose preamble."
+		return i.tryGenerateDiff(ctx, system, corrected, retries+1)
 	}
 }
 

--- a/internal/agents/implementer_test.go
+++ b/internal/agents/implementer_test.go
@@ -496,6 +496,166 @@ func TestImplementerRunRejectsInfiniteNeedFiles(t *testing.T) {
 	}
 }
 
+// TestImplementerRunRecoversFromProsePrefixViolation drives the
+// format-correction retry: the Implementer's first diff-generation
+// turn responds with prose ("Looking at this, I need the TSX call
+// sites to anchor edits precisely...") instead of a valid prefix.
+// The harness must catch the violation, send the model back with a
+// corrective message that quotes the broken response, and recover
+// on the retry. This is the exact failure mode the user hit on
+// their real run — model had the right intent, wrong format.
+func TestImplementerRunRecoversFromProsePrefixViolation(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.tsx"), []byte("const Foo = () => <>hi</>\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &scriptedProvider{
+		responses: []string{
+			// Turn 1 (picker): normal JSON array.
+			`["x.tsx"]`,
+			// Turn 2 (generateDiff, initial): prose instead of a
+			// valid prefix. This is the real-world failure mode.
+			"Looking at this, I need the TSX call sites to anchor edits precisely. Could you send me the component file?",
+			// Turn 2b (generateDiff, format-corrected retry):
+			// the model now emits a valid NEED_FILES directive.
+			`NEED_FILES: ["x.tsx"]`,
+			// Turn 2c (generateDiff, post-NEED_FILES): real diff.
+			// x.tsx is already in the initial picker's contents so
+			// the NEED_FILES short-circuits on duplicate...
+		},
+	}
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "T", Body: "b"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+
+	// The scripted NEED_FILES re-requests x.tsx which is already
+	// loaded. The Run loop will reject that with
+	// "already provided" — exercising BOTH the format-correction
+	// path AND the dedup guard. We assert we make it that far (i.e.
+	// the prose didn't kill the run) by checking the error message.
+	_, err := impl.Run(context.Background(), ctx, sketch)
+	if err == nil {
+		t.Fatal("expected a later error, got nil")
+	}
+	if !strings.Contains(err.Error(), "already provided") {
+		t.Errorf("expected the NEED_FILES dedup guard to fire after format recovery, got: %v", err)
+	}
+	// Provider should have been called for: picker(1) + first
+	// generateDiff(1, prose) + format-corrected retry(1, NEED_FILES) = 3 calls.
+	if provider.calls != 3 {
+		t.Errorf("provider called %d times, want 3 (picker + prose + recovery)", provider.calls)
+	}
+}
+
+// TestImplementerRunFailsAfterRepeatedFormatViolations guards the
+// retry cap: a model that responds with prose twice in a row (once
+// on the initial turn, once on the correction) must fail hard
+// rather than loop forever. Format-correction is bounded at 1 retry
+// — past that, something is deeply wrong and more retries waste
+// tokens without fixing it.
+func TestImplementerRunFailsAfterRepeatedFormatViolations(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &scriptedProvider{
+		responses: []string{
+			`["x.go"]`, // picker
+			"Here's what I think we should do: first, we'd need to check the existing call sites...",
+			"Actually, let me think about this differently. The consolidation should...",
+		},
+	}
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "T", Body: "b"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+
+	_, err := impl.Run(context.Background(), ctx, sketch)
+	if err == nil {
+		t.Fatal("expected error after repeated format violations")
+	}
+	if !strings.Contains(err.Error(), "format-correction attempts") {
+		t.Errorf("expected format-correction cap error, got: %v", err)
+	}
+}
+
+// TestImplementerRunFormatCorrectionPromptQuotesOriginal verifies
+// the correction message actually quotes the model's broken
+// response back at it. This is what makes the correction effective:
+// the model sees exactly what it wrote and can compare it to the
+// format rule. We check by using a scripted provider that records
+// the last Request it received.
+func TestImplementerRunFormatCorrectionPromptQuotesOriginal(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use a provider that captures the user message on each call.
+	captures := &captureAllProvider{
+		responses: []string{
+			`["x.go"]`,
+			"Looking at this, I need the TSX call sites to anchor edits precisely.",
+			"diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-package x\n+package y\n",
+		},
+	}
+	impl := &Implementer{Provider: captures}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "T", Body: "b"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+
+	patch, err := impl.Run(context.Background(), ctx, sketch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if patch == nil {
+		t.Fatal("nil patch")
+	}
+
+	// The third call should be the format-corrected retry — it
+	// should contain the broken quote from the second call.
+	if len(captures.prompts) < 3 {
+		t.Fatalf("want 3 captured prompts, got %d", len(captures.prompts))
+	}
+	retryPrompt := captures.prompts[2]
+	if !strings.Contains(retryPrompt, "YOUR PREVIOUS RESPONSE VIOLATED THE OUTPUT FORMAT") {
+		t.Errorf("correction prompt missing violation header; got:\n%s", retryPrompt)
+	}
+	if !strings.Contains(retryPrompt, "Looking at this, I need the TSX call sites") {
+		t.Errorf("correction prompt did not quote the broken response back to the model; got:\n%s", retryPrompt)
+	}
+}
+
+// captureAllProvider records every user message passed to Complete
+// and returns scripted responses in order. Used by
+// TestImplementerRunFormatCorrectionPromptQuotesOriginal to verify
+// the retry prompt actually quotes the original violation.
+type captureAllProvider struct {
+	responses []string
+	prompts   []string
+}
+
+func (p *captureAllProvider) Name() string { return "captureAll" }
+func (p *captureAllProvider) Complete(_ context.Context, req llm.Request) (llm.Response, error) {
+	if len(req.Messages) > 0 {
+		p.prompts = append(p.prompts, req.Messages[0].Content)
+	}
+	idx := len(p.prompts) - 1
+	if idx >= len(p.responses) {
+		idx = len(p.responses) - 1
+	}
+	return llm.Response{Content: p.responses[idx]}, nil
+}
+
 // TestImplementerRunRejectsRepeatedFileRequests guards against a
 // model that keeps re-requesting paths the harness already loaded.
 // We de-duplicate inside Run; if the model asks for ONLY files that


### PR DESCRIPTION
## Summary

The user's first run on the new Coordinator + preset pipeline hit a new failure mode: the Implementer wanted to request more files ('Looking at this, I need the TSX call sites to anchor edits precisely...') but expressed the intent in prose instead of the required `NEED_FILES: [...]` protocol. The strict prefix validator rejected the response:

```
expected 'diff --git', 'NEED_FILES:', or 'ERROR:',
got "Looking at this, I need the TSX call sites..."
```

That's a defense-in-depth failure on my side. The validator is correct to be strict — it exists to catch the wedge failure modes the last two PRs documented — but it had no recovery path when the model violated the format. Good tool-use loops self-correct on format violations; this one just gave up.

## Two fixes, in order of desperation

### 1. End-of-prompt format reminder
The main system prompt already has rule 6 explaining the three valid prefixes, but the full user message can be several thousand tokens long. Models attend more strongly to the most recent context. Adding a FORMAT REMINDER block as the LAST thing in the user message significantly reduces the probability of a prose response — the format rule is now the last thing the model reads before responding.

This is the first line of defense. Should eliminate most violations outright.

### 2. Format-correction retry loop
For cases where the reminder isn't enough, catch the violation and re-send with a specific follow-up that:

- quotes the model's broken response back at it verbatim
- explains which three prefixes are valid
- recognises the most common failure mode (prose that describes wanting more files) and tells the model exactly how to translate that intent into `NEED_FILES`
- emphasises that the retry must start with a valid prefix

This is the standard shape for tool-use loops in the Anthropic/OpenAI SDKs: schema violations get a corrective follow-up before failing hard.

Bounded at `maxFormatRetries = 1`. Past one correction, something is deeply wrong that more retries won't fix, and further calls waste tokens.

## Refactor

`generateDiff` is now a thin wrapper that assembles the prompt and calls `tryGenerateDiff(ctx, system, user, 0)`. `tryGenerateDiff` is the underlying single-shot call that also handles the format-correction recursion. Separating them keeps prompt assembly in one place and response-validation in another.

## Tests

- `TestImplementerRunRecoversFromProsePrefixViolation` — the exact failure the user hit. Scripted provider: picker succeeds, first diff turn returns `"Looking at this, I need the TSX call sites..."`, harness detects the violation, re-calls with correction, second response is a valid `NEED_FILES` directive. Asserts 3 total LLM calls (picker + prose + recovery).
- `TestImplementerRunFailsAfterRepeatedFormatViolations` — the cap guard. Model responds with prose twice in a row. Harness must fail hard with a `format-correction attempts` error rather than loop forever.
- `TestImplementerRunFormatCorrectionPromptQuotesOriginal` — the correction prompt must quote the model's broken response back verbatim. Captures the full third prompt and asserts both the `YOUR PREVIOUS RESPONSE VIOLATED` header AND the verbatim quote of the original prose are present.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Re-run `/aidev-run 533` on the same issue. Expect: either (a) the format reminder is enough and the Implementer emits a valid `NEED_FILES:` on the first try, or (b) it still writes prose once and the correction retry recovers it. Either way, the run should now reach a real patch (or a real `ERROR:` with a specific reason) instead of dying on the format check.