### PR TITLE
fix(implementer): surface missing NEED_FILES paths + show inventory on every turn

### DIFF
--- a/internal/agents/implementer.go
+++ b/internal/agents/implementer.go
@@ -81,6 +81,19 @@ const (
 	maxRequestedFiles  = 40
 	maxFileBytes       = 128 * 1024
 	maxNeedFilesRounds = 2
+
+	// inventoryCap is the maximum number of repo-relative file paths
+	// shown to the picker and to generateDiff's "file inventory"
+	// section. Bumped from the old 200-ish limit because a modern
+	// Next.js marketing site or TS monorepo routinely has 500-1500
+	// source files; a too-small inventory forces the picker to
+	// hallucinate paths it hasn't seen. 2000 is generous enough to
+	// cover almost every real codebase while keeping the prompt
+	// under ~80 KB of text — well inside the Claude-large context
+	// window. Oversized monorepos still get truncated, but the
+	// prompt explicitly tells the model to guess + expect a
+	// "missing path" response on the next turn as a fallback.
+	inventoryCap = 2000
 )
 
 // Run asks the LLM to produce a unified diff that implements the chosen
@@ -126,15 +139,24 @@ func (i *Implementer) Run(ctx context.Context, c *Context, chosen *Sketch) (*Pat
 	}
 
 	// Load the requested file contents (size-capped, path-validated).
-	// File read errors are logged into the contents map rather than
-	// aborting — the model can still work with partial information.
-	contents := readFiles(c.Snapshot.Root, wanted)
+	// Missing paths (hallucinated by the picker) are tracked
+	// separately so the next prompt turn can tell the model which
+	// guesses were wrong — the difference between "silent under-
+	// specification" and "actionable error signal".
+	contents, missing := readFiles(c.Snapshot.Root, wanted)
 
 	// Turn 2 (with up to maxNeedFilesRounds additional rounds): ask
 	// for the diff. If the model comes back with NEED_FILES instead,
 	// load the requested paths and retry with the expanded context.
+	//
+	// missing is threaded through every round so the model always
+	// knows exactly which paths it guessed wrong on the previous
+	// turn. Without this feedback the model keeps asking for
+	// hallucinated paths, burns the NEED_FILES budget, and the run
+	// dies with "NEED_FILES limit reached" while the real paths
+	// sit in the inventory unread.
 	for round := 0; round <= maxNeedFilesRounds; round++ {
-		patch, need, err := i.generateDiff(ctx, c, chosen, contents)
+		patch, need, err := i.generateDiff(ctx, c, chosen, contents, missing)
 		if err != nil {
 			return nil, err
 		}
@@ -160,9 +182,20 @@ func (i *Implementer) Run(ctx context.Context, c *Context, chosen *Sketch) (*Pat
 		if len(fresh) == 0 {
 			return nil, fmt.Errorf("implementer: NEED_FILES requested only files that were already provided: %v", need)
 		}
-		more := readFiles(c.Snapshot.Root, fresh)
+		more, missedNow := readFiles(c.Snapshot.Root, fresh)
+		// Update the missing list for the next turn: keep both the
+		// paths we couldn't load this round AND the paths we've
+		// failed to load on earlier rounds (capped at a reasonable
+		// size so the prompt doesn't balloon).
+		missing = appendUniqueCapped(missing, missedNow, 40)
 		if len(more) == 0 {
-			return nil, fmt.Errorf("implementer: NEED_FILES requested %v but none of those paths exist on disk", fresh)
+			// Every path the model asked for on this round was
+			// missing. We don't fail here any more — missingNow is
+			// now in the prompt, so next round the model has the
+			// actual feedback signal it needs to try again. But we
+			// still don't let the loop be infinite — the round cap
+			// above covers that.
+			continue
 		}
 		for p, body := range more {
 			contents[p] = body
@@ -170,6 +203,28 @@ func (i *Implementer) Run(ctx context.Context, c *Context, chosen *Sketch) (*Pat
 	}
 	// Unreachable — the loop above either returns a patch or errors.
 	return nil, errors.New("implementer: loop fell through unexpectedly")
+}
+
+// appendUniqueCapped appends every string in extras to base that
+// isn't already there, and returns a slice capped at cap elements
+// (dropping oldest entries first). Used by the NEED_FILES loop to
+// track missing-path history across rounds without unbounded growth.
+func appendUniqueCapped(base, extras []string, cap int) []string {
+	seen := make(map[string]bool, len(base))
+	for _, s := range base {
+		seen[s] = true
+	}
+	out := base
+	for _, s := range extras {
+		if !seen[s] {
+			out = append(out, s)
+			seen[s] = true
+		}
+	}
+	if len(out) > cap {
+		out = out[len(out)-cap:]
+	}
+	return out
 }
 
 // fileSelectionJSONRe extracts a JSON array from a potentially messy
@@ -219,7 +274,7 @@ func (i *Implementer) selectFiles(ctx context.Context, c *Context, chosen *Sketc
 	fmt.Fprintf(&user, "\n\n## Chosen sketch %d: %s\n\n", chosen.Number, chosen.Title)
 	user.WriteString(chosen.Markdown)
 
-	files := listSourceFiles(c.Snapshot.Root, 200)
+	files := listSourceFiles(c.Snapshot.Root, inventoryCap)
 	if len(files) > 0 {
 		user.WriteString("\n\n## File inventory (paths only, pick from this list)\n\n")
 		for _, f := range files {
@@ -330,15 +385,29 @@ func isSafeRelPath(p string) bool {
 }
 
 // readFiles loads the file contents for the given paths, relative to
-// repoRoot. Missing files are skipped silently (they may have been
-// requested by the model but don't exist on disk). Files larger than
-// maxFileBytes are truncated with a marker at the end.
+// repoRoot. Files larger than maxFileBytes are truncated with a
+// marker at the end. Returns two values:
 //
-// The returned map is keyed by the ORIGINAL requested path (not the
-// resolved absolute path), so the second-turn prompt can cite the same
-// strings the first turn returned.
-func readFiles(repoRoot string, paths []string) map[string]string {
+//  1. a map of successfully-loaded content, keyed by the ORIGINAL
+//     requested path (not the resolved absolute path), so the
+//     second-turn prompt can cite the same strings the first turn
+//     returned.
+//
+//  2. a slice of paths that were requested but could NOT be loaded
+//     because they don't exist on disk, are directories, or failed
+//     to read. The caller surfaces this list back to the model on
+//     the next turn so it knows its guess was wrong — without this
+//     feedback signal, a model hallucinating paths will silently
+//     get empty responses and keep guessing until the NEED_FILES
+//     cap trips.
+//
+// Paths that fail isSafeRelPath are silently dropped (rejected at
+// the boundary, not reported). We never surface "you asked for
+// ../../etc/passwd" to the model because that's a red-flag path
+// that should be killed at the edge.
+func readFiles(repoRoot string, paths []string) (map[string]string, []string) {
 	out := make(map[string]string, len(paths))
+	var missing []string
 	for _, p := range paths {
 		if !isSafeRelPath(p) {
 			continue
@@ -346,10 +415,12 @@ func readFiles(repoRoot string, paths []string) map[string]string {
 		abs := filepath.Join(repoRoot, p)
 		info, err := os.Stat(abs)
 		if err != nil || info.IsDir() {
+			missing = append(missing, p)
 			continue
 		}
 		data, err := os.ReadFile(abs)
 		if err != nil {
+			missing = append(missing, p)
 			continue
 		}
 		if len(data) > maxFileBytes {
@@ -357,7 +428,7 @@ func readFiles(repoRoot string, paths []string) map[string]string {
 		}
 		out[p] = string(data)
 	}
-	return out
+	return out, missing
 }
 
 // generateDiff is turn 2. Returns (patch, nil, nil) on success, or
@@ -366,9 +437,16 @@ func readFiles(repoRoot string, paths []string) map[string]string {
 // Run() loop interprets the three-way return to decide whether to
 // retry with expanded file context or surface a terminal error.
 //
+// The missing argument is the running list of paths the model has
+// requested on prior rounds that the harness could not load
+// (because they don't exist on disk, are directories, or failed to
+// read). The prompt surfaces these to the model under a "DO NOT
+// REQUEST AGAIN" heading so it stops guessing at paths that aren't
+// in the repo.
+//
 // Kept separate from selectFiles so tests and callers can exercise
 // the two phases independently.
-func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sketch, contents map[string]string) (*Patch, []string, error) {
+func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sketch, contents map[string]string, missing []string) (*Patch, []string, error) {
 
 	system := "You are the Implementer for aidev, a multi-agent coding tool.\n" +
 		"\n" +
@@ -513,19 +591,44 @@ func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sket
 		for _, p := range paths {
 			fmt.Fprintf(&user, "### %s\n\n```\n%s\n```\n\n", p, contents[p])
 		}
-		user.WriteString("Only the files above have been loaded for you. If you need to read additional repo-relative files to produce a COMPLETE and VALID diff — for example to copy a canonical translation value from another locale, or to see the exact call site of a function you're rewriting — respond with `NEED_FILES: [\"path/a.json\", \"path/b.tsx\"]` per rule 7 and the harness will load them and call you again. Do NOT fabricate values, annotate TODOs inside the diff, or hand back a partial starting point.\n")
-	} else {
-		// Fallback to the v0.3a behaviour (paths only) when the picker
-		// returned nothing useful. Degrades gracefully.
-		files := listSourceFiles(c.Snapshot.Root, 150)
-		if len(files) > 0 {
-			user.WriteString("\n\n## File inventory (paths only — the file picker did not identify any files to load)\n\n")
-			for _, f := range files {
-				user.WriteString("- ")
-				user.WriteString(f)
-				user.WriteString("\n")
-			}
+		user.WriteString("These are the files already loaded for you. If you need to read additional repo-relative files to produce a COMPLETE and VALID diff, respond with `NEED_FILES: [\"path/a.json\", \"path/b.tsx\"]` per rule 7 and the harness will load them and call you again. Do NOT fabricate values, annotate TODOs inside the diff, or hand back a partial starting point.\n")
+	}
+
+	// ALWAYS surface a file inventory, even when contents is
+	// populated. On NEED_FILES retries the model needs a list of
+	// real paths to pick from — otherwise it guesses, burns the
+	// retry budget on hallucinated paths, and the run dies with
+	// "NEED_FILES limit reached" while the actual files sit in the
+	// inventory unread. Cap at inventoryCap so the prompt can't
+	// balloon on huge monorepos, but the cap is generous enough for
+	// most codebases (a standard Next.js marketing site has on the
+	// order of 500-1500 source files).
+	inv := listSourceFiles(c.Snapshot.Root, inventoryCap)
+	if len(inv) > 0 {
+		user.WriteString("\n\n## Repository file inventory (pick NEED_FILES paths from this list — anything outside this list won't be found)\n\n")
+		for _, f := range inv {
+			user.WriteString("- ")
+			user.WriteString(f)
+			user.WriteString("\n")
 		}
+		if len(inv) >= inventoryCap {
+			fmt.Fprintf(&user, "\n_(Inventory truncated at %d files. If you need a file not listed here, guess the path and the harness will tell you if it doesn't exist — but prefer picking from the list above.)_\n", inventoryCap)
+		}
+	}
+
+	// Thread missing paths back to the model so it stops asking for
+	// the same hallucinated paths over and over. This is the
+	// feedback signal that was silently missing in v0.3a.2: without
+	// it, the model had no way to know its picker+NEED_FILES
+	// guesses were wrong, and it just kept guessing.
+	if len(missing) > 0 {
+		user.WriteString("\n\n## Paths you previously requested that DO NOT EXIST in this repo — DO NOT request these again\n\n")
+		for _, m := range missing {
+			user.WriteString("- ")
+			user.WriteString(m)
+			user.WriteString("\n")
+		}
+		user.WriteString("\nThese paths are NOT in the repository. If you still need more files, pick from the repository file inventory above — do not guess at plausible-sounding paths.\n")
 	}
 
 	user.WriteString("\n\n## Principles\n\n")

--- a/internal/agents/implementer_test.go
+++ b/internal/agents/implementer_test.go
@@ -293,12 +293,29 @@ func TestReadFilesSkipsMissingAndDirs(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "exists.go"), []byte("package main"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := readFiles(dir, []string{"exists.go", "missing.go", "sub"})
+	got, missing := readFiles(dir, []string{"exists.go", "missing.go", "sub"})
 	if len(got) != 1 {
 		t.Errorf("got %d files, want 1", len(got))
 	}
 	if got["exists.go"] != "package main" {
 		t.Errorf("content mismatch: %q", got["exists.go"])
+	}
+	// missing.go and sub (directory) should both be in the missing list
+	// so the caller can tell the model they're unavailable.
+	if len(missing) != 2 {
+		t.Errorf("missing list = %v, want 2 entries", missing)
+	}
+	var haveMissing, haveSub bool
+	for _, m := range missing {
+		if m == "missing.go" {
+			haveMissing = true
+		}
+		if m == "sub" {
+			haveSub = true
+		}
+	}
+	if !haveMissing || !haveSub {
+		t.Errorf("expected missing list to contain 'missing.go' and 'sub', got %v", missing)
 	}
 }
 
@@ -308,7 +325,7 @@ func TestReadFilesTruncatesLargeFiles(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "big.txt"), []byte(big), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := readFiles(dir, []string{"big.txt"})
+	got, _ := readFiles(dir, []string{"big.txt"})
 	content := got["big.txt"]
 	if !strings.Contains(content, "truncated") {
 		t.Errorf("expected truncation marker, got first 100 chars: %q", content[:100])
@@ -330,9 +347,16 @@ func TestReadFilesRefusesUnsafePaths(t *testing.T) {
 	}
 	defer os.Remove(secret)
 
-	got := readFiles(dir, []string{"../" + filepath.Base(secret), "/etc/passwd"})
+	got, missing := readFiles(dir, []string{"../" + filepath.Base(secret), "/etc/passwd"})
 	if len(got) != 0 {
 		t.Errorf("unsafe paths should have been rejected, got %v", got)
+	}
+	// Unsafe paths are silently dropped at the boundary — they do
+	// NOT go into the "missing" list, because we don't want to
+	// surface red-flag paths back to the model. The missing list is
+	// for legitimate typos and hallucinations, not for probing.
+	if len(missing) != 0 {
+		t.Errorf("unsafe paths should not be reported as 'missing', got %v", missing)
 	}
 }
 
@@ -654,6 +678,90 @@ func (p *captureAllProvider) Complete(_ context.Context, req llm.Request) (llm.R
 		idx = len(p.responses) - 1
 	}
 	return llm.Response{Content: p.responses[idx]}, nil
+}
+
+// TestImplementerRunSurfacesMissingPathsAndRecovers is the
+// regression guard for the real failure the user hit: the picker
+// hallucinated plausible-but-nonexistent paths (apps/marketing/src/
+// pages/Sectors.tsx) and the harness silently dropped them from
+// readFiles, leaving the model with no feedback signal. It kept
+// asking for more hallucinated paths until the NEED_FILES cap
+// tripped, while the REAL paths sat in the inventory unread.
+//
+// After this fix, readFiles reports missing paths, Run threads
+// them into the next generateDiff turn under a 'DO NOT request
+// these again' section, and the model can self-correct on the
+// retry. This test drives that exact flow: hallucinated path in
+// the picker, real path on the NEED_FILES round, success.
+func TestImplementerRunSurfacesMissingPathsAndRecovers(t *testing.T) {
+	dir := t.TempDir()
+	// Real file that the model SHOULD have asked for from the start.
+	realPath := filepath.Join(dir, "apps", "marketing", "src", "components", "pages", "pricing", "pricing.tsx")
+	if err := os.MkdirAll(filepath.Dir(realPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(realPath, []byte("export const Pricing = () => <div>hello</div>\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &captureAllProvider{
+		responses: []string{
+			// Turn 1 (picker): hallucinated path. This is the real
+			// failure mode — the picker guessed a plausible-looking
+			// path structure that doesn't match the actual repo.
+			`["apps/marketing/src/pages/Pricing.tsx"]`,
+			// Turn 2 (generateDiff round 0): model sees the
+			// hallucinated path in its missing list and correctly
+			// requests the REAL path.
+			`NEED_FILES: ["apps/marketing/src/components/pages/pricing/pricing.tsx"]`,
+			// Turn 2 (generateDiff round 1): real diff with the
+			// loaded file contents.
+			"diff --git a/apps/marketing/src/components/pages/pricing/pricing.tsx b/apps/marketing/src/components/pages/pricing/pricing.tsx\n" +
+				"--- a/apps/marketing/src/components/pages/pricing/pricing.tsx\n" +
+				"+++ b/apps/marketing/src/components/pages/pricing/pricing.tsx\n" +
+				"@@ -1 +1 @@\n" +
+				"-export const Pricing = () => <div>hello</div>\n" +
+				"+export const Pricing = () => <div>contact sales</div>\n",
+		},
+	}
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "T", Body: "body"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "consolidate CTA", Markdown: "## Plan\n- update pricing CTA"}
+
+	patch, err := impl.Run(context.Background(), ctx, sketch)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if patch == nil {
+		t.Fatal("nil patch")
+	}
+	if !strings.Contains(patch.Diff, "contact sales") {
+		t.Errorf("patch missing expected content, got:\n%s", patch.Diff)
+	}
+
+	// Verify the second prompt (generateDiff round 0) surfaced the
+	// missing path under the DO NOT request again heading. Without
+	// that surfacing the model has no feedback signal and the fix
+	// is moot.
+	if len(provider.prompts) < 2 {
+		t.Fatalf("want at least 2 prompts, got %d", len(provider.prompts))
+	}
+	secondPrompt := provider.prompts[1]
+	if !strings.Contains(secondPrompt, "DO NOT EXIST") {
+		t.Errorf("second prompt missing 'DO NOT EXIST' missing-paths header; got:\n%s", secondPrompt)
+	}
+	if !strings.Contains(secondPrompt, "apps/marketing/src/pages/Pricing.tsx") {
+		t.Errorf("second prompt should list the hallucinated path as missing; got:\n%s", secondPrompt)
+	}
+	// The inventory should also appear in every generateDiff turn,
+	// not just the picker. This is what gives the model something
+	// real to pick from on the retry.
+	if !strings.Contains(secondPrompt, "Repository file inventory") {
+		t.Errorf("second prompt missing file inventory; got:\n%s", secondPrompt)
+	}
 }
 
 // TestImplementerRunRejectsRepeatedFileRequests guards against a


### PR DESCRIPTION
## Summary

The user's latest run finally reached a clean `build` verdict, used NEED_FILES correctly after the format recovery from #34, and STILL failed — with `NEED_FILES limit reached` — because the picker hallucinated plausible-but-nonexistent paths (`apps/marketing/src/pages/Sectors.tsx` in a repo where the real paths live under `apps/marketing/src/components/pages/sectors/...`). The harness silently dropped the missing paths from `readFiles`, the model got no feedback signal, it kept guessing new hallucinations, and the loop died with the REAL files sitting in the inventory unread.

## Three root causes

1. **`readFiles` silently dropped missing paths.** Any path that didn't exist on disk was indistinguishable from 'I didn't ask for that' in the next turn's prompt. The model had no way to know its guess was wrong.
2. **The diff-generation prompt never showed a file inventory.** Only the picker (turn 1) saw the `listSourceFiles` output. On every NEED_FILES retry the Implementer had no list of real paths to pick from — it had to guess, and the picker's bad guesses were never contradicted.
3. **The inventory cap was 200 files.** For a standard Next.js marketing site with 500-1500 source files this forced the picker to guess at paths it hadn't seen.

## Fixes

- `readFiles` signature: `(map[string]string, []string)` — returns both the loaded content AND the list of paths that couldn't be loaded (missing on disk, directories, unreadable). Unsafe paths (path traversal) are still silently dropped at the boundary and NOT reported as 'missing' — we don't surface red-flag paths back to the model because they're signals of something worse than a typo.

- `Run()` tracks missing paths across NEED_FILES rounds with `appendUniqueCapped(40)` so the history grows but never bloats the prompt. Each round's missing list is merged with prior rounds' so the model sees the cumulative set of 'paths the harness couldn't find for you'.

- `generateDiff` prompt now ALWAYS includes a 'Repository file inventory (pick NEED_FILES paths from this list — anything outside this list won't be found)' section, not just when contents is empty. On NEED_FILES retries the model gets a real list of paths to pick from instead of guessing.

- `generateDiff` prompt now includes a 'Paths you previously requested that DO NOT EXIST in this repo — DO NOT request these again' section when `missing` is non-empty. Specific, actionable feedback.

- New `inventoryCap = 2000` constant replaces the 200-file limit for both the picker and the diff-generation inventory. Generous enough to cover almost every real codebase while keeping the prompt under ~80 KB of text.

- `Run()` no longer fails with 'NEED_FILES requested X but none of those paths exist on disk' — that error killed a run prematurely when it should have been giving the model a chance to self-correct with the missing-feedback signal. Now the loop continues with the missing-list updated, and the round-cap is the only hard limit.

## Tests

- `TestReadFilesSkipsMissingAndDirs` updated to assert that `missing.go` and `sub` (the directory) appear in the returned missing list, while existing files are loaded.
- `TestReadFilesRefusesUnsafePaths` updated to assert that unsafe paths are NOT in the missing list (silently dropped, not surfaced).
- `TestImplementerRunSurfacesMissingPathsAndRecovers` — **the regression guard for the exact failure the user hit**. Scripted provider: picker hallucinates `apps/marketing/src/pages/Pricing.tsx`, harness surfaces it as missing in round 0's prompt, model corrects to the real path `apps/marketing/src/components/pages/pricing/pricing.tsx`, round 1 produces a valid diff. Asserts the second prompt contains BOTH the 'DO NOT EXIST' header AND the 'Repository file inventory' section.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all new tests + updated readFiles tests pass)
- [ ] Re-run `/aidev-run 533`. Expect: picker sees a 2000-file inventory (enough for the Company-Site marketing tree), chooses real paths on the first try. If it still hallucinates, the next turn's prompt will contain both the inventory AND a specific 'do not request these again' list, and the model should self-correct within the NEED_FILES budget. The run should reach a real patch instead of dying on 'NEED_FILES limit reached'.