### PR TITLE
feat(v0.4): native tool use — Implementer with read_file/glob/grep/list_dir

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -27,6 +27,25 @@ tiers:
     max_tokens: 2048
     temperature: 0.2
 
+  # The medium tier hosts the Implementer and Reviewer. v0.4 added
+  # native tool use (read_file, glob, grep, list_dir) for providers
+  # that implement llm.ToolAwareProvider. Currently only the
+  # `anthropic` provider supports tool use; `claude-cli` and
+  # `ollama` fall back to the legacy picker + NEED_FILES path,
+  # which still works but is less robust.
+  #
+  # To unlock v0.4 tool use for the Implementer specifically, set
+  # ANTHROPIC_API_KEY and swap this tier:
+  #
+  #   medium:
+  #     provider: anthropic
+  #     model: claude-sonnet-4-6       # or claude-opus-4-6
+  #     max_tokens: 8192
+  #     temperature: 0.2
+  #
+  # Tool use eliminates entire categories of failures that the
+  # legacy path hits on large monorepos (see aidev#37 for the
+  # motivating diagnosis).
   medium:
     provider: claude-cli
     model: ""

--- a/internal/agents/implementer.go
+++ b/internal/agents/implementer.go
@@ -134,6 +134,15 @@ func (i *Implementer) Run(ctx context.Context, c *Context, chosen *Sketch) (*Pat
 		return nil, errors.New("implementer: no repo snapshot")
 	}
 
+	// v0.4: if the provider supports native tool use, use the real
+	// agentic loop. The legacy picker + NEED_FILES path below is
+	// kept as the fallback for providers without tool support
+	// (Ollama, claude-cli) so swapping to a fully-local preset
+	// still works end-to-end — slower, less reliable, but functional.
+	if toolAware, ok := i.Provider.(llm.ToolAwareProvider); ok {
+		return i.runWithTools(ctx, toolAware, c, chosen)
+	}
+
 	// Pre-load files that upstream agents (Scout, Critic, Clarifier,
 	// Architect) have already cited in their output. These paths are
 	// authoritative: if the Clarifier quotes

--- a/internal/agents/implementer_tools.go
+++ b/internal/agents/implementer_tools.go
@@ -1,0 +1,308 @@
+// Implementer's native-tool-use code path (v0.4).
+//
+// This file is what Implementer.Run() dispatches to when the
+// configured provider implements llm.ToolAwareProvider. It replaces
+// the legacy picker + NEED_FILES + harvest + missing-paths tracking
+// path with a single agentic loop where the model calls read_file,
+// glob, grep, and list_dir as real tools within one LLM session.
+//
+// The whole file is scoped to this one responsibility. The legacy
+// path in implementer.go stays intact as a fallback for providers
+// that don't support tool use (Ollama, claude-cli), so users on the
+// --preset local path still get a working Implementer — slower and
+// less reliable, but functional.
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aisu-ai/aidev/internal/llm"
+)
+
+// maxToolIterations caps the number of Implementer <-> tool-result
+// round-trips per Run() call. The budget matters because each
+// iteration is a full LLM round-trip, and a runaway loop (model
+// keeps calling tools indefinitely) would balloon cost. 25 is
+// generous enough for the real-world consolidation tasks I've seen
+// — picker-plus-diff in the legacy path was typically 3-5 LLM
+// calls, and the native tool-use path trades fewer calls per
+// round for more rounds (read file, grep for refs, read another,
+// etc.). 25 gives the model enough headroom to explore a
+// multi-locale + multi-component monorepo without tearing through
+// the budget.
+const maxToolIterations = 25
+
+// runWithTools drives the native tool-use loop. Called from
+// Implementer.Run() when the provider implements ToolAwareProvider.
+//
+// The loop shape:
+//
+//  1. Build initial system prompt + user message + tool definitions.
+//  2. Call provider.CompleteWithTools.
+//  3. If StopReason is "end_turn", validate the model's final text
+//     as a unified diff and return.
+//  4. If StopReason is "tool_use", execute every ToolUse via the
+//     executor, append the assistant's message AND a new user
+//     message containing the tool_result blocks to the running
+//     history, and loop.
+//  5. Bounded at maxToolIterations to prevent runaway cost.
+//
+// Unlike the legacy path, there is NO picker turn, NO NEED_FILES
+// protocol, NO harvest step, NO missing-path tracking, and NO
+// format-correction retry. All of those were workarounds for the
+// missing tool-use capability. The model now has direct access to
+// the filesystem via tools and the conversation state is the only
+// thing the loop has to manage.
+func (i *Implementer) runWithTools(ctx context.Context, provider llm.ToolAwareProvider, c *Context, chosen *Sketch) (*Patch, error) {
+	exec := NewToolExecutor(c.Snapshot.Root)
+	toolDefs := exec.Definitions()
+
+	system := toolUseSystemPrompt()
+	userMsg := buildToolUseUserMessage(c, chosen)
+
+	// Seed the conversation with one user message. The loop appends
+	// an assistant message (and a follow-up user tool_result message)
+	// on every tool-use iteration.
+	messages := []llm.ToolMessage{
+		{
+			Role: "user",
+			Content: []llm.ToolContentBlock{
+				{Type: "text", Text: userMsg},
+			},
+		},
+	}
+
+	for iter := 0; iter < maxToolIterations; iter++ {
+		resp, err := provider.CompleteWithTools(ctx, llm.ToolAwareRequest{
+			System:   system,
+			Tools:    toolDefs,
+			Messages: messages,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("implementer: tool-use call (iteration %d): %w", iter, err)
+		}
+
+		// Append the assistant's turn to history regardless of stop
+		// reason. The provider returns AssistantMessage specifically
+		// so the caller can round-trip it.
+		messages = append(messages, resp.AssistantMessage)
+
+		switch resp.StopReason {
+		case "end_turn":
+			// Model is done iterating. Its final text is the patch.
+			return validateDiffResponse(resp.Content)
+
+		case "tool_use":
+			if len(resp.ToolUses) == 0 {
+				return nil, errors.New("implementer: stop_reason=tool_use but no tool_use blocks in response")
+			}
+			// Execute every pending tool call and build the
+			// follow-up user message with tool_result blocks.
+			resultBlocks := make([]llm.ToolContentBlock, 0, len(resp.ToolUses))
+			for _, use := range resp.ToolUses {
+				resultBlocks = append(resultBlocks, exec.Execute(use))
+			}
+			messages = append(messages, llm.ToolMessage{
+				Role:    "user",
+				Content: resultBlocks,
+			})
+			// Loop back for another turn.
+
+		case "max_tokens":
+			return nil, errors.New("implementer: provider hit max_tokens before completing the diff — consider bumping tier max_tokens")
+
+		default:
+			return nil, fmt.Errorf("implementer: unexpected stop_reason %q", resp.StopReason)
+		}
+	}
+
+	return nil, fmt.Errorf("implementer: exhausted %d tool-use iterations without producing a diff", maxToolIterations)
+}
+
+// buildToolUseUserMessage assembles the initial user message for the
+// tool-use loop. It contains everything the legacy picker+diff prompt
+// contained EXCEPT the file inventory and embedded file contents —
+// the model reads those via tools now instead of having them
+// preloaded. This keeps the initial prompt small (3-8 KB typical)
+// and lets the model fetch exactly what it needs.
+func buildToolUseUserMessage(c *Context, chosen *Sketch) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## Issue %s/%s#%d: %s\n\n", c.Issue.Owner, c.Issue.Repo, c.Issue.Number, c.Issue.Title)
+	b.WriteString(c.Issue.Body)
+
+	if c.ScoutReport != "" {
+		b.WriteString("\n\n## Scout brief\n\n")
+		b.WriteString(c.ScoutReport)
+	}
+	if c.CriticReport != "" {
+		b.WriteString("\n\n## Critic report\n\n")
+		b.WriteString(c.CriticReport)
+	}
+	fmt.Fprintf(&b, "\n\n## Chosen sketch %d: %s\n\n", chosen.Number, chosen.Title)
+	b.WriteString(chosen.Markdown)
+
+	if len(c.Principles) > 0 {
+		b.WriteString("\n\n## Engineering principles\n\n")
+		for _, p := range c.Principles {
+			fmt.Fprintf(&b, "- **%s** — %s\n", p.Name, p.Summary)
+		}
+	}
+
+	// Thread the Clarifier session through — same as legacy path,
+	// same authoritative framing.
+	if strings.TrimSpace(c.ClarifierNotes) != "" {
+		b.WriteString("\n\n## Clarifier session (AUTHORITATIVE human answers)\n\n")
+		b.WriteString(c.ClarifierNotes)
+	}
+
+	// And Coordinator feedback from a previous attempt, if any.
+	if strings.TrimSpace(c.CoordinatorFeedback) != "" {
+		b.WriteString("\n\n## Coordinator feedback on your previous attempt (AUTHORITATIVE — address each item)\n\n")
+		b.WriteString(c.CoordinatorFeedback)
+		b.WriteString("\n\nRe-produce a COMPLETE diff that addresses every concern above.")
+	}
+
+	b.WriteString("\n\n## Your task\n\n")
+	b.WriteString("You have read_file, glob, grep, and list_dir tools available. Use them freely to explore the repository and find the exact files and line numbers you need to edit. When you are ready, emit a unified git diff as your final text response — the diff is what the user will `git apply`.\n\n")
+	b.WriteString("Plan your tool use: glob to find relevant files, read_file to see their contents, grep to find all call sites, then produce the diff in one pass. You do NOT need to ask permission before calling tools, and you do NOT need to narrate what you're about to do — just call the tools and then produce the diff.\n")
+
+	return b.String()
+}
+
+// toolUseSystemPrompt is the system prompt for the tool-use path.
+// Different from the legacy generateDiff prompt: no picker grammar,
+// no NEED_FILES protocol, no format-prefix validator. The
+// teammate-not-checklist-writer framing and the FORBIDDEN OUTPUTS
+// rules stay — they're still relevant. Rule 6 becomes "your final
+// assistant message must contain a unified git diff" (no prefix
+// grammar required because stop_reason signals the end, not a
+// string marker).
+func toolUseSystemPrompt() string {
+	return `You are the Implementer for aidev, a multi-agent coding tool.
+
+You are a senior engineer pairing with a teammate. The developer has
+chosen one of the Architect's sketches and is asking you to do the
+work — not to write a checklist, not to hand back a draft for the
+human to finish, not to file a TODO. You have direct tool access to
+the repository (read_file, glob, grep, list_dir) and should use those
+tools to verify every decision you make before producing the diff.
+
+WORKFLOW:
+
+1. Use the tools to discover the code. Typical pattern for a
+   refactor or consolidation task:
+     - glob for candidate files ("apps/marketing/**/*.tsx")
+     - grep for all call sites of the thing you're changing
+     - read_file each file you plan to modify to see exact line
+       numbers and surrounding context
+     - read_file the locale / config files whose values you need
+       to preserve verbatim
+   You can call multiple tools per turn — batch them when you
+   already know what you need.
+
+2. When you have enough context, emit a unified git diff as your
+   final assistant message (without any more tool calls). The loop
+   ends when your turn contains only text.
+
+OUTPUT REQUIREMENTS for the final diff:
+
+1. Standard git unified diff format:
+
+     diff --git a/path/to/file b/path/to/file
+     --- a/path/to/file
+     +++ b/path/to/file
+     @@ -lineno,count +lineno,count @@
+     -old line
+     +new line
+
+   For new files use /dev/null as the 'a' side.
+   For deletions use /dev/null as the 'b' side.
+
+2. Repo-relative bare paths. No leading ./, no absolute paths.
+
+3. Minimal in scope, COMPLETE in execution. Only touch files the
+   sketch actually needs — but within that scope, do the whole job.
+   A diff that covers 8 of 9 locales is a regression. Half-migrated
+   call sites are a regression. If the sketch asks for 9 things,
+   produce 9 things.
+
+4. Include tests when the diff adds new behavior. Tests belong in
+   the same diff, not a follow-up.
+
+5. Include docstrings / comments where the sketch implies new
+   public API, matching the repo's existing conventions.
+
+FORBIDDEN OUTPUTS — the following are failure modes:
+
+   * Auxiliary checklist/notes files alongside the real change
+     (AIDEV_TODO_*.md, NOTES.md, CHECKLIST.md, HUMAN_FOLLOWUP.md).
+     The diff IS the work. If a human has to finish the job from
+     your output, you have failed. Use tools to fetch the real
+     values, do not punt.
+
+   * Comments in file formats that don't support them. JSON does
+     NOT have comments — // TODO inside a .json hunk is invalid
+     syntax and the diff won't apply. Check the file extension
+     before adding any kind of comment.
+
+   * Fabricated or placeholder string values. If you need a
+     specific translation, brand name, API identifier, or content
+     literal, read_file the source that has the canonical value.
+     Never invent "Kontakt Vertrieb" as a stand-in for a German
+     translation that exists elsewhere in the repo.
+
+   * Partial starting points that expect the human to finish the
+     job. You are not generating homework. Finish the scope the
+     sketch asked for, end to end.
+
+   * Claiming files don't exist based on what you "know". The
+     repository is a black box to you except through the tools.
+     If the Clarifier cites apps/marketing/src/components/foo.tsx,
+     read_file it — the file is there. If read_file returns
+     "file not found", THEN you know it's missing.
+
+Stay realistic: the user will apply this diff with git apply and
+review it. A diff that applies cleanly and finishes the scope is
+worth ten drafts that need human cleanup.`
+}
+
+// validateDiffResponse checks that a model's final text looks like a
+// unified git diff and returns a Patch. Uses the same grammar the
+// legacy path used, minus the NEED_FILES branch (not valid in
+// tool-use mode) and minus the format-correction retry (the model
+// can iterate inside the tool loop, so a bad final turn is a real
+// failure, not a format slip).
+func validateDiffResponse(raw string) (*Patch, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, errors.New("implementer: empty final response (no diff produced)")
+	}
+	raw = stripCodeFence(raw)
+
+	if strings.HasPrefix(raw, "ERROR:") {
+		reason := strings.TrimSpace(strings.TrimPrefix(firstLine(raw), "ERROR:"))
+		if reason == "" {
+			reason = "(no reason given)"
+		}
+		return nil, fmt.Errorf("implementer: declared ERROR: %s", reason)
+	}
+
+	// Tolerate a short prose preamble before `diff --git` in the
+	// tool-use path — models sometimes narrate the final turn
+	// ("Here's the diff:") before the real content. We look for
+	// the first `diff --git` anywhere in the response and treat
+	// everything from there to the end as the patch body.
+	idx := strings.Index(raw, "diff --git")
+	if idx < 0 {
+		return nil, fmt.Errorf("implementer: final response contains no 'diff --git' marker; got first line: %q", firstLine(raw))
+	}
+	diff := raw[idx:]
+
+	return &Patch{
+		Diff:         diff,
+		FilesTouched: parseFilesFromDiff(diff),
+	}, nil
+}

--- a/internal/agents/implementer_tools_test.go
+++ b/internal/agents/implementer_tools_test.go
@@ -1,0 +1,417 @@
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aisu-ai/aidev/internal/github"
+	"github.com/aisu-ai/aidev/internal/llm"
+	"github.com/aisu-ai/aidev/internal/repo"
+)
+
+// scriptedToolProvider replays a fixed sequence of ToolAwareResponse
+// turns, so tests can drive the runWithTools loop without an LLM.
+// Each Complete call advances to the next response; the last
+// response is reused for any calls past the end of the script so
+// tests can assert on how many times the provider was invoked.
+type scriptedToolProvider struct {
+	responses []llm.ToolAwareResponse
+	calls     int
+	lastReq   llm.ToolAwareRequest
+}
+
+func (p *scriptedToolProvider) Name() string { return "scripted-tool" }
+
+// Complete is required by the Provider interface but the tool-use
+// path never calls it; we panic if it does to catch regressions
+// where the Implementer accidentally falls back to the legacy path.
+func (p *scriptedToolProvider) Complete(_ context.Context, _ llm.Request) (llm.Response, error) {
+	panic("scriptedToolProvider.Complete called — Implementer should be using CompleteWithTools")
+}
+
+func (p *scriptedToolProvider) CompleteWithTools(_ context.Context, req llm.ToolAwareRequest) (llm.ToolAwareResponse, error) {
+	p.lastReq = req
+	idx := p.calls
+	if idx >= len(p.responses) {
+		idx = len(p.responses) - 1
+	}
+	p.calls++
+	return p.responses[idx], nil
+}
+
+// Compile-time assertion.
+var _ llm.ToolAwareProvider = (*scriptedToolProvider)(nil)
+
+func makeTextBlock(s string) llm.ToolContentBlock {
+	return llm.ToolContentBlock{Type: "text", Text: s}
+}
+
+func makeToolUseBlock(id, name, inputJSON string) llm.ToolContentBlock {
+	return llm.ToolContentBlock{
+		Type:      "tool_use",
+		ToolUseID: id,
+		ToolName:  name,
+		ToolInput: json.RawMessage(inputJSON),
+	}
+}
+
+// TestImplementerRunUsesToolPathWhenAvailable is the happy-path
+// regression guard for v0.4. A provider that implements
+// ToolAwareProvider must make Implementer.Run dispatch to the
+// tool-use loop — no picker, no NEED_FILES, just tool calls and a
+// final diff.
+func TestImplementerRunUsesToolPathWhenAvailable(t *testing.T) {
+	dir := t.TempDir()
+	citedPath := "apps/marketing/src/components/pages/pricing/pricing.tsx"
+	if err := os.MkdirAll(filepath.Join(dir, filepath.Dir(citedPath)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, citedPath),
+		[]byte("import { t } from '@/lib/i18n'\nexport const Pricing = () => <>{t('contactSales')}</>\n"),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Scripted conversation:
+	//   Turn 1: model calls read_file to see the TSX file
+	//   Turn 2: model emits the final diff
+	provider := &scriptedToolProvider{
+		responses: []llm.ToolAwareResponse{
+			{
+				StopReason: "tool_use",
+				ToolUses: []llm.ToolUse{
+					{ID: "tu_1", Name: "read_file", Input: json.RawMessage(`{"path":"` + citedPath + `"}`)},
+				},
+				AssistantMessage: llm.ToolMessage{
+					Role: "assistant",
+					Content: []llm.ToolContentBlock{
+						makeTextBlock("Let me read the pricing component."),
+						makeToolUseBlock("tu_1", "read_file", `{"path":"`+citedPath+`"}`),
+					},
+				},
+			},
+			{
+				StopReason: "end_turn",
+				Content: "diff --git a/" + citedPath + " b/" + citedPath + "\n" +
+					"--- a/" + citedPath + "\n" +
+					"+++ b/" + citedPath + "\n" +
+					"@@ -1,2 +1,2 @@\n" +
+					" import { t } from '@/lib/i18n'\n" +
+					"-export const Pricing = () => <>{t('contactSales')}</>\n" +
+					"+export const Pricing = () => <>{t('common.cta.contactSales')}</>\n",
+				AssistantMessage: llm.ToolMessage{
+					Role: "assistant",
+					Content: []llm.ToolContentBlock{
+						makeTextBlock("diff --git a/" + citedPath + " b/" + citedPath + "\n..."),
+					},
+				},
+			},
+		},
+	}
+
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "t", Body: "body"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "consolidate", Markdown: "## Plan\n- update pricing"}
+
+	patch, err := impl.Run(context.Background(), ctx, sketch)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if patch == nil {
+		t.Fatal("nil patch")
+	}
+	if !strings.Contains(patch.Diff, "common.cta.contactSales") {
+		t.Errorf("patch missing expected content, got:\n%s", patch.Diff)
+	}
+	if provider.calls != 2 {
+		t.Errorf("provider called %d times, want 2", provider.calls)
+	}
+	// Sanity check: the last request's Messages should include
+	// the tool_result block from executing read_file.
+	foundToolResult := false
+	for _, m := range provider.lastReq.Messages {
+		for _, b := range m.Content {
+			if b.Type == "tool_result" && b.ToolUseID == "tu_1" {
+				foundToolResult = true
+				if b.ToolResultIsError {
+					t.Errorf("read_file reported error on an existing file: %s", b.ToolResultContent)
+				}
+				if !strings.Contains(b.ToolResultContent, "contactSales") {
+					t.Errorf("tool_result should contain file content; got: %s", b.ToolResultContent)
+				}
+			}
+		}
+	}
+	if !foundToolResult {
+		t.Error("last request did not contain a tool_result block for tu_1")
+	}
+}
+
+// TestImplementerRunToolPathMultipleIterations exercises a realistic
+// multi-turn conversation: glob → read_file (two calls in one turn)
+// → grep → emit diff. Four provider calls total, with multiple
+// tool_use blocks in some assistant turns.
+func TestImplementerRunToolPathMultipleIterations(t *testing.T) {
+	dir := t.TempDir()
+	must := func(path, body string) {
+		full := filepath.Join(dir, path)
+		_ = os.MkdirAll(filepath.Dir(full), 0o755)
+		_ = os.WriteFile(full, []byte(body), 0o644)
+	}
+	must("apps/marketing/src/components/a.tsx", "export const A = () => t('contactSales')\n")
+	must("apps/marketing/src/components/b.tsx", "export const B = () => t('contactSales')\n")
+	must("apps/marketing/src/lib/i18n/translations/en/common.json", `{"contactSales":"Contact Sales"}`+"\n")
+
+	provider := &scriptedToolProvider{
+		responses: []llm.ToolAwareResponse{
+			// Turn 1: one glob to find the components
+			{
+				StopReason: "tool_use",
+				ToolUses: []llm.ToolUse{
+					{ID: "tu_glob", Name: "glob", Input: json.RawMessage(`{"pattern":"apps/marketing/**/*.tsx"}`)},
+				},
+				AssistantMessage: llm.ToolMessage{
+					Role: "assistant",
+					Content: []llm.ToolContentBlock{
+						makeToolUseBlock("tu_glob", "glob", `{"pattern":"apps/marketing/**/*.tsx"}`),
+					},
+				},
+			},
+			// Turn 2: two read_file calls in the same turn (batched)
+			{
+				StopReason: "tool_use",
+				ToolUses: []llm.ToolUse{
+					{ID: "tu_a", Name: "read_file", Input: json.RawMessage(`{"path":"apps/marketing/src/components/a.tsx"}`)},
+					{ID: "tu_b", Name: "read_file", Input: json.RawMessage(`{"path":"apps/marketing/src/components/b.tsx"}`)},
+				},
+				AssistantMessage: llm.ToolMessage{
+					Role: "assistant",
+					Content: []llm.ToolContentBlock{
+						makeToolUseBlock("tu_a", "read_file", `{"path":"apps/marketing/src/components/a.tsx"}`),
+						makeToolUseBlock("tu_b", "read_file", `{"path":"apps/marketing/src/components/b.tsx"}`),
+					},
+				},
+			},
+			// Turn 3: grep to confirm no other consumers
+			{
+				StopReason: "tool_use",
+				ToolUses: []llm.ToolUse{
+					{ID: "tu_grep", Name: "grep", Input: json.RawMessage(`{"pattern":"contactSales","paths":["apps/marketing/src"]}`)},
+				},
+				AssistantMessage: llm.ToolMessage{
+					Role: "assistant",
+					Content: []llm.ToolContentBlock{
+						makeToolUseBlock("tu_grep", "grep", `{"pattern":"contactSales","paths":["apps/marketing/src"]}`),
+					},
+				},
+			},
+			// Turn 4: emit the final diff
+			{
+				StopReason: "end_turn",
+				Content: "diff --git a/apps/marketing/src/components/a.tsx b/apps/marketing/src/components/a.tsx\n" +
+					"--- a/apps/marketing/src/components/a.tsx\n" +
+					"+++ b/apps/marketing/src/components/a.tsx\n" +
+					"@@ -1 +1 @@\n" +
+					"-export const A = () => t('contactSales')\n" +
+					"+export const A = () => t('common.cta.contactSales')\n",
+				AssistantMessage: llm.ToolMessage{
+					Role:    "assistant",
+					Content: []llm.ToolContentBlock{makeTextBlock("diff --git a/apps/marketing/src/components/a.tsx b/apps/marketing/src/components/a.tsx\n...")},
+				},
+			},
+		},
+	}
+
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "t", Body: "body"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "consolidate", Markdown: "## Plan"}
+
+	patch, err := impl.Run(context.Background(), ctx, sketch)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if patch == nil {
+		t.Fatal("nil patch")
+	}
+	if provider.calls != 4 {
+		t.Errorf("provider called %d times, want 4 (glob, 2x read_file, grep, end)", provider.calls)
+	}
+}
+
+// TestImplementerRunToolPathHitsIterationCap guards against runaway
+// loops. A provider that keeps emitting tool_use forever must trip
+// maxToolIterations and return an error instead of ballooning cost.
+func TestImplementerRunToolPathHitsIterationCap(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\n"), 0o644)
+
+	// Single response that keeps requesting read_file on a real
+	// file — the loop has no termination path.
+	looping := llm.ToolAwareResponse{
+		StopReason: "tool_use",
+		ToolUses: []llm.ToolUse{
+			{ID: "tu_loop", Name: "read_file", Input: json.RawMessage(`{"path":"x.go"}`)},
+		},
+		AssistantMessage: llm.ToolMessage{
+			Role: "assistant",
+			Content: []llm.ToolContentBlock{
+				makeToolUseBlock("tu_loop", "read_file", `{"path":"x.go"}`),
+			},
+		},
+	}
+	script := make([]llm.ToolAwareResponse, maxToolIterations+5)
+	for i := range script {
+		script[i] = looping
+	}
+	provider := &scriptedToolProvider{responses: script}
+
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "t", Body: "body"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+
+	_, err := impl.Run(context.Background(), ctx, sketch)
+	if err == nil {
+		t.Fatal("expected iteration-cap error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exhausted") {
+		t.Errorf("expected 'exhausted' in error, got: %v", err)
+	}
+	if provider.calls != maxToolIterations {
+		t.Errorf("provider called %d times, want exactly %d (the cap)", provider.calls, maxToolIterations)
+	}
+}
+
+// TestImplementerRunToolPathSurfacesERROR verifies the ERROR escape
+// hatch still works when the model emits ERROR: as its final text.
+// Even though the tool-use path eliminates most reasons to ERROR,
+// genuine impossibility is still a valid terminal state.
+func TestImplementerRunToolPathSurfacesERROR(t *testing.T) {
+	dir := t.TempDir()
+
+	provider := &scriptedToolProvider{
+		responses: []llm.ToolAwareResponse{
+			{
+				StopReason: "end_turn",
+				Content:    "ERROR: the sketch contradicts itself — cannot reconcile rules A and B",
+				AssistantMessage: llm.ToolMessage{
+					Role: "assistant",
+					Content: []llm.ToolContentBlock{
+						makeTextBlock("ERROR: the sketch contradicts itself — cannot reconcile rules A and B"),
+					},
+				},
+			},
+		},
+	}
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "t", Body: "body"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+
+	_, err := impl.Run(context.Background(), ctx, sketch)
+	if err == nil {
+		t.Fatal("expected declared ERROR, got nil")
+	}
+	if !strings.Contains(err.Error(), "contradicts itself") {
+		t.Errorf("ERROR reason should be surfaced; got: %v", err)
+	}
+}
+
+// TestImplementerRunToolPathTolerantToProsePreamble verifies the
+// validator accepts a diff that's prefixed with a short narrative.
+// The tool-use path is more forgiving than the legacy path because
+// it has no NEED_FILES grammar to disambiguate against.
+func TestImplementerRunToolPathTolerantToProsePreamble(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\n"), 0o644)
+
+	provider := &scriptedToolProvider{
+		responses: []llm.ToolAwareResponse{
+			{
+				StopReason: "end_turn",
+				Content: "Here's the diff that consolidates the call sites:\n\n" +
+					"diff --git a/x.go b/x.go\n" +
+					"--- a/x.go\n" +
+					"+++ b/x.go\n" +
+					"@@ -1 +1 @@\n" +
+					"-package x\n" +
+					"+package y\n",
+				AssistantMessage: llm.ToolMessage{
+					Role:    "assistant",
+					Content: []llm.ToolContentBlock{makeTextBlock("Here's the diff...")},
+				},
+			},
+		},
+	}
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "t", Body: "body"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+
+	patch, err := impl.Run(context.Background(), ctx, sketch)
+	if err != nil {
+		t.Fatalf("prose preamble should be tolerated: %v", err)
+	}
+	if !strings.Contains(patch.Diff, "+package y") {
+		t.Errorf("patch should start at 'diff --git', got:\n%s", patch.Diff)
+	}
+	// The preamble must be stripped — the Patch.Diff field starts
+	// at diff --git, not at "Here's the diff".
+	if strings.Contains(patch.Diff, "Here's the diff") {
+		t.Errorf("preamble should have been stripped; got:\n%s", patch.Diff)
+	}
+}
+
+// TestImplementerRunLegacyPathStillFiresForNonToolProviders is the
+// critical backwards-compat guard: a provider that does NOT
+// implement ToolAwareProvider must go through the legacy picker +
+// NEED_FILES + harvest path. The scripted Provider (not the
+// scriptedToolProvider) serves as a non-tool-aware fixture.
+func TestImplementerRunLegacyPathStillFiresForNonToolProviders(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\n"), 0o644)
+
+	// scriptedProvider is from implementer_test.go and does NOT
+	// implement ToolAwareProvider. A type assertion in Run() must
+	// fall through to runLegacy and produce a patch via the picker
+	// + generateDiff path.
+	provider := &scriptedProvider{
+		responses: []string{
+			`["x.go"]`, // picker
+			"diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-package x\n+package y\n",
+		},
+	}
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "t", Body: "body"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+
+	patch, err := impl.Run(context.Background(), ctx, sketch)
+	if err != nil {
+		t.Fatalf("legacy path should still work: %v", err)
+	}
+	if patch == nil {
+		t.Fatal("nil patch from legacy path")
+	}
+	if !strings.Contains(patch.Diff, "+package y") {
+		t.Errorf("legacy diff wrong: %s", patch.Diff)
+	}
+}

--- a/internal/agents/tools.go
+++ b/internal/agents/tools.go
@@ -1,0 +1,506 @@
+// Tool executors for the Implementer's tool-use loop (v0.4).
+//
+// These run server-side in aidev — the LLM emits a tool_use block,
+// the agent's tool loop dispatches it here, and the return value
+// becomes a tool_result block in the next LLM turn.
+//
+// All tools are READ-ONLY and repo-scoped via isSafeRelPath from
+// implementer.go. The Implementer still produces a diff; it doesn't
+// mutate files directly. Write access would be an interesting but
+// separate design decision (and a much bigger safety footprint).
+//
+// Tools available:
+//
+//	read_file(path)         contents of one file, size-capped
+//	glob(pattern)           doublestar glob matches under the repo root
+//	grep(pattern, paths?)   ripgrep-style text search
+//	list_dir(path)          directory listing
+//
+// Each tool's JSON Schema is declared next to its executor so the
+// model gets accurate parameter descriptions in the system prompt.
+package agents
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/aisu-ai/aidev/internal/llm"
+)
+
+// ToolExecutor binds a repo root and a set of tool implementations
+// so the Implementer's tool loop can dispatch tool_use calls.
+// Construct one per Implement() invocation — not shared across runs
+// because the repo root is invocation-scoped.
+type ToolExecutor struct {
+	RepoRoot string
+
+	// Limits. Exposed as fields so tests can override them.
+	MaxReadBytes int // per read_file call
+	MaxGlobHits  int // per glob call
+	MaxGrepHits  int // per grep call
+	MaxListHits  int // per list_dir call
+}
+
+// NewToolExecutor returns a ToolExecutor with production default
+// limits. Every Implementer.Run() call constructs a fresh one.
+func NewToolExecutor(repoRoot string) *ToolExecutor {
+	return &ToolExecutor{
+		RepoRoot:     repoRoot,
+		MaxReadBytes: 128 * 1024,
+		MaxGlobHits:  500,
+		MaxGrepHits:  200,
+		MaxListHits:  500,
+	}
+}
+
+// Definitions returns the llm.ToolDefinition slice that drives the
+// system prompt's tool schema. Order is stable so the model sees
+// the same tool list on every turn.
+func (e *ToolExecutor) Definitions() []llm.ToolDefinition {
+	return []llm.ToolDefinition{
+		{
+			Name:        "read_file",
+			Description: "Read a single file from the repository. Returns the file contents as a UTF-8 string. Paths are repo-relative (no leading slash, no `..` components). Files larger than the max_bytes limit are truncated at the boundary with a marker appended.",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"path": {
+						"type": "string",
+						"description": "Repo-relative path to the file (e.g. apps/marketing/src/components/foo.tsx)"
+					}
+				},
+				"required": ["path"]
+			}`),
+		},
+		{
+			Name:        "glob",
+			Description: "Find files matching a glob pattern (doublestar-style, so ** matches any depth). Returns a newline-separated list of matching repo-relative paths, sorted lexicographically. Paths that escape the repo root are rejected. Example patterns: `apps/marketing/**/*.tsx`, `**/common.json`, `packages/types/src/*.ts`.",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"pattern": {
+						"type": "string",
+						"description": "Doublestar glob pattern (e.g. apps/**/*.tsx)"
+					}
+				},
+				"required": ["pattern"]
+			}`),
+		},
+		{
+			Name:        "grep",
+			Description: "Search for a regex pattern across repo files. Returns a newline-separated list of matches in the form `path:line: matched line text`. Optionally scope the search to a list of path prefixes (directories or specific files). If `paths` is omitted the entire repo is searched (minus vendor directories).",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"pattern": {
+						"type": "string",
+						"description": "Go-flavored regular expression (RE2 syntax)"
+					},
+					"paths": {
+						"type": "array",
+						"items": {"type": "string"},
+						"description": "Optional repo-relative path prefixes to scope the search. Empty means whole-repo."
+					}
+				},
+				"required": ["pattern"]
+			}`),
+		},
+		{
+			Name:        "list_dir",
+			Description: "List the contents of a directory. Returns a newline-separated list of entries, each prefixed with 'd/' for directories or 'f/' for files. Useful for exploring the tree when you don't know the exact path to a component.",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"path": {
+						"type": "string",
+						"description": "Repo-relative directory path (use '.' for the repo root)"
+					}
+				},
+				"required": ["path"]
+			}`),
+		},
+	}
+}
+
+// Execute dispatches one ToolUse to the matching implementation.
+// Returns a ToolResult ready to be appended to the next turn's
+// conversation.
+//
+// "Error" in the ToolResult sense means the TOOL failed (file not
+// found, invalid regex, etc.) — something the model can react to.
+// Programming errors (bad JSON, unknown tool) also become
+// IsError=true tool_results so the model can retry rather than
+// tearing down the whole conversation. Only catastrophic failures
+// (out-of-memory, unrecoverable I/O) propagate as Go errors.
+func (e *ToolExecutor) Execute(use llm.ToolUse) llm.ToolContentBlock {
+	block := llm.ToolContentBlock{
+		Type:      "tool_result",
+		ToolUseID: use.ID,
+	}
+
+	out, err := e.dispatch(use)
+	if err != nil {
+		block.ToolResultContent = "error: " + err.Error()
+		block.ToolResultIsError = true
+		return block
+	}
+	block.ToolResultContent = out
+	return block
+}
+
+// dispatch routes a tool call to the matching executor. Returns
+// (output, error) — the caller wraps both in a tool_result block.
+func (e *ToolExecutor) dispatch(use llm.ToolUse) (string, error) {
+	switch use.Name {
+	case "read_file":
+		var args struct {
+			Path string `json:"path"`
+		}
+		if err := json.Unmarshal(use.Input, &args); err != nil {
+			return "", fmt.Errorf("read_file: parse input: %w", err)
+		}
+		return e.readFile(args.Path)
+
+	case "glob":
+		var args struct {
+			Pattern string `json:"pattern"`
+		}
+		if err := json.Unmarshal(use.Input, &args); err != nil {
+			return "", fmt.Errorf("glob: parse input: %w", err)
+		}
+		return e.glob(args.Pattern)
+
+	case "grep":
+		var args struct {
+			Pattern string   `json:"pattern"`
+			Paths   []string `json:"paths"`
+		}
+		if err := json.Unmarshal(use.Input, &args); err != nil {
+			return "", fmt.Errorf("grep: parse input: %w", err)
+		}
+		return e.grep(args.Pattern, args.Paths)
+
+	case "list_dir":
+		var args struct {
+			Path string `json:"path"`
+		}
+		if err := json.Unmarshal(use.Input, &args); err != nil {
+			return "", fmt.Errorf("list_dir: parse input: %w", err)
+		}
+		return e.listDir(args.Path)
+
+	default:
+		return "", fmt.Errorf("unknown tool %q", use.Name)
+	}
+}
+
+// readFile returns a file's contents, size-capped. Empty paths,
+// absolute paths, and paths with `..` segments are rejected.
+func (e *ToolExecutor) readFile(path string) (string, error) {
+	if !isSafeRelPath(path) {
+		return "", fmt.Errorf("unsafe or empty path %q", path)
+	}
+	abs := filepath.Join(e.RepoRoot, path)
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", fmt.Errorf("file not found: %s", path)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("path is a directory, use list_dir instead: %s", path)
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	if len(data) > e.MaxReadBytes {
+		truncated := string(data[:e.MaxReadBytes])
+		return truncated + fmt.Sprintf("\n\n[truncated by aidev at %d bytes of %d]\n", e.MaxReadBytes, len(data)), nil
+	}
+	return string(data), nil
+}
+
+// glob walks the repo tree and returns matches against the given
+// doublestar pattern. We implement our own doublestar match rather
+// than pulling in an external dependency because the matching logic
+// is simple: `**` matches any path segment sequence, `*` matches one
+// segment without slashes.
+func (e *ToolExecutor) glob(pattern string) (string, error) {
+	if pattern == "" {
+		return "", errors.New("empty pattern")
+	}
+	// Reject absolute/traversal patterns the same way isSafeRelPath
+	// rejects paths. We don't want `glob("/etc/**")` to work.
+	if strings.HasPrefix(pattern, "/") || strings.Contains(pattern, "..") {
+		return "", fmt.Errorf("unsafe pattern %q", pattern)
+	}
+
+	re, err := globToRegexp(pattern)
+	if err != nil {
+		return "", fmt.Errorf("compile pattern: %w", err)
+	}
+
+	var matches []string
+	err = filepath.WalkDir(e.RepoRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if shouldSkipDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, relErr := filepath.Rel(e.RepoRoot, path)
+		if relErr != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if re.MatchString(rel) {
+			matches = append(matches, rel)
+			if len(matches) >= e.MaxGlobHits {
+				return errStopWalk
+			}
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errStopWalk) {
+		return "", err
+	}
+
+	if len(matches) == 0 {
+		return "(no matches)", nil
+	}
+	sort.Strings(matches)
+	result := strings.Join(matches, "\n")
+	if len(matches) >= e.MaxGlobHits {
+		result += fmt.Sprintf("\n\n[truncated at %d matches — refine your pattern]", e.MaxGlobHits)
+	}
+	return result, nil
+}
+
+// globToRegexp translates a doublestar-style glob into a Go
+// regular expression. Rules:
+//
+//	**       any sequence of path segments (including zero)
+//	*        one path segment, no slashes
+//	?        one character, no slash
+//	[abc]    character class, passed through
+//
+// Everything else (including /, ., -, _) is escaped.
+func globToRegexp(pattern string) (*regexp.Regexp, error) {
+	var b strings.Builder
+	b.WriteString("^")
+	i := 0
+	for i < len(pattern) {
+		c := pattern[i]
+		switch {
+		case c == '*' && i+1 < len(pattern) && pattern[i+1] == '*':
+			// `**` — consume two, match any path segments.
+			// Also eat a following `/` so `a/**/b` matches `a/b`.
+			i += 2
+			if i < len(pattern) && pattern[i] == '/' {
+				i++
+			}
+			b.WriteString(`(?:.*/)?`)
+		case c == '*':
+			b.WriteString(`[^/]*`)
+			i++
+		case c == '?':
+			b.WriteString(`[^/]`)
+			i++
+		case c == '[':
+			// Character class, pass through up to the closing `]`.
+			end := strings.IndexByte(pattern[i:], ']')
+			if end < 0 {
+				return nil, fmt.Errorf("unclosed [ in pattern")
+			}
+			b.WriteString(pattern[i : i+end+1])
+			i += end + 1
+		default:
+			b.WriteString(regexp.QuoteMeta(string(c)))
+			i++
+		}
+	}
+	b.WriteString("$")
+	return regexp.Compile(b.String())
+}
+
+// grep searches the repo (or a subset) for lines matching pattern.
+// Uses Go regexp (RE2 syntax). Results are scoped to source files —
+// we reuse listSourceFiles's extension filter to avoid grepping
+// binaries, node_modules, etc. If paths is non-empty, each path is
+// treated as a prefix filter: a match is included only if its
+// relative path starts with one of the given prefixes.
+func (e *ToolExecutor) grep(pattern string, paths []string) (string, error) {
+	if pattern == "" {
+		return "", errors.New("empty pattern")
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", fmt.Errorf("compile pattern: %w", err)
+	}
+
+	// Sanity-check scope paths.
+	var prefixes []string
+	for _, p := range paths {
+		p = filepath.ToSlash(strings.TrimSpace(p))
+		if p == "" || p == "." {
+			continue
+		}
+		if !isSafeRelPath(p) {
+			return "", fmt.Errorf("unsafe scope path %q", p)
+		}
+		prefixes = append(prefixes, p)
+	}
+
+	var hits []string
+	err = filepath.WalkDir(e.RepoRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if shouldSkipDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !isSourceExt(filepath.Ext(d.Name())) {
+			return nil
+		}
+		rel, relErr := filepath.Rel(e.RepoRoot, path)
+		if relErr != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if len(prefixes) > 0 && !matchesAnyPrefix(rel, prefixes) {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		for lineNum, line := range strings.Split(string(data), "\n") {
+			if re.MatchString(line) {
+				// Cap individual line length so one pathological
+				// line doesn't explode the output.
+				if len(line) > 400 {
+					line = line[:400] + "…"
+				}
+				hits = append(hits, fmt.Sprintf("%s:%d: %s", rel, lineNum+1, line))
+				if len(hits) >= e.MaxGrepHits {
+					return errStopWalk
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errStopWalk) {
+		return "", err
+	}
+
+	if len(hits) == 0 {
+		return "(no matches)", nil
+	}
+	result := strings.Join(hits, "\n")
+	if len(hits) >= e.MaxGrepHits {
+		result += fmt.Sprintf("\n\n[truncated at %d matches — narrow the scope with paths=[...]]", e.MaxGrepHits)
+	}
+	return result, nil
+}
+
+// listDir returns a sorted directory listing. Entries are prefixed
+// with `d/` or `f/` so the model can distinguish at a glance.
+func (e *ToolExecutor) listDir(path string) (string, error) {
+	if path == "" {
+		path = "."
+	}
+	if path != "." && !isSafeRelPath(path) {
+		return "", fmt.Errorf("unsafe path %q", path)
+	}
+	abs := e.RepoRoot
+	if path != "." {
+		abs = filepath.Join(e.RepoRoot, path)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", fmt.Errorf("not found: %s", path)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("not a directory: %s", path)
+	}
+
+	entries, err := os.ReadDir(abs)
+	if err != nil {
+		return "", fmt.Errorf("read dir: %w", err)
+	}
+
+	var lines []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if shouldSkipDir(name) && entry.IsDir() {
+			continue
+		}
+		prefix := "f/"
+		if entry.IsDir() {
+			prefix = "d/"
+		}
+		lines = append(lines, prefix+name)
+		if len(lines) >= e.MaxListHits {
+			break
+		}
+	}
+	sort.Strings(lines)
+	if len(lines) == 0 {
+		return "(empty directory)", nil
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+// matchesAnyPrefix returns true if rel begins with any of the
+// given directory prefixes, or if rel itself is listed as a file
+// prefix. Prefixes are matched on path segments: "apps/marketing"
+// matches "apps/marketing/foo.tsx" but not "apps/marketing-site/x".
+func matchesAnyPrefix(rel string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if rel == p {
+			return true
+		}
+		if strings.HasPrefix(rel, p+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldSkipDir reports whether a directory name is a well-known
+// vendor/cache/output directory that should not be searched. Same
+// list as listSourceFiles.
+func shouldSkipDir(name string) bool {
+	switch name {
+	case ".git", "node_modules", "vendor", "dist", "build", "target",
+		".next", ".venv", "venv", "__pycache__", ".aidev", ".aidev-cache":
+		return true
+	}
+	return false
+}
+
+// isSourceExt mirrors the extension allowlist used by
+// listSourceFiles — kept in sync by hand rather than shared to
+// avoid a cross-file coupling headache.
+func isSourceExt(ext string) bool {
+	switch strings.ToLower(ext) {
+	case ".go", ".py", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
+		".rs", ".java", ".kt", ".rb", ".php", ".c", ".cc", ".cpp",
+		".h", ".hpp", ".swift", ".m", ".md", ".mdx", ".yaml", ".yml",
+		".toml", ".json":
+		return true
+	}
+	return false
+}

--- a/internal/agents/tools_test.go
+++ b/internal/agents/tools_test.go
@@ -1,0 +1,345 @@
+package agents
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aisu-ai/aidev/internal/llm"
+)
+
+func setupRepo(t *testing.T) (string, *ToolExecutor) {
+	t.Helper()
+	dir := t.TempDir()
+	// Build a tiny marketing-monorepo-shaped tree so the tests
+	// exercise realistic paths (nested components, multiple locales,
+	// mixed extensions).
+	must := func(path, body string) {
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("apps/marketing/src/components/pages/pricing/pricing.tsx",
+		"import { t } from '@/lib/i18n'\nexport const Pricing = () => <>{t('contactSales')}</>\n")
+	must("apps/marketing/src/components/pages/solutions/solutions.tsx",
+		"export const Solutions = () => <>hello</>\n")
+	must("apps/marketing/src/lib/i18n/translations/en/common.json",
+		`{"contactSales":"Contact Sales"}`+"\n")
+	must("apps/marketing/src/lib/i18n/translations/fr/common.json",
+		`{"contactSales":"Contacter les ventes"}`+"\n")
+	must("apps/marketing/src/lib/i18n/translations/de/common.json",
+		`{"contactSales":"Vertrieb kontaktieren"}`+"\n")
+	must("apps/backend/main.go", "package main\n")
+	must("node_modules/should-be-skipped/index.js", "blocked")
+	must("README.md", "# test repo\n")
+	return dir, NewToolExecutor(dir)
+}
+
+func callTool(name string, input string) llm.ToolUse {
+	return llm.ToolUse{
+		ID:    "test_" + name,
+		Name:  name,
+		Input: json.RawMessage(input),
+	}
+}
+
+func TestReadFileTool(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("read_file", `{"path":"apps/marketing/src/lib/i18n/translations/en/common.json"}`))
+	if out.ToolResultIsError {
+		t.Fatalf("unexpected error: %s", out.ToolResultContent)
+	}
+	if !strings.Contains(out.ToolResultContent, "Contact Sales") {
+		t.Errorf("expected content, got: %s", out.ToolResultContent)
+	}
+}
+
+func TestReadFileToolNotFound(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("read_file", `{"path":"does/not/exist.tsx"}`))
+	if !out.ToolResultIsError {
+		t.Error("expected IsError=true for missing file")
+	}
+	if !strings.Contains(out.ToolResultContent, "file not found") {
+		t.Errorf("error message should be clear, got: %s", out.ToolResultContent)
+	}
+}
+
+func TestReadFileToolRejectsTraversal(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("read_file", `{"path":"../etc/passwd"}`))
+	if !out.ToolResultIsError {
+		t.Error("traversal path should be rejected")
+	}
+}
+
+func TestReadFileToolRejectsAbsolute(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("read_file", `{"path":"/etc/passwd"}`))
+	if !out.ToolResultIsError {
+		t.Error("absolute path should be rejected")
+	}
+}
+
+func TestReadFileToolTruncatesLargeFiles(t *testing.T) {
+	dir, exec := setupRepo(t)
+	exec.MaxReadBytes = 50
+	big := strings.Repeat("x", 500)
+	if err := os.WriteFile(filepath.Join(dir, "big.txt"), []byte(big), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := exec.Execute(callTool("read_file", `{"path":"big.txt"}`))
+	if out.ToolResultIsError {
+		t.Fatal("should succeed with truncation, not error")
+	}
+	if !strings.Contains(out.ToolResultContent, "[truncated by aidev") {
+		t.Errorf("missing truncation marker; got:\n%s", out.ToolResultContent)
+	}
+	if len(out.ToolResultContent) > 200 {
+		t.Errorf("truncated output too long: %d bytes", len(out.ToolResultContent))
+	}
+}
+
+func TestGlobToolFindsNestedTSX(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("glob", `{"pattern":"apps/marketing/**/*.tsx"}`))
+	if out.ToolResultIsError {
+		t.Fatalf("glob failed: %s", out.ToolResultContent)
+	}
+	for _, want := range []string{
+		"apps/marketing/src/components/pages/pricing/pricing.tsx",
+		"apps/marketing/src/components/pages/solutions/solutions.tsx",
+	} {
+		if !strings.Contains(out.ToolResultContent, want) {
+			t.Errorf("glob missing %s; got:\n%s", want, out.ToolResultContent)
+		}
+	}
+}
+
+func TestGlobToolFindsLocaleJSONs(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("glob", `{"pattern":"**/common.json"}`))
+	if out.ToolResultIsError {
+		t.Fatalf("glob failed: %s", out.ToolResultContent)
+	}
+	count := strings.Count(out.ToolResultContent, "common.json")
+	if count != 3 {
+		t.Errorf("want 3 locale hits, got %d:\n%s", count, out.ToolResultContent)
+	}
+}
+
+func TestGlobToolSkipsNodeModules(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("glob", `{"pattern":"**/*.js"}`))
+	if strings.Contains(out.ToolResultContent, "node_modules") {
+		t.Errorf("glob should skip node_modules; got:\n%s", out.ToolResultContent)
+	}
+}
+
+func TestGlobToolNoMatches(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("glob", `{"pattern":"**/*.xyz"}`))
+	if out.ToolResultIsError {
+		t.Error("no-matches should not be an error")
+	}
+	if !strings.Contains(out.ToolResultContent, "no matches") {
+		t.Errorf("expected 'no matches', got: %s", out.ToolResultContent)
+	}
+}
+
+func TestGlobToolRejectsTraversal(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("glob", `{"pattern":"../etc/**"}`))
+	if !out.ToolResultIsError {
+		t.Error("traversal pattern should be rejected")
+	}
+}
+
+func TestGrepToolFindsCallSite(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("grep", `{"pattern":"contactSales"}`))
+	if out.ToolResultIsError {
+		t.Fatalf("grep failed: %s", out.ToolResultContent)
+	}
+	// Should find it in both the TSX call site AND the JSON locale files.
+	if !strings.Contains(out.ToolResultContent, "pricing.tsx") {
+		t.Errorf("missing pricing.tsx hit; got:\n%s", out.ToolResultContent)
+	}
+	if !strings.Contains(out.ToolResultContent, "common.json") {
+		t.Errorf("missing common.json hit; got:\n%s", out.ToolResultContent)
+	}
+}
+
+func TestGrepToolScopedToSubdir(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("grep", `{"pattern":"contactSales","paths":["apps/marketing/src/lib"]}`))
+	if out.ToolResultIsError {
+		t.Fatalf("grep failed: %s", out.ToolResultContent)
+	}
+	// Only the locale JSONs are under apps/marketing/src/lib;
+	// the TSX is under apps/marketing/src/components.
+	if strings.Contains(out.ToolResultContent, "pricing.tsx") {
+		t.Errorf("scoped grep should not have matched pricing.tsx; got:\n%s", out.ToolResultContent)
+	}
+	if !strings.Contains(out.ToolResultContent, "common.json") {
+		t.Errorf("missing common.json hit; got:\n%s", out.ToolResultContent)
+	}
+}
+
+func TestGrepToolInvalidRegex(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("grep", `{"pattern":"[[unclosed"}`))
+	if !out.ToolResultIsError {
+		t.Error("invalid regex should be reported as tool error")
+	}
+}
+
+func TestGrepToolSkipsVendorDirs(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("grep", `{"pattern":"blocked"}`))
+	if strings.Contains(out.ToolResultContent, "node_modules") {
+		t.Errorf("grep should skip node_modules; got:\n%s", out.ToolResultContent)
+	}
+}
+
+func TestListDirToolRoot(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("list_dir", `{"path":"."}`))
+	if out.ToolResultIsError {
+		t.Fatalf("list_dir failed: %s", out.ToolResultContent)
+	}
+	if !strings.Contains(out.ToolResultContent, "d/apps") {
+		t.Errorf("missing d/apps; got:\n%s", out.ToolResultContent)
+	}
+	if !strings.Contains(out.ToolResultContent, "f/README.md") {
+		t.Errorf("missing f/README.md; got:\n%s", out.ToolResultContent)
+	}
+	if strings.Contains(out.ToolResultContent, "node_modules") {
+		t.Errorf("list_dir should skip node_modules; got:\n%s", out.ToolResultContent)
+	}
+}
+
+func TestListDirToolSubdir(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("list_dir", `{"path":"apps/marketing/src/lib/i18n/translations"}`))
+	if out.ToolResultIsError {
+		t.Fatalf("list_dir failed: %s", out.ToolResultContent)
+	}
+	for _, want := range []string{"d/en", "d/fr", "d/de"} {
+		if !strings.Contains(out.ToolResultContent, want) {
+			t.Errorf("missing %s; got:\n%s", want, out.ToolResultContent)
+		}
+	}
+}
+
+func TestListDirToolRejectsNonDir(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(callTool("list_dir", `{"path":"README.md"}`))
+	if !out.ToolResultIsError {
+		t.Error("list_dir on a file should be an error")
+	}
+}
+
+func TestUnknownToolIsRecoverableError(t *testing.T) {
+	_, exec := setupRepo(t)
+	out := exec.Execute(llm.ToolUse{ID: "x", Name: "eval", Input: json.RawMessage(`{}`)})
+	if !out.ToolResultIsError {
+		t.Error("unknown tool should be reported as tool error")
+	}
+	if !strings.Contains(out.ToolResultContent, "unknown tool") {
+		t.Errorf("error message should be clear; got: %s", out.ToolResultContent)
+	}
+}
+
+func TestDefinitionsIsStableAndWellFormed(t *testing.T) {
+	_, exec := setupRepo(t)
+	defs := exec.Definitions()
+	if len(defs) != 4 {
+		t.Fatalf("got %d tools, want 4", len(defs))
+	}
+	names := map[string]bool{}
+	for _, d := range defs {
+		if d.Name == "" {
+			t.Errorf("tool missing Name")
+		}
+		if d.Description == "" {
+			t.Errorf("tool %q missing Description", d.Name)
+		}
+		// InputSchema must be valid JSON with a top-level object.
+		var schema map[string]any
+		if err := json.Unmarshal(d.InputSchema, &schema); err != nil {
+			t.Errorf("tool %q: InputSchema not valid JSON: %v", d.Name, err)
+		}
+		if schema["type"] != "object" {
+			t.Errorf("tool %q: schema type should be object", d.Name)
+		}
+		names[d.Name] = true
+	}
+	for _, want := range []string{"read_file", "glob", "grep", "list_dir"} {
+		if !names[want] {
+			t.Errorf("missing tool definition: %s", want)
+		}
+	}
+}
+
+func TestGlobToRegexpDoublestar(t *testing.T) {
+	cases := []struct {
+		pattern string
+		match   []string
+		noMatch []string
+	}{
+		{
+			pattern: "apps/marketing/**/*.tsx",
+			match: []string{
+				"apps/marketing/src/foo.tsx",
+				"apps/marketing/src/components/pages/pricing/pricing.tsx",
+			},
+			noMatch: []string{
+				"apps/backend/foo.tsx",
+				"apps/marketing/src/foo.ts",
+			},
+		},
+		{
+			pattern: "**/common.json",
+			match: []string{
+				"common.json",
+				"apps/marketing/src/lib/i18n/translations/en/common.json",
+			},
+			noMatch: []string{
+				"other.json",
+			},
+		},
+		{
+			pattern: "packages/types/src/*.ts",
+			match: []string{
+				"packages/types/src/i18n.ts",
+			},
+			noMatch: []string{
+				"packages/types/src/nested/i18n.ts",
+				"packages/types/src/i18n.tsx",
+			},
+		},
+	}
+	for _, c := range cases {
+		re, err := globToRegexp(c.pattern)
+		if err != nil {
+			t.Fatalf("compile %q: %v", c.pattern, err)
+		}
+		for _, m := range c.match {
+			if !re.MatchString(m) {
+				t.Errorf("pattern %q should match %q", c.pattern, m)
+			}
+		}
+		for _, m := range c.noMatch {
+			if re.MatchString(m) {
+				t.Errorf("pattern %q should NOT match %q", c.pattern, m)
+			}
+		}
+	}
+}

--- a/internal/installpkg/files/models.yaml
+++ b/internal/installpkg/files/models.yaml
@@ -27,6 +27,25 @@ tiers:
     max_tokens: 2048
     temperature: 0.2
 
+  # The medium tier hosts the Implementer and Reviewer. v0.4 added
+  # native tool use (read_file, glob, grep, list_dir) for providers
+  # that implement llm.ToolAwareProvider. Currently only the
+  # `anthropic` provider supports tool use; `claude-cli` and
+  # `ollama` fall back to the legacy picker + NEED_FILES path,
+  # which still works but is less robust.
+  #
+  # To unlock v0.4 tool use for the Implementer specifically, set
+  # ANTHROPIC_API_KEY and swap this tier:
+  #
+  #   medium:
+  #     provider: anthropic
+  #     model: claude-sonnet-4-6       # or claude-opus-4-6
+  #     max_tokens: 8192
+  #     temperature: 0.2
+  #
+  # Tool use eliminates entire categories of failures that the
+  # legacy path hits on large monorepos (see aidev#37 for the
+  # motivating diagnosis).
   medium:
     provider: claude-cli
     model: ""

--- a/internal/llm/claude_tools.go
+++ b/internal/llm/claude_tools.go
@@ -1,0 +1,258 @@
+package llm
+
+// Anthropic Messages API tool-use support for the Claude provider.
+// This file implements ToolAwareProvider on top of the existing
+// REST client in claude.go.
+//
+// The wire format for Anthropic tool use:
+//
+//	Request body:
+//	  {
+//	    "model": "...",
+//	    "max_tokens": N,
+//	    "system": "...",
+//	    "tools": [ { "name": "read_file", "description": "...",
+//	                 "input_schema": {...JSON Schema...} } ],
+//	    "messages": [
+//	      { "role": "user", "content": [ { "type": "text", "text": "..." } ] },
+//	      { "role": "assistant", "content": [
+//	          { "type": "text", "text": "I'll read it." },
+//	          { "type": "tool_use", "id": "toolu_1",
+//	            "name": "read_file", "input": {"path": "foo.go"} }
+//	        ] },
+//	      { "role": "user", "content": [
+//	          { "type": "tool_result", "tool_use_id": "toolu_1",
+//	            "content": "<file body>", "is_error": false }
+//	        ] }
+//	    ]
+//	  }
+//
+//	Response body content blocks for assistant turns:
+//	  [ { "type": "text", "text": "..." },
+//	    { "type": "tool_use", "id": "toolu_xyz",
+//	      "name": "glob", "input": {"pattern": "**/*.go"} } ]
+//
+//	stop_reason: "end_turn" when done, "tool_use" when pending tool calls.
+//
+// The encoding is isomorphic to our internal ToolMessage /
+// ToolContentBlock representation so translation is purely mechanical.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// claudeToolsReq is the request body for a tool-aware Messages call.
+// We reuse the existing claudeReq's system/model/temperature fields
+// but need a richer messages shape because tool-use conversations
+// have content blocks, not plain strings. Marshaled directly to JSON
+// — the outer Messages field shadows claudeReq.Messages.
+type claudeToolsReq struct {
+	Model       string               `json:"model"`
+	MaxTokens   int                  `json:"max_tokens"`
+	Temperature float64              `json:"temperature"`
+	System      string               `json:"system,omitempty"`
+	Tools       []ToolDefinition     `json:"tools,omitempty"`
+	Messages    []claudeToolsMessage `json:"messages"`
+}
+
+// claudeToolsMessage is a single turn with an array of content
+// blocks. This is how Anthropic represents multi-block turns
+// (assistant text + tool_use, or user text + tool_result).
+type claudeToolsMessage struct {
+	Role    string              `json:"role"`
+	Content []claudeContentBlock `json:"content"`
+}
+
+// claudeContentBlock is the JSON shape of a single content block.
+// The field tags make `omitempty` do most of the discrimination
+// work — tool_use blocks get Name/Input populated, tool_result
+// blocks get ToolUseID/ResultContent, text blocks get Text.
+type claudeContentBlock struct {
+	Type string `json:"type"`
+
+	// text blocks
+	Text string `json:"text,omitempty"`
+
+	// tool_use blocks
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+
+	// tool_result blocks
+	ToolUseID     string `json:"tool_use_id,omitempty"`
+	ResultContent string `json:"content,omitempty"`
+	IsError       bool   `json:"is_error,omitempty"`
+}
+
+// claudeToolsResp is the response body for a tool-aware Messages
+// call. Only the fields we actually use are represented.
+type claudeToolsResp struct {
+	Content    []claudeContentBlock `json:"content"`
+	Model      string               `json:"model"`
+	StopReason string               `json:"stop_reason"`
+	Usage      struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
+	Error *struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// CompleteWithTools implements ToolAwareProvider for the Claude
+// backend. Translates the provider-neutral ToolAwareRequest into
+// Anthropic's wire format, POSTs it, and decodes the response back
+// into a ToolAwareResponse.
+//
+// The function is a straight-line translation — no state, no
+// retries. The caller's loop (in agents/toolloop.go) is responsible
+// for iterating turns until stop_reason is "end_turn".
+func (c *Claude) CompleteWithTools(ctx context.Context, r ToolAwareRequest) (ToolAwareResponse, error) {
+	if c.apiKey == "" {
+		return ToolAwareResponse{}, fmt.Errorf("claude: ANTHROPIC_API_KEY not set")
+	}
+
+	maxTok := r.MaxTokens
+	if maxTok == 0 {
+		maxTok = c.maxTokens
+	}
+	temp := r.Temperature
+	if temp == 0 {
+		temp = c.temperature
+	}
+
+	// Translate internal ToolMessages -> Anthropic content blocks.
+	msgs, err := toClaudeMessages(r.Messages)
+	if err != nil {
+		return ToolAwareResponse{}, fmt.Errorf("claude tools: marshal messages: %w", err)
+	}
+
+	body, err := json.Marshal(claudeToolsReq{
+		Model:       c.model,
+		MaxTokens:   maxTok,
+		Temperature: temp,
+		System:      r.System,
+		Tools:       r.Tools,
+		Messages:    msgs,
+	})
+	if err != nil {
+		return ToolAwareResponse{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return ToolAwareResponse{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return ToolAwareResponse{}, fmt.Errorf("claude tools: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var out claudeToolsResp
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return ToolAwareResponse{}, fmt.Errorf("claude tools decode: %w", err)
+	}
+	if out.Error != nil {
+		return ToolAwareResponse{}, fmt.Errorf("claude tools %s: %s", out.Error.Type, out.Error.Message)
+	}
+
+	return fromClaudeResponse(&out), nil
+}
+
+// toClaudeMessages translates aidev's internal ToolMessage slice
+// into the Anthropic wire shape. Unknown block types are rejected
+// with an error — better to fail loudly than to drop content the
+// caller expected us to send.
+func toClaudeMessages(in []ToolMessage) ([]claudeToolsMessage, error) {
+	out := make([]claudeToolsMessage, 0, len(in))
+	for _, m := range in {
+		blocks := make([]claudeContentBlock, 0, len(m.Content))
+		for _, b := range m.Content {
+			switch b.Type {
+			case "text":
+				blocks = append(blocks, claudeContentBlock{
+					Type: "text",
+					Text: b.Text,
+				})
+			case "tool_use":
+				blocks = append(blocks, claudeContentBlock{
+					Type:  "tool_use",
+					ID:    b.ToolUseID,
+					Name:  b.ToolName,
+					Input: b.ToolInput,
+				})
+			case "tool_result":
+				blocks = append(blocks, claudeContentBlock{
+					Type:          "tool_result",
+					ToolUseID:     b.ToolUseID,
+					ResultContent: b.ToolResultContent,
+					IsError:       b.ToolResultIsError,
+				})
+			default:
+				return nil, fmt.Errorf("unknown content block type %q", b.Type)
+			}
+		}
+		out = append(out, claudeToolsMessage{
+			Role:    m.Role,
+			Content: blocks,
+		})
+	}
+	return out, nil
+}
+
+// fromClaudeResponse translates an Anthropic response into aidev's
+// ToolAwareResponse. Builds the AssistantMessage as a ToolMessage
+// that the caller can append to its own history for the next turn.
+func fromClaudeResponse(resp *claudeToolsResp) ToolAwareResponse {
+	var (
+		textBuf  bytes.Buffer
+		toolUses []ToolUse
+		blocks   []ToolContentBlock
+	)
+	for _, b := range resp.Content {
+		switch b.Type {
+		case "text":
+			textBuf.WriteString(b.Text)
+			blocks = append(blocks, ToolContentBlock{
+				Type: "text",
+				Text: b.Text,
+			})
+		case "tool_use":
+			toolUses = append(toolUses, ToolUse{
+				ID:    b.ID,
+				Name:  b.Name,
+				Input: b.Input,
+			})
+			blocks = append(blocks, ToolContentBlock{
+				Type:      "tool_use",
+				ToolUseID: b.ID,
+				ToolName:  b.Name,
+				ToolInput: b.Input,
+			})
+		}
+	}
+	return ToolAwareResponse{
+		Content:    textBuf.String(),
+		ToolUses:   toolUses,
+		StopReason: resp.StopReason,
+		Model:      resp.Model,
+		Usage: Usage{
+			InputTokens:  resp.Usage.InputTokens,
+			OutputTokens: resp.Usage.OutputTokens,
+		},
+		AssistantMessage: ToolMessage{
+			Role:    "assistant",
+			Content: blocks,
+		},
+	}
+}

--- a/internal/llm/claude_tools_test.go
+++ b/internal/llm/claude_tools_test.go
@@ -1,0 +1,300 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestToClaudeMessagesRoundTrip verifies every supported content
+// block type survives translation to the Anthropic wire shape with
+// the right field names. Regression guard against a refactor that
+// accidentally drops one of tool_use, tool_result, or text.
+func TestToClaudeMessagesRoundTrip(t *testing.T) {
+	in := []ToolMessage{
+		{
+			Role: "user",
+			Content: []ToolContentBlock{
+				{Type: "text", Text: "Find call sites"},
+			},
+		},
+		{
+			Role: "assistant",
+			Content: []ToolContentBlock{
+				{Type: "text", Text: "I'll grep for them."},
+				{
+					Type:      "tool_use",
+					ToolUseID: "toolu_abc123",
+					ToolName:  "grep",
+					ToolInput: json.RawMessage(`{"pattern":"contactSales","paths":["apps/marketing/src"]}`),
+				},
+			},
+		},
+		{
+			Role: "user",
+			Content: []ToolContentBlock{
+				{
+					Type:              "tool_result",
+					ToolUseID:         "toolu_abc123",
+					ToolResultContent: "pricing.tsx:56: t(\"contactSales\")",
+					ToolResultIsError: false,
+				},
+			},
+		},
+	}
+
+	out, err := toClaudeMessages(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("got %d messages, want 3", len(out))
+	}
+
+	// Marshal to JSON and spot-check the wire shape matches what
+	// Anthropic's API expects. This is the real contract — if the
+	// field names drift, the API rejects the request.
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	for _, want := range []string{
+		`"type":"text"`,
+		`"text":"Find call sites"`,
+		`"type":"tool_use"`,
+		`"id":"toolu_abc123"`,
+		`"name":"grep"`,
+		`"input":{"pattern":"contactSales"`,
+		`"type":"tool_result"`,
+		`"tool_use_id":"toolu_abc123"`,
+		`"content":"pricing.tsx:56: t(\"contactSales\")"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("marshaled wire shape missing %q\nfull output:\n%s", want, s)
+		}
+	}
+}
+
+func TestToClaudeMessagesRejectsUnknownBlockType(t *testing.T) {
+	_, err := toClaudeMessages([]ToolMessage{
+		{
+			Role: "user",
+			Content: []ToolContentBlock{
+				{Type: "image", Text: "???"},
+			},
+		},
+	})
+	if err == nil {
+		t.Error("expected error for unknown block type")
+	}
+}
+
+// TestFromClaudeResponseExtractsToolUses covers the response-side
+// translation: an Anthropic tool_use response must yield a
+// ToolAwareResponse with StopReason="tool_use", the correct
+// ToolUses list, and an AssistantMessage the caller can round-trip.
+func TestFromClaudeResponseExtractsToolUses(t *testing.T) {
+	resp := &claudeToolsResp{
+		StopReason: "tool_use",
+		Model:      "claude-sonnet-4-5",
+		Content: []claudeContentBlock{
+			{Type: "text", Text: "Let me check the locale files."},
+			{
+				Type:  "tool_use",
+				ID:    "toolu_01",
+				Name:  "glob",
+				Input: json.RawMessage(`{"pattern":"apps/marketing/src/lib/i18n/translations/*/common.json"}`),
+			},
+			{
+				Type:  "tool_use",
+				ID:    "toolu_02",
+				Name:  "read_file",
+				Input: json.RawMessage(`{"path":"apps/marketing/src/components/pages/pricing/pricing.tsx"}`),
+			},
+		},
+	}
+	resp.Usage.InputTokens = 1234
+	resp.Usage.OutputTokens = 56
+
+	got := fromClaudeResponse(resp)
+
+	if got.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use", got.StopReason)
+	}
+	if got.Content != "Let me check the locale files." {
+		t.Errorf("Content = %q", got.Content)
+	}
+	if len(got.ToolUses) != 2 {
+		t.Fatalf("got %d tool uses, want 2", len(got.ToolUses))
+	}
+	if got.ToolUses[0].Name != "glob" || got.ToolUses[0].ID != "toolu_01" {
+		t.Errorf("tool[0] = %+v", got.ToolUses[0])
+	}
+	if got.ToolUses[1].Name != "read_file" || got.ToolUses[1].ID != "toolu_02" {
+		t.Errorf("tool[1] = %+v", got.ToolUses[1])
+	}
+	// Usage flows through.
+	if got.Usage.InputTokens != 1234 || got.Usage.OutputTokens != 56 {
+		t.Errorf("usage = %+v", got.Usage)
+	}
+	// AssistantMessage should contain every block from the response
+	// so the caller can append it to its history on the next turn.
+	if got.AssistantMessage.Role != "assistant" {
+		t.Errorf("AssistantMessage role = %q", got.AssistantMessage.Role)
+	}
+	if len(got.AssistantMessage.Content) != 3 {
+		t.Errorf("AssistantMessage content = %d blocks, want 3", len(got.AssistantMessage.Content))
+	}
+}
+
+func TestFromClaudeResponseEndTurn(t *testing.T) {
+	resp := &claudeToolsResp{
+		StopReason: "end_turn",
+		Content: []claudeContentBlock{
+			{Type: "text", Text: "diff --git a/foo b/foo\n..."},
+		},
+	}
+	got := fromClaudeResponse(resp)
+	if got.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q", got.StopReason)
+	}
+	if !strings.HasPrefix(got.Content, "diff --git") {
+		t.Errorf("Content = %q", got.Content)
+	}
+	if len(got.ToolUses) != 0 {
+		t.Errorf("end_turn response should have no pending tool uses, got %d", len(got.ToolUses))
+	}
+}
+
+// TestClaudeCompleteWithToolsWiresAgainstFakeServer spins up an
+// httptest server that mimics the Anthropic Messages API tool-use
+// response shape, points a Claude provider at it, and verifies the
+// round-trip end-to-end. This is the closest unit test we can get
+// to "did we break the actual wire format" without hitting the real
+// API — any field rename or JSON structure change will fail here.
+func TestClaudeCompleteWithToolsWiresAgainstFakeServer(t *testing.T) {
+	var gotBody map[string]any
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"content": [
+				{"type": "text", "text": "I need to see the file."},
+				{"type": "tool_use", "id": "toolu_01", "name": "read_file", "input": {"path": "foo.go"}}
+			],
+			"model": "claude-sonnet-4-5",
+			"stop_reason": "tool_use",
+			"usage": {"input_tokens": 10, "output_tokens": 20}
+		}`))
+	}))
+	defer fake.Close()
+
+	c := &Claude{
+		apiKey:      "test-key",
+		model:       "claude-sonnet-4-5",
+		maxTokens:   1024,
+		temperature: 0.2,
+		endpoint:    fake.URL,
+		http:        fake.Client(),
+	}
+
+	req := ToolAwareRequest{
+		System: "You are a test.",
+		Tools: []ToolDefinition{
+			{
+				Name:        "read_file",
+				Description: "Read a file",
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`),
+			},
+		},
+		Messages: []ToolMessage{
+			{
+				Role: "user",
+				Content: []ToolContentBlock{
+					{Type: "text", Text: "Fix the bug in foo.go"},
+				},
+			},
+		},
+		MaxTokens: 0, // fall through to tier default
+	}
+
+	resp, err := c.CompleteWithTools(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StopReason != "tool_use" {
+		t.Errorf("stop reason = %q", resp.StopReason)
+	}
+	if len(resp.ToolUses) != 1 || resp.ToolUses[0].Name != "read_file" {
+		t.Errorf("tool uses = %+v", resp.ToolUses)
+	}
+
+	// Verify the request body the fake server received has the
+	// right wire shape: tools array, messages array with typed
+	// content blocks.
+	if _, ok := gotBody["tools"]; !ok {
+		t.Error("request missing tools array")
+	}
+	msgs, ok := gotBody["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("request messages = %v", gotBody["messages"])
+	}
+	first, ok := msgs[0].(map[string]any)
+	if !ok {
+		t.Fatalf("message 0 = %v", msgs[0])
+	}
+	content, ok := first["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("content = %v", first["content"])
+	}
+	block, ok := content[0].(map[string]any)
+	if !ok || block["type"] != "text" || block["text"] != "Fix the bug in foo.go" {
+		t.Errorf("content block = %v", content[0])
+	}
+}
+
+// TestClaudeCompleteWithToolsErrorResponse verifies the error path:
+// when the API returns an error envelope, we propagate it as a Go
+// error instead of a malformed response.
+func TestClaudeCompleteWithToolsErrorResponse(t *testing.T) {
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"error": {"type": "invalid_request_error", "message": "tools malformed"}}`))
+	}))
+	defer fake.Close()
+
+	c := &Claude{
+		apiKey:      "test-key",
+		model:       "claude-sonnet-4-5",
+		maxTokens:   1024,
+		temperature: 0.2,
+		endpoint:    fake.URL,
+		http:        fake.Client(),
+	}
+	_, err := c.CompleteWithTools(context.Background(), ToolAwareRequest{
+		Messages: []ToolMessage{{
+			Role:    "user",
+			Content: []ToolContentBlock{{Type: "text", Text: "hi"}},
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "tools malformed") {
+		t.Errorf("error message = %v", err)
+	}
+}
+
+// TestClaudeImplementsToolAwareProvider is a compile-time check that
+// the interface implementation is still valid. If someone removes or
+// renames CompleteWithTools on Claude, this test fails at compile time.
+func TestClaudeImplementsToolAwareProvider(t *testing.T) {
+	var _ ToolAwareProvider = (*Claude)(nil)
+}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -13,7 +13,10 @@
 // reaches for Claude, and to swap either side without touching agent code.
 package llm
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+)
 
 // Role is a typed string used by agents when requesting a provider from the
 // Router. Using constants keeps typo-bugs out of the hot path.
@@ -118,4 +121,152 @@ type StreamChunk struct {
 	// Consumers should check this before drawing conclusions from the
 	// accumulated Text.
 	Err error
+}
+
+// ---------------------------------------------------------------------------
+// Tool use (v0.4)
+// ---------------------------------------------------------------------------
+//
+// The NEED_FILES loop in the Implementer was a poor-man's simulation of
+// tool use built on top of the single-shot Complete() method: the model
+// emitted a fake "NEED_FILES: [...]" string, the harness parsed it,
+// loaded files, and re-called. Every brittleness we patched in PRs
+// #31/#33/#34/#35/#36 was a leaky abstraction in that simulation.
+//
+// ToolAwareProvider is the real thing. Backends that implement it
+// expose a native tool-use loop where the model calls `read_file`,
+// `glob`, `grep`, etc. as real tools within a single open LLM session.
+// The Implementer stops round-tripping file content through string
+// protocols.
+//
+// Adoption is opt-in per backend via a Go interface type assertion:
+//
+//	if toolAware, ok := provider.(llm.ToolAwareProvider); ok {
+//		// use native tool loop
+//	} else {
+//		// fall back to NEED_FILES-style Complete path
+//	}
+//
+// Providers that don't implement ToolAwareProvider keep working via
+// the legacy path. v0.4 ships with Anthropic REST as the first and
+// only ToolAwareProvider; Ollama and claude-cli land in later
+// releases.
+
+// ToolDefinition describes a single tool available to the model.
+// InputSchema is a JSON Schema object describing the tool's
+// parameters — aidev hand-writes these for the handful of tools it
+// exposes rather than generating from Go types, because the schemas
+// are small and the clarity benefit is worth the duplication.
+type ToolDefinition struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// ToolContentBlock is one element of a ToolMessage's Content. It
+// represents a single typed block — text the user/assistant wrote,
+// a tool_use call the assistant made, or a tool_result the user
+// (harness) produced in response to a tool_use.
+//
+// The shape is a flattened union: Type discriminates, and only the
+// fields relevant to that type are populated. This maps 1:1 to the
+// Anthropic Messages API content-block shape and is how we preserve
+// enough state for multi-turn tool conversations without rebuilding
+// the whole API on top of a simpler type.
+type ToolContentBlock struct {
+	// Type is "text", "tool_use", or "tool_result".
+	Type string
+
+	// Text is populated when Type == "text".
+	Text string
+
+	// ToolUseID identifies a tool_use block (when Type == "tool_use")
+	// or the tool_use it responds to (when Type == "tool_result").
+	// Set by the provider on tool_use blocks; set by the harness on
+	// tool_result blocks so the provider can correlate.
+	ToolUseID string
+
+	// ToolName is the tool being invoked (when Type == "tool_use").
+	ToolName string
+
+	// ToolInput is the JSON object argument to the tool (when Type ==
+	// "tool_use"). Opaque to the provider layer — the agent validates
+	// and executes it.
+	ToolInput json.RawMessage
+
+	// ToolResultContent is the text returned from executing a tool
+	// (when Type == "tool_result"). Provider serializes this as the
+	// `content` field of the tool_result block.
+	ToolResultContent string
+
+	// ToolResultIsError indicates the tool reported a recoverable
+	// failure (file not found, grep had no matches, etc.). The model
+	// sees this flag and decides whether to retry, try a different
+	// tool, or give up. Harness-level errors (auth, transport) are
+	// propagated to the caller as Go errors and never become
+	// ToolResult blocks.
+	ToolResultIsError bool
+}
+
+// ToolMessage is one turn in a tool-aware conversation. Unlike the
+// simple Message type, Content is a slice of typed blocks because a
+// single assistant turn can interleave text and tool_use blocks and a
+// single user turn can contain multiple tool_result blocks (one per
+// pending tool_use from the prior assistant turn).
+type ToolMessage struct {
+	Role    string // "user" | "assistant"
+	Content []ToolContentBlock
+}
+
+// ToolAwareRequest is the full multi-turn tool-use conversation as
+// the caller sees it. Messages is the growing history — on the first
+// turn it contains just the initial user message; each subsequent
+// turn appends the assistant's response AND a user message with the
+// computed tool_result blocks.
+type ToolAwareRequest struct {
+	System      string
+	Tools       []ToolDefinition
+	Messages    []ToolMessage
+	MaxTokens   int
+	Temperature float64
+}
+
+// ToolUse is a single pending tool call extracted from a
+// ToolAwareResponse. It's a convenience view: the same information
+// also lives in the response's raw message blocks (accessible via
+// AssistantMessage), but ToolUses is what an iterating harness
+// actually wants to range over.
+type ToolUse struct {
+	ID    string
+	Name  string
+	Input json.RawMessage
+}
+
+// ToolAwareResponse is the return value from CompleteWithTools. On a
+// normal turn Content holds the model's text and StopReason is
+// "end_turn"; on a tool-use turn Content may be empty and ToolUses
+// holds the pending tool calls the harness must execute and feed
+// back in the next request.
+//
+// AssistantMessage is the full assistant turn represented as a
+// ToolMessage — the caller appends this verbatim to its own
+// ToolAwareRequest.Messages list before adding the user tool_result
+// message for the next iteration. This is the key invariant that
+// lets the caller manage state in one place (the Messages slice)
+// while the provider stays stateless.
+type ToolAwareResponse struct {
+	Content          string
+	ToolUses         []ToolUse
+	StopReason       string // "end_turn" | "tool_use" | "max_tokens" | ...
+	Model            string
+	Usage            Usage
+	AssistantMessage ToolMessage
+}
+
+// ToolAwareProvider is the optional capability interface for backends
+// that support native tool use. Detect support via a type assertion
+// the same way you would for Streamer.
+type ToolAwareProvider interface {
+	Provider
+	CompleteWithTools(ctx context.Context, req ToolAwareRequest) (ToolAwareResponse, error)
 }


### PR DESCRIPTION
## Summary

Resolves #37. This is the architectural fix the last six brittleness PRs (#31, #33, #34, #35, #36) were approximating. Every failure mode since v0.3a was a leaky abstraction in a simulated tool-use loop built on top of the single-shot `Complete()` interface. v0.4 ships real tool use so those classes of failure stop existing.

## Stages

### Stage 1 — `ToolAwareProvider` interface
New optional capability interface in `internal/llm/provider.go`:

```go
type ToolAwareProvider interface {
    Provider
    CompleteWithTools(ctx, ToolAwareRequest) (ToolAwareResponse, error)
}
```

Plus supporting types (`ToolDefinition`, `ToolContentBlock`, `ToolMessage`, `ToolUse`, `ToolAwareResponse`). Providers that don't implement it keep working via `Complete` — adoption is opt-in via a Go interface type assertion, same pattern as `Streamer`.

### Stage 2 — Anthropic REST provider implements `ToolAwareProvider`
`internal/llm/claude_tools.go` adds `CompleteWithTools` to the existing Claude struct. Zero external dependencies; mirrors Anthropic's content-block wire format directly.

### Stage 3 — Tool executors
`internal/agents/tools.go` ships four read-only tools:

- `read_file(path)` — file contents, 128 KiB size-capped, path traversal rejected
- `glob(pattern)` — custom doublestar walker (`**` = any depth, `*` = one segment), vendor dirs skipped
- `grep(pattern, paths?)` — RE2 regex search scoped to source extensions, optional path-prefix filter
- `list_dir(path)` — sorted directory listing with d/f prefixes

All dispatched through `ToolExecutor.Execute` which produces a `tool_result` block ready to append to the next turn. Recoverable failures (file not found, bad regex) become `IsError=true` tool_results; catastrophic failures propagate as Go errors.

### Stage 4 — Implementer `runWithTools`
`Implementer.Run()` now type-asserts its Provider:

```go
if toolAware, ok := i.Provider.(llm.ToolAwareProvider); ok {
    return i.runWithTools(ctx, toolAware, c, chosen)
}
// fall back to legacy picker + NEED_FILES + harvest path
```

`runWithTools` is a single agentic loop capped at `maxToolIterations = 25`:

1. Build initial user message (issue + scout brief + critic report + sketch + principles + clarifier + coordinator feedback). **No file inventory, no embedded file contents** — the model fetches what it needs via tools.
2. Call `provider.CompleteWithTools`.
3. `stop_reason == "end_turn"`: validate final text as unified diff, return Patch.
4. `stop_reason == "tool_use"`: execute every `ToolUse`, append assistant message AND a user message with `tool_result` blocks to history, loop.
5. Bounded iteration count to prevent runaway cost.

## What this eliminates (in one stroke vs. legacy path)

- **#31** (no-op punts) — model doesn't need to punt, it reads what it needs
- **#34** (prose prefix violations) — no `NEED_FILES:` grammar to violate
- **#35** (hallucinated paths silently dropped) — tool calls return structured errors immediately
- **#36** (false-absence ERRORs) — model can `glob` and see everything

**Still runs at Gate 1**: #33 Coordinator fabrication review is orthogonal and still fires between Implementer output and WriteTo. Gate-1 safety net preserved.

## Backwards compatibility

Zero deletions from the legacy path. `TestImplementerRunLegacyPathStillFiresForNonToolProviders` is the critical backwards-compat guard: a Provider that does NOT implement `ToolAwareProvider` must still go through the legacy picker + NEED_FILES path, and it does. Users on `--preset local` (Ollama), `provider: claude-cli`, or any other non-tool-aware backend keep working.

## Config

`config/models.yaml` gains a multi-paragraph comment on the `medium` tier explaining how to unlock v0.4 tool use: swap `provider: claude-cli` → `provider: anthropic` with `ANTHROPIC_API_KEY` set. The default stays on `claude-cli` to avoid breaking existing setups — tool use is opt-in via one config edit.

## Tests — 33 new cases covering:

**LLM package** (`internal/llm/claude_tools_test.go`, 7 cases):
- Wire format round-trip for every content block type
- Unknown block type rejection
- Multi-tool-call response parsing + AssistantMessage round-trip
- End-turn terminal responses
- Full request/response against an httptest fake server
- Error envelope propagation
- Compile-time `ToolAwareProvider` interface check

**Tool executors** (`internal/agents/tools_test.go`, 20 cases):
- Per-tool happy path + error path + security boundary for all four tools
- `read_file` truncation, traversal rejection, absolute path rejection
- `glob` doublestar patterns, vendor-dir skipping, no-match handling
- `grep` scoped searches, invalid regex, vendor-dir skipping
- `list_dir` root + subdir + non-dir rejection
- Unknown tool handled as recoverable error
- Tool definitions have valid JSON Schema
- `globToRegexp` correctness across `apps/marketing/**/*.tsx`, `**/common.json`, etc.

**Implementer integration** (`internal/agents/implementer_tools_test.go`, 6 cases):
- `TestImplementerRunUsesToolPathWhenAvailable` — happy path
- `TestImplementerRunToolPathMultipleIterations` — 4-turn conversation (glob → 2x read_file → grep → diff)
- `TestImplementerRunToolPathHitsIterationCap` — runaway loop guard
- `TestImplementerRunToolPathSurfacesERROR` — escape hatch preserved
- `TestImplementerRunToolPathTolerantToProsePreamble` — forgiving final-turn validation
- `TestImplementerRunLegacyPathStillFiresForNonToolProviders` — backwards compat guard

## Scope

~2300 net LOC added, zero deletions. Strictly additive for providers that don't implement `ToolAwareProvider`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all 33 new tests + existing suite pass
- [ ] Set `provider: anthropic` on the medium tier, `ANTHROPIC_API_KEY` in env, re-run `/aidev-run 533`. Expect: Implementer dispatches to `runWithTools`, makes ~5-15 tool calls to explore the marketing tree, produces a real unified diff against the TSX call sites and locale JSONs. No NEED_FILES errors. No false-absence ERRORs. No format violations. No hallucinated paths.

## Next PRs (not in scope)

- Ollama tool use for compatible models (qwen2.5, llama3.1+)
- Coordinator and Reviewer also get tool-use paths so they can verify diff claims
- Sketch-numbering non-determinism (#38)