### PR TITLE
fix(implementer): auto-harvest upstream-cited paths + forbid false-absence ERRORs

### DIFF
--- a/internal/agents/implementer.go
+++ b/internal/agents/implementer.go
@@ -84,16 +84,18 @@ const (
 
 	// inventoryCap is the maximum number of repo-relative file paths
 	// shown to the picker and to generateDiff's "file inventory"
-	// section. Bumped from the old 200-ish limit because a modern
-	// Next.js marketing site or TS monorepo routinely has 500-1500
-	// source files; a too-small inventory forces the picker to
-	// hallucinate paths it hasn't seen. 2000 is generous enough to
-	// cover almost every real codebase while keeping the prompt
-	// under ~80 KB of text — well inside the Claude-large context
-	// window. Oversized monorepos still get truncated, but the
-	// prompt explicitly tells the model to guess + expect a
-	// "missing path" response on the next turn as a fallback.
-	inventoryCap = 2000
+	// section. Bumped from 2000 to 3000 after a real monorepo
+	// (Next.js marketing site inside a larger product monorepo) hit
+	// the cap on alphabetically-earlier directories and never reached
+	// apps/marketing/src/components/ — leaving the Implementer with
+	// a truncated view of the tree and no TSX files from the
+	// component directory the Clarifier had explicitly cited. 3000
+	// is the next belt-and-braces step above 2000; the FUNDAMENTAL
+	// fix is in Run(), which now auto-harvests paths from upstream
+	// agent output (Scout, Critic, Clarifier, sketch) and loads
+	// them directly regardless of whether they're in the inventory.
+	// The inventory is now a hint, not a source of truth.
+	inventoryCap = 3000
 )
 
 // Run asks the LLM to produce a unified diff that implements the chosen
@@ -132,18 +134,59 @@ func (i *Implementer) Run(ctx context.Context, c *Context, chosen *Sketch) (*Pat
 		return nil, errors.New("implementer: no repo snapshot")
 	}
 
+	// Pre-load files that upstream agents (Scout, Critic, Clarifier,
+	// Architect) have already cited in their output. These paths are
+	// authoritative: if the Clarifier quotes
+	// `apps/marketing/src/components/sections/foo/bar.tsx:193` as
+	// evidence, we should load that file automatically instead of
+	// making the Implementer guess from the picker's inventory.
+	//
+	// This is the fix for the v0.3a.3 failure mode where the
+	// Implementer emitted `ERROR: files don't exist` because its
+	// inventory was truncated before reaching the directory the
+	// Clarifier had literally just cited. The inventory is
+	// necessarily bounded; upstream agent output is not, and it
+	// tends to contain exactly the paths that matter.
+	contents := make(map[string]string)
+	var missing []string
+	upstreamPaths := harvestPaths(
+		c.Issue.Body,
+		c.ScoutReport,
+		c.CriticReport,
+		chosen.Markdown,
+		c.ClarifierNotes,
+	)
+	if c.Snapshot != nil {
+		upstreamPaths = append(upstreamPaths, harvestPaths(c.Snapshot.ClarifierContent)...)
+	}
+	if len(upstreamPaths) > 0 {
+		harvested, harvestMissing := readFiles(c.Snapshot.Root, upstreamPaths)
+		for p, body := range harvested {
+			contents[p] = body
+		}
+		// harvestMissing represents upstream citations that
+		// couldn't be resolved — worth surfacing so the
+		// Implementer knows the Clarifier/Scout mentioned them
+		// but the harness couldn't find them on disk. This is
+		// useful feedback even though it's rare (upstream agents
+		// usually cite real paths).
+		missing = appendUniqueCapped(missing, harvestMissing, 40)
+	}
+
 	// Turn 1: ask the model which files it needs to see.
 	wanted, err := i.selectFiles(ctx, c, chosen)
 	if err != nil {
 		return nil, fmt.Errorf("implementer: file selection: %w", err)
 	}
 
-	// Load the requested file contents (size-capped, path-validated).
-	// Missing paths (hallucinated by the picker) are tracked
-	// separately so the next prompt turn can tell the model which
-	// guesses were wrong — the difference between "silent under-
-	// specification" and "actionable error signal".
-	contents, missing := readFiles(c.Snapshot.Root, wanted)
+	// Load the picker's requested file contents on top of the
+	// already-harvested upstream paths. Both go into the same
+	// contents map.
+	pickerContents, pickerMissing := readFiles(c.Snapshot.Root, wanted)
+	for p, body := range pickerContents {
+		contents[p] = body
+	}
+	missing = appendUniqueCapped(missing, pickerMissing, 40)
 
 	// Turn 2 (with up to maxNeedFilesRounds additional rounds): ask
 	// for the diff. If the model comes back with NEED_FILES instead,
@@ -518,12 +561,35 @@ func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sket
 		"   opt-in to seeing MORE of the codebase before you do the work.\n" +
 		"   Do not use it to defer writing the diff entirely.\n" +
 		"\n" +
-		"8. ERROR escape hatch. If the task is genuinely impossible\n" +
-		"   (required files don't exist on disk, the sketch contradicts\n" +
-		"   itself, the chosen approach would require migrations outside\n" +
-		"   this repository), emit a single line starting with 'ERROR: '\n" +
-		"   followed by a one-sentence explanation. The orchestrator will\n" +
-		"   surface the reason verbatim.\n" +
+		"   IMPORTANT: paths cited in the Clarifier session, Scout brief,\n" +
+		"   Critic report, or Architect sketch are KNOWN TO EXIST in the\n" +
+		"   repository — those agents ran against the same checkout you\n" +
+		"   are and verified those paths. You can NEED_FILES them even if\n" +
+		"   they are not listed in the 'Repository file inventory' section\n" +
+		"   below: the inventory may be truncated and absence from it is\n" +
+		"   NOT evidence that a file is missing. When in doubt, prefer\n" +
+		"   NEED_FILES over ERROR.\n" +
+		"\n" +
+		"8. ERROR escape hatch. Reserved for the NARROW case where the\n" +
+		"   task is genuinely impossible — for example, the sketch\n" +
+		"   contradicts itself, or it requires migrations outside this\n" +
+		"   repository. Emit a single line starting with 'ERROR: '\n" +
+		"   followed by a one-sentence explanation. The orchestrator\n" +
+		"   will surface the reason verbatim.\n" +
+		"\n" +
+		"   Do NOT emit ERROR claiming 'files do not exist' unless you\n" +
+		"   have FIRST tried to load them via NEED_FILES and the harness\n" +
+		"   reported them in the 'Paths you previously requested that DO\n" +
+		"   NOT EXIST' section. Absence from your current view is NOT\n" +
+		"   evidence of absence from the repository; the inventory is\n" +
+		"   necessarily bounded and you can always request more.\n" +
+		"\n" +
+		"   Concretely: if the Clarifier or Scout brief mentions a path\n" +
+		"   like apps/marketing/src/components/foo/bar.tsx and that path\n" +
+		"   is not in your current file contents, your next response\n" +
+		"   should be NEED_FILES requesting that path — NOT ERROR\n" +
+		"   declaring the file doesn't exist. The harness will tell you\n" +
+		"   on the next turn whether the path resolved.\n" +
 		"\n" +
 		"9. FORBIDDEN OUTPUTS — the following are failure modes, not\n" +
 		"   acceptable compromises. Prefer NEED_FILES or ERROR over any of\n" +
@@ -605,7 +671,7 @@ func (i *Implementer) generateDiff(ctx context.Context, c *Context, chosen *Sket
 	// order of 500-1500 source files).
 	inv := listSourceFiles(c.Snapshot.Root, inventoryCap)
 	if len(inv) > 0 {
-		user.WriteString("\n\n## Repository file inventory (pick NEED_FILES paths from this list — anything outside this list won't be found)\n\n")
+		user.WriteString("\n\n## Repository file inventory (may be truncated — prefer paths from this list, but the absence of a path here is NOT proof the file is missing)\n\n")
 		for _, f := range inv {
 			user.WriteString("- ")
 			user.WriteString(f)
@@ -838,6 +904,70 @@ func stripCodeFence(s string) string {
 		lines = lines[:n-1]
 	}
 	return strings.Join(lines, "\n")
+}
+
+// harvestPathRe matches what LOOKS like a repo-relative source file
+// path: one or more path segments separated by forward slashes, ending
+// in a known source-file extension. Leading drive letters, absolute
+// paths, URL schemes, and trailing non-path characters are deliberately
+// excluded by the pattern.
+//
+// We intentionally accept false positives here (strings that look like
+// paths but aren't real files) — readFiles will reject any non-existent
+// path via its os.Stat check and route it to the missing list. The
+// cost of a false positive is one extra entry in the missing list; the
+// cost of a false negative is the Implementer emitting ERROR when it
+// should have loaded the file.
+var harvestPathRe = regexp.MustCompile(`(?:^|[^A-Za-z0-9_\-./])([A-Za-z0-9_\-]+(?:/[A-Za-z0-9_\-.]+)+\.(?:tsx?|jsx?|mjs|cjs|go|py|rs|java|kt|rb|php|c|cc|cpp|h|hpp|swift|m|md|mdx|ya?ml|toml|json|yaml))\b`)
+
+// harvestPaths extracts repo-relative source file paths that upstream
+// agents (Scout brief, Critic report, Clarifier session, Architect
+// sketch markdown) have cited in their prose. These paths are loaded
+// directly into the Implementer's contents map at the start of Run()
+// so the model never has to guess at paths that have already been
+// verified by an earlier stage of the pipeline.
+//
+// The regex is deliberately permissive — false positives (strings
+// that look like paths but aren't) are cheap because readFiles will
+// reject them via os.Stat and report them in the missing list. False
+// negatives (real paths the regex didn't match) are expensive because
+// they force the Implementer to fall back to NEED_FILES or, in the
+// worst case, emit ERROR claiming files don't exist.
+//
+// Capped at maxHarvestedPaths entries to keep the initial load
+// bounded on prose-heavy inputs. De-duplicated. Filtered through
+// isSafeRelPath.
+func harvestPaths(inputs ...string) []string {
+	const maxHarvestedPaths = 60
+	seen := make(map[string]bool)
+	var out []string
+	for _, input := range inputs {
+		if input == "" {
+			continue
+		}
+		matches := harvestPathRe.FindAllStringSubmatch(input, -1)
+		for _, m := range matches {
+			p := strings.TrimSpace(m[1])
+			// Strip a trailing `:` with a line-number annotation
+			// (e.g. "foo/bar.tsx:193-199" → "foo/bar.tsx"). This
+			// is how Clarifier evidence usually cites files.
+			if idx := strings.Index(p, ":"); idx >= 0 {
+				p = p[:idx]
+			}
+			if !isSafeRelPath(p) {
+				continue
+			}
+			if seen[p] {
+				continue
+			}
+			seen[p] = true
+			out = append(out, p)
+			if len(out) >= maxHarvestedPaths {
+				return out
+			}
+		}
+	}
+	return out
 }
 
 // listSourceFiles returns up to `limit` source file paths from rootDir,

--- a/internal/agents/implementer_test.go
+++ b/internal/agents/implementer_test.go
@@ -797,6 +797,172 @@ func TestImplementerRunRejectsRepeatedFileRequests(t *testing.T) {
 	}
 }
 
+// harvestPaths tests — the Implementer's pre-flight path extractor
+// that pulls repo-relative source paths out of upstream agent prose
+// and loads them automatically before the picker turn. The
+// regression guard against 'files don't exist' ERRORs when the
+// Clarifier literally just cited the file.
+
+func TestHarvestPathsFromClarifierEvidence(t *testing.T) {
+	// The exact shape of a Clarifier evidence bullet — file path
+	// followed by a line-number annotation. This is what the user's
+	// Wave 1 Clarifier output contained, verbatim.
+	input := "In `apps/marketing/src/components/sections/pricing-section/pricing-section-client.tsx:193-199` the Button call site uses t(\"contactSales\")."
+	got := harvestPaths(input)
+	if len(got) != 1 {
+		t.Fatalf("want 1 path, got %d: %v", len(got), got)
+	}
+	want := "apps/marketing/src/components/sections/pricing-section/pricing-section-client.tsx"
+	if got[0] != want {
+		t.Errorf("got %q, want %q", got[0], want)
+	}
+}
+
+func TestHarvestPathsMultipleExtensions(t *testing.T) {
+	input := `
+The translation lives in apps/marketing/src/lib/i18n/translations/fr/common.json and the
+call site is at apps/marketing/src/components/pages/pricing/pricing.tsx:56. The type
+definition is in packages/types/src/i18n.ts and the helper is use-translation.ts at
+apps/marketing/src/lib/i18n/use-translation.ts.
+`
+	got := harvestPaths(input)
+	want := map[string]bool{
+		"apps/marketing/src/lib/i18n/translations/fr/common.json": true,
+		"apps/marketing/src/components/pages/pricing/pricing.tsx": true,
+		"packages/types/src/i18n.ts":                              true,
+		"apps/marketing/src/lib/i18n/use-translation.ts":          true,
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d paths %v, want %d (%v)", len(got), got, len(want), want)
+	}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected path %q", p)
+		}
+	}
+}
+
+func TestHarvestPathsDeduplicates(t *testing.T) {
+	input := "foo/bar.go foo/bar.go foo/bar.go"
+	got := harvestPaths(input)
+	if len(got) != 1 || got[0] != "foo/bar.go" {
+		t.Errorf("got %v, want [foo/bar.go]", got)
+	}
+}
+
+func TestHarvestPathsFromMultipleSources(t *testing.T) {
+	scout := "Top-level is apps/marketing/src/app/page.tsx with components/..."
+	critic := "Worth checking: apps/marketing/src/components/cta/button.tsx"
+	clarifier := "Fix site: apps/marketing/src/components/pages/pricing/pricing.tsx:56"
+	got := harvestPaths(scout, critic, clarifier)
+	if len(got) != 3 {
+		t.Errorf("want 3, got %d: %v", len(got), got)
+	}
+}
+
+func TestHarvestPathsRejectsAbsoluteAndTraversal(t *testing.T) {
+	input := "Check /etc/passwd and ../../../outside.go but foo/bar.go is fine."
+	got := harvestPaths(input)
+	if len(got) != 1 || got[0] != "foo/bar.go" {
+		t.Errorf("got %v, want only [foo/bar.go] (absolute and traversal filtered)", got)
+	}
+}
+
+func TestHarvestPathsIgnoresBareFilenames(t *testing.T) {
+	// Bare filenames without a directory component ("main.go" on its
+	// own) are too noisy to harvest — they match too many things in
+	// prose. The regex requires at least one slash.
+	got := harvestPaths("see main.go for details, or check foo.tsx")
+	if len(got) != 0 {
+		t.Errorf("bare filenames should be rejected, got %v", got)
+	}
+}
+
+func TestHarvestPathsIgnoresEmptyInput(t *testing.T) {
+	got := harvestPaths("", "   ", "\n\n")
+	if len(got) != 0 {
+		t.Errorf("empty inputs should return nothing, got %v", got)
+	}
+}
+
+// TestImplementerRunAutoLoadsUpstreamCitedPaths is the regression
+// guard for the 'ERROR: files do not exist' failure the user hit.
+// The Clarifier cites a path that is NOT in the picker's inventory
+// (simulates an inventory cap truncation). The Implementer.Run()
+// must auto-harvest the path from the Clarifier content, load it
+// via readFiles, and make it available to generateDiff BEFORE the
+// picker runs. Without this fix the Implementer would see only the
+// truncated inventory, conclude the file doesn't exist, and ERROR.
+func TestImplementerRunAutoLoadsUpstreamCitedPaths(t *testing.T) {
+	dir := t.TempDir()
+	// Create the "hidden" file in a deep subdirectory — the
+	// Clarifier cites it but we'll simulate the picker not seeing
+	// it by having the picker return an empty inventory pick.
+	citedPath := "apps/marketing/src/components/pages/pricing/pricing.tsx"
+	if err := os.MkdirAll(filepath.Join(dir, filepath.Dir(citedPath)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, citedPath), []byte("export const Pricing = () => <>\"Contact our sales team\"</>\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &captureAllProvider{
+		responses: []string{
+			// Picker turn: returns empty (simulating the picker not
+			// knowing about the cited path because it's truncated
+			// out of the inventory). This matches the real failure
+			// where the picker returned an empty list too.
+			`[]`,
+			// generateDiff turn: because Run() auto-harvested the
+			// Clarifier path and loaded it, the file contents are
+			// already in the prompt. Model produces a real diff.
+			"diff --git a/apps/marketing/src/components/pages/pricing/pricing.tsx b/apps/marketing/src/components/pages/pricing/pricing.tsx\n" +
+				"--- a/apps/marketing/src/components/pages/pricing/pricing.tsx\n" +
+				"+++ b/apps/marketing/src/components/pages/pricing/pricing.tsx\n" +
+				"@@ -1 +1 @@\n" +
+				"-export const Pricing = () => <>\"Contact our sales team\"</>\n" +
+				"+export const Pricing = () => <>\"Contact Sales\"</>\n",
+		},
+	}
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue: &github.Issue{
+			Owner: "a", Repo: "b", Number: 1,
+			Title: "Unify CTA",
+			Body:  "fix the drift",
+		},
+		Snapshot: &repo.Snapshot{Root: dir},
+		ClarifierNotes: "### q1 — evidence\n\n**Answer:** The call site is at `" + citedPath + ":193-199` and it uses t(\"contactSales\").",
+	}
+	sketch := &Sketch{Number: 1, Title: "consolidate", Markdown: "## Plan\n- update the " + citedPath + " label"}
+
+	patch, err := impl.Run(context.Background(), ctx, sketch)
+	if err != nil {
+		t.Fatalf("Run should not fail — upstream-cited path should be auto-loaded: %v", err)
+	}
+	if patch == nil {
+		t.Fatal("nil patch")
+	}
+	if !strings.Contains(patch.Diff, "Contact Sales") {
+		t.Errorf("patch missing expected change, got:\n%s", patch.Diff)
+	}
+
+	// Verify the second prompt (generateDiff turn) actually
+	// contains the file contents Run() auto-loaded from the
+	// Clarifier citation. If the harvest didn't fire, the contents
+	// section would be empty.
+	if len(provider.prompts) < 2 {
+		t.Fatalf("want 2 prompts, got %d", len(provider.prompts))
+	}
+	diffPrompt := provider.prompts[1]
+	if !strings.Contains(diffPrompt, "export const Pricing") {
+		t.Errorf("diff-generation prompt did not include auto-harvested file contents; got:\n%s", diffPrompt)
+	}
+	if !strings.Contains(diffPrompt, citedPath) {
+		t.Errorf("diff-generation prompt should cite the upstream path under ## Current file contents; got:\n%s", diffPrompt)
+	}
+}
+
 func TestParseNeedFilesCapsLength(t *testing.T) {
 	// parseNeedFiles reuses cleanFileList's cap, so a huge request
 	// still fits within maxRequestedFiles.


### PR DESCRIPTION
## Summary

Latest failure from the user's run: the Implementer emitted `ERROR: The marketing app's TSX call sites do not exist in this repository checkout` when the Clarifier's Wave 1 evidence had literally just quoted `apps/marketing/src/components/sections/pricing-section/pricing-section-client.tsx:193-199` as the exact call site. The files existed; the user verified via Grep afterwards. **aidev was wrong on a factual claim about what's in the repo.**

## Root cause

The Implementer was treating its file inventory as ground truth for 'what files exist in the repo'. When the deterministic depth-first walk filled `inventoryCap = 2000` on alphabetically-earlier directories and never reached `apps/marketing/src/components/`, the inventory showed only the locale JSON files (which made it in through a different walk path). The model concluded 'no TSX files exist' and emitted ERROR — when the Clarifier had just confirmed those files exist and given exact line numbers.

**The architectural bug**: the Implementer was trusting the bounded, walk-order-dependent inventory over the Clarifier/Scout/Critic output that had already verified those paths. Upstream agents had already done the work; the Implementer ignored it.

## Three layered fixes

### 1. Auto-harvest upstream-cited paths
New `harvestPaths(inputs ...string)` scans prose from Scout brief, Critic report, Clarifier session (both `ClarifierNotes` in-memory and `Snapshot.ClarifierContent` on-disk), issue body, and chosen sketch markdown for anything that looks like a repo-relative source path. Regex requires at least one slash and a known source extension. Strips trailing `:line-number` annotations that Clarifier evidence bullets typically carry.

`Run()` now calls `harvestPaths` **before** the picker runs and loads every cited path via `readFiles`. The contents get merged into the same map the picker's output lands in, so `generateDiff` sees both sources. Missing cited paths (regex false positives, or upstream agents citing paths that don't actually exist) go into the missing list just like picker misses.

Capped at `maxHarvestedPaths = 60`. False positives are cheap (`os.Stat` rejects them); false negatives are expensive (they force NEED_FILES or, worst case, ERROR). The regex is deliberately permissive.

### 2. Prompt rules 7 + 8 hardened against false-absence ERRORs
Rule 7 (NEED_FILES) gains an explicit paragraph: paths cited in the Clarifier/Scout/Critic/Architect output are KNOWN TO EXIST. You can NEED_FILES them even if they are not in the Repository file inventory. The inventory may be truncated and absence from it is NOT evidence a file is missing.

Rule 8 (ERROR) gains a constraint: do NOT emit ERROR claiming files don't exist unless you have FIRST tried NEED_FILES and the harness reported them in the 'Paths you previously requested that DO NOT EXIST' section. The rule quotes a concrete example: if the Clarifier mentions `apps/marketing/src/components/foo/bar.tsx` and it's not in your current contents, respond with NEED_FILES, not ERROR.

The `## Repository file inventory` heading now explicitly says `(may be truncated — prefer paths from this list, but the absence of a path here is NOT proof the file is missing)` so the model sees the warning every turn.

### 3. `inventoryCap` 2000 → 3000
Belt-and-braces. One more doubling isn't the fundamental fix (fix #1 is), but it raises the ceiling for monorepos where the walk order is unfortunate. Comment now explicitly calls out that the inventory is a HINT, not a source of truth, and `Run()`'s upstream-path harvester is the actual ground truth path.

## Tests

- `TestHarvestPathsFromClarifierEvidence` — the exact Wave 1 bullet shape the user's Clarifier produced (`path.tsx:193-199`). Must extract the `.tsx` path cleanly.
- `TestHarvestPathsMultipleExtensions` — `.json`, `.tsx`, `.ts` all harvested from the same prose block.
- `TestHarvestPathsDeduplicates` / `TestHarvestPathsFromMultipleSources` — grammar + multi-source merging.
- `TestHarvestPathsRejectsAbsoluteAndTraversal` — `/etc/passwd` and `../../outside.go` filtered via `isSafeRelPath`.
- `TestHarvestPathsIgnoresBareFilenames` — bare `main.go` in prose is too noisy to harvest; regex requires a slash.
- `TestHarvestPathsIgnoresEmptyInput` — robustness.
- `TestImplementerRunAutoLoadsUpstreamCitedPaths` — **the regression guard for the user's failure**. Scripted picker returns `[]` (simulating truncated inventory that doesn't include the cited path). The cited path is in `ctx.ClarifierNotes`. `Run()` must harvest it, load it, and the `generateDiff` prompt must contain both the file contents AND the path string. Model produces a real diff without hitting ERROR.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Re-run `/aidev-run 533`. Expect: even if the inventory walk still misses `apps/marketing/src/components/`, the Implementer auto-loads the paths cited by the Clarifier/Scout before the picker runs. No more false 'files don't exist' ERRORs on paths upstream agents have already verified.