### PR TITLE
feat(v0.4a): Ollama tool use — local Implementer stops using NEED_FILES

### DIFF
--- a/config/models.local.yaml
+++ b/config/models.local.yaml
@@ -12,6 +12,32 @@
 #
 # ---
 #
+# v0.4a: native tool use for local Implementer
+#
+# As of v0.4a (aidev#40) the Ollama provider implements the
+# ToolAwareProvider interface, so the Implementer running on this
+# preset now uses real tool calls (read_file, glob, grep, list_dir)
+# instead of the legacy picker + NEED_FILES string protocol. The
+# same loop that backs `provider: anthropic` now backs the local
+# qwen2.5-coder Implementer — no more hallucinated paths, no more
+# stale inventory snapshots, no more missing-file silent drops.
+#
+# Tool use requires a tool-capable Ollama model. Compatible
+# families as of this writing:
+#
+#   qwen2.5 / qwen2.5-coder   (7B, 14B, 32B)     ← this preset
+#   llama3.1 / llama3.2       (8B, 70B)
+#   mistral-nemo              (12B)
+#   command-r-plus            (104B)
+#   firefunction-v2           (70B)
+#
+# If you swap the medium tier below to an older model that doesn't
+# support tool use (e.g. code-llama, starcoder, or an Ollama build
+# older than 0.3.0), the daemon will reject the request with a
+# clear error pointing you at a compatible model.
+#
+# ---
+#
 # Hardware expectations (approximate, Q4 quantisation):
 #
 #   small tier  (qwen2.5-coder:7b):   ~5 GB VRAM (or CPU with patience)
@@ -44,22 +70,27 @@
 #
 #   - Scout brief: indistinguishable — the Scout's task is factual
 #     extraction, which local 7B models handle well.
-#   - Implementer diffs: 80-90% of cloud quality for focused,
-#     single-feature changes. The NEED_FILES loop helps by letting
-#     the model iteratively discover context instead of trying to
-#     hold a whole repo in one window.
+#   - Implementer diffs: significantly improved in v0.4a because the
+#     Implementer now has native tool use (read_file, glob, grep,
+#     list_dir) on local models. Gaps vs. cloud are mostly about
+#     code quality and reasoning depth on large refactors, not
+#     about basic correctness any more. Expect 85-95% of cloud
+#     quality for focused, single-feature changes.
 #   - Critic sharp questions: 60-75% of cloud quality. Local
 #     generalist models produce less adversarial analysis than
 #     Claude Opus; expect a gentler Critic.
 #   - Architect sketches: 70-85% of cloud quality. Sketches are
 #     usually sensible but less creative about splitting work.
 #
-# The Coordinator agent (future PR) acts as a cloud-backed safety
-# net for this preset: it reviews Implementer output and catches
-# the common local-model failure modes (fabrication, invalid
-# syntax, half-finished work) before the patch hits disk. If
-# you're running this preset AND have Claude CLI available for the
-# Coordinator role alone, that's the recommended shape.
+# The Coordinator agent (shipped in aidev#33) runs as Gate 1 after
+# the Implementer and catches the common local-model failure modes
+# (fabrication, invalid syntax, half-finished work) before the
+# patch hits disk. This preset routes the Coordinator to the
+# local large tier (qwen2.5:32b). If you have Claude CLI available
+# and want the "local horse, cloud jockey" shape — local
+# Implementer with a cloud-backed Coordinator — drop a
+# models.local-mixed.yaml in your config directory with the
+# coordinator tier set to provider: claude-cli (or anthropic).
 
 tiers:
   small:

--- a/internal/installpkg/files/models.local.yaml
+++ b/internal/installpkg/files/models.local.yaml
@@ -12,6 +12,32 @@
 #
 # ---
 #
+# v0.4a: native tool use for local Implementer
+#
+# As of v0.4a (aidev#40) the Ollama provider implements the
+# ToolAwareProvider interface, so the Implementer running on this
+# preset now uses real tool calls (read_file, glob, grep, list_dir)
+# instead of the legacy picker + NEED_FILES string protocol. The
+# same loop that backs `provider: anthropic` now backs the local
+# qwen2.5-coder Implementer — no more hallucinated paths, no more
+# stale inventory snapshots, no more missing-file silent drops.
+#
+# Tool use requires a tool-capable Ollama model. Compatible
+# families as of this writing:
+#
+#   qwen2.5 / qwen2.5-coder   (7B, 14B, 32B)     ← this preset
+#   llama3.1 / llama3.2       (8B, 70B)
+#   mistral-nemo              (12B)
+#   command-r-plus            (104B)
+#   firefunction-v2           (70B)
+#
+# If you swap the medium tier below to an older model that doesn't
+# support tool use (e.g. code-llama, starcoder, or an Ollama build
+# older than 0.3.0), the daemon will reject the request with a
+# clear error pointing you at a compatible model.
+#
+# ---
+#
 # Hardware expectations (approximate, Q4 quantisation):
 #
 #   small tier  (qwen2.5-coder:7b):   ~5 GB VRAM (or CPU with patience)
@@ -44,22 +70,27 @@
 #
 #   - Scout brief: indistinguishable — the Scout's task is factual
 #     extraction, which local 7B models handle well.
-#   - Implementer diffs: 80-90% of cloud quality for focused,
-#     single-feature changes. The NEED_FILES loop helps by letting
-#     the model iteratively discover context instead of trying to
-#     hold a whole repo in one window.
+#   - Implementer diffs: significantly improved in v0.4a because the
+#     Implementer now has native tool use (read_file, glob, grep,
+#     list_dir) on local models. Gaps vs. cloud are mostly about
+#     code quality and reasoning depth on large refactors, not
+#     about basic correctness any more. Expect 85-95% of cloud
+#     quality for focused, single-feature changes.
 #   - Critic sharp questions: 60-75% of cloud quality. Local
 #     generalist models produce less adversarial analysis than
 #     Claude Opus; expect a gentler Critic.
 #   - Architect sketches: 70-85% of cloud quality. Sketches are
 #     usually sensible but less creative about splitting work.
 #
-# The Coordinator agent (future PR) acts as a cloud-backed safety
-# net for this preset: it reviews Implementer output and catches
-# the common local-model failure modes (fabrication, invalid
-# syntax, half-finished work) before the patch hits disk. If
-# you're running this preset AND have Claude CLI available for the
-# Coordinator role alone, that's the recommended shape.
+# The Coordinator agent (shipped in aidev#33) runs as Gate 1 after
+# the Implementer and catches the common local-model failure modes
+# (fabrication, invalid syntax, half-finished work) before the
+# patch hits disk. This preset routes the Coordinator to the
+# local large tier (qwen2.5:32b). If you have Claude CLI available
+# and want the "local horse, cloud jockey" shape — local
+# Implementer with a cloud-backed Coordinator — drop a
+# models.local-mixed.yaml in your config directory with the
+# coordinator tier set to provider: claude-cli (or anthropic).
 
 tiers:
   small:

--- a/internal/llm/ollama_tools.go
+++ b/internal/llm/ollama_tools.go
@@ -1,0 +1,353 @@
+package llm
+
+// Ollama tool-use support (v0.4a) — ToolAwareProvider implementation
+// for the local Ollama daemon.
+//
+// Ollama's tool-use wire format is OpenAI-style function calling,
+// which is meaningfully different from Anthropic's content-block
+// model that aidev's internal ToolContentBlock / ToolMessage types
+// are shaped around:
+//
+//   Anthropic: assistant message with a content ARRAY of typed
+//              blocks (text, tool_use); tool_result blocks live
+//              inside a user message and correlate to a prior
+//              tool_use by ID.
+//
+//   Ollama:    assistant message with a plain string content AND
+//              a separate tool_calls field; tool results are
+//              separate top-level messages with role="tool" and no
+//              correlation ID (matched by position to the prior
+//              assistant's tool_calls).
+//
+// The translation layer below converts between the two. Ollama
+// tool_calls don't carry IDs, so we synthesize deterministic
+// "ollama_<index>" IDs when parsing responses so the caller can
+// keep using the same internal correlation model the Anthropic
+// path uses. On the way back out, those synthetic IDs are dropped
+// because Ollama's wire format doesn't need them.
+//
+// Supported models (as of v0.4a): qwen2.5, qwen2.5-coder, llama3.1,
+// llama3.2, mistral-nemo, command-r-plus, firefunction-v2. Older or
+// non-tool-capable models return an error from the Ollama daemon
+// on a tools-containing request, which we propagate as a Go error.
+// Callers routing the Implementer to a non-tool-capable local model
+// should either swap the model OR keep provider:ollama and fall
+// back to the legacy NEED_FILES path (which Implementer.Run does
+// automatically when CompleteWithTools is not implemented — this
+// PR changes that by *adding* CompleteWithTools to Ollama, so the
+// fallback is no longer automatic. See the model compatibility
+// doc in config/models.local.yaml).
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// ollamaToolReq is the chat request shape for tool-aware calls.
+// Same /api/chat endpoint, but with a `tools` field and messages
+// that can carry tool_calls (assistant) or be role="tool" (results).
+type ollamaToolReq struct {
+	Model    string              `json:"model"`
+	Stream   bool                `json:"stream"`
+	Options  ollamaOptions       `json:"options,omitempty"`
+	Messages []ollamaToolMessage `json:"messages"`
+	Tools    []ollamaTool        `json:"tools,omitempty"`
+}
+
+// ollamaToolMessage matches Ollama's chat message schema for
+// tool-aware conversations. Fields are omitempty so each message
+// type serializes cleanly:
+//
+//	system: {role, content}
+//	user:   {role, content}
+//	assistant with text only: {role, content}
+//	assistant with tool calls: {role, content?, tool_calls}
+//	tool result: {role: "tool", content}
+type ollamaToolMessage struct {
+	Role      string           `json:"role"`
+	Content   string           `json:"content,omitempty"`
+	ToolCalls []ollamaToolCall `json:"tool_calls,omitempty"`
+}
+
+// ollamaToolCall is Ollama's function-call shape. No ID field —
+// correlation is positional.
+type ollamaToolCall struct {
+	Function ollamaToolCallFunction `json:"function"`
+}
+
+type ollamaToolCallFunction struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// ollamaTool is the OpenAI-style tool schema Ollama expects.
+type ollamaTool struct {
+	Type     string             `json:"type"` // always "function"
+	Function ollamaToolFunction `json:"function"`
+}
+
+type ollamaToolFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+// ollamaToolResp is the response shape for a tool-aware chat call.
+type ollamaToolResp struct {
+	Model   string `json:"model"`
+	Message struct {
+		Role      string           `json:"role"`
+		Content   string           `json:"content"`
+		ToolCalls []ollamaToolCall `json:"tool_calls,omitempty"`
+	} `json:"message"`
+	DoneReason      string `json:"done_reason"`
+	PromptEvalCount int    `json:"prompt_eval_count"`
+	EvalCount       int    `json:"eval_count"`
+
+	Error string `json:"error,omitempty"`
+}
+
+// CompleteWithTools implements ToolAwareProvider for the Ollama
+// backend. The Implementer's agentic loop (agents/implementer_tools.go)
+// dispatches here when the router hands it an *Ollama for the
+// implementer role.
+//
+// Known failure modes + how we handle them:
+//
+//   * Model doesn't support tool use. Ollama's daemon returns a
+//     400-ish error with a descriptive message. We propagate the
+//     error with a hint to switch models or tiers.
+//
+//   * Model emits malformed tool_calls. We let the JSON decoder
+//     fail and return a clear error — the caller's retry loop in
+//     the Implementer can decide what to do.
+//
+//   * Model ignores the tools and just writes prose describing
+//     what it would do. We treat that as stop_reason=end_turn
+//     with the prose as Content. The Implementer's
+//     validateDiffResponse then catches the missing `diff --git`
+//     and surfaces a clear error.
+func (o *Ollama) CompleteWithTools(ctx context.Context, r ToolAwareRequest) (ToolAwareResponse, error) {
+	maxTok := r.MaxTokens
+	if maxTok == 0 {
+		maxTok = o.maxTokens
+	}
+	temp := r.Temperature
+	if temp == 0 {
+		temp = o.temperature
+	}
+
+	msgs, err := toOllamaMessages(r.System, r.Messages)
+	if err != nil {
+		return ToolAwareResponse{}, fmt.Errorf("ollama tools: marshal messages: %w", err)
+	}
+
+	body, err := json.Marshal(ollamaToolReq{
+		Model:    o.model,
+		Stream:   false,
+		Options:  ollamaOptions{NumPredict: maxTok, Temperature: temp},
+		Messages: msgs,
+		Tools:    toOllamaTools(r.Tools),
+	})
+	if err != nil {
+		return ToolAwareResponse{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.endpoint+"/api/chat", bytes.NewReader(body))
+	if err != nil {
+		return ToolAwareResponse{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := o.http.Do(req)
+	if err != nil {
+		return ToolAwareResponse{}, fmt.Errorf("ollama tools: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Ollama surfaces tool-use errors either as HTTP 4xx or as a
+	// 200 OK with an "error" field in the body. Handle both.
+	if resp.StatusCode >= 400 {
+		buf := new(bytes.Buffer)
+		_, _ = buf.ReadFrom(resp.Body)
+		return ToolAwareResponse{}, fmt.Errorf("ollama tools: %s: %s", resp.Status, buf.String())
+	}
+
+	var out ollamaToolResp
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return ToolAwareResponse{}, fmt.Errorf("ollama tools decode: %w", err)
+	}
+	if out.Error != "" {
+		return ToolAwareResponse{}, fmt.Errorf("ollama tools: %s — hint: not all Ollama models support tool use; try qwen2.5-coder:14b, llama3.1, or mistral-nemo", out.Error)
+	}
+
+	return fromOllamaResponse(&out), nil
+}
+
+// toOllamaTools maps aidev's internal ToolDefinition slice to the
+// OpenAI-style {type: "function", function: {...}} shape Ollama
+// expects. The InputSchema json.RawMessage passes through verbatim
+// as the `parameters` field — aidev hand-writes these schemas
+// specifically to be portable between Anthropic and OpenAI styles.
+func toOllamaTools(defs []ToolDefinition) []ollamaTool {
+	if len(defs) == 0 {
+		return nil
+	}
+	out := make([]ollamaTool, 0, len(defs))
+	for _, d := range defs {
+		out = append(out, ollamaTool{
+			Type: "function",
+			Function: ollamaToolFunction{
+				Name:        d.Name,
+				Description: d.Description,
+				Parameters:  d.InputSchema,
+			},
+		})
+	}
+	return out
+}
+
+// toOllamaMessages translates the internal ToolMessage slice to
+// Ollama's wire shape. This is where the Anthropic-vs-OpenAI style
+// gap shows up: a user ToolMessage carrying tool_result content
+// blocks fans out to one or more role="tool" messages on the
+// Ollama side.
+func toOllamaMessages(system string, in []ToolMessage) ([]ollamaToolMessage, error) {
+	out := make([]ollamaToolMessage, 0, len(in)+1)
+	if system != "" {
+		out = append(out, ollamaToolMessage{
+			Role:    "system",
+			Content: system,
+		})
+	}
+	for _, m := range in {
+		switch m.Role {
+		case "user":
+			// A user turn with a single text block collapses to a
+			// plain {role:"user", content} message. A user turn
+			// with tool_result blocks fans out to one role="tool"
+			// message per block. A mixed turn (both text and
+			// tool_result) becomes one "user" + one or more
+			// "tool" messages; unusual but supported.
+			var textContent string
+			var toolResults []ollamaToolMessage
+			for _, b := range m.Content {
+				switch b.Type {
+				case "text":
+					textContent = b.Text
+				case "tool_result":
+					// Ollama's tool message is just {role:"tool", content}
+					// with no correlation ID — positional matching
+					// against the preceding assistant's tool_calls.
+					content := b.ToolResultContent
+					if b.ToolResultIsError {
+						content = "error: " + content
+					}
+					toolResults = append(toolResults, ollamaToolMessage{
+						Role:    "tool",
+						Content: content,
+					})
+				default:
+					return nil, fmt.Errorf("user message: unknown content block type %q", b.Type)
+				}
+			}
+			if textContent != "" {
+				out = append(out, ollamaToolMessage{Role: "user", Content: textContent})
+			}
+			out = append(out, toolResults...)
+
+		case "assistant":
+			// An assistant turn either carries text + tool_use
+			// blocks (model called tools) or just text (terminal
+			// response). Collapse the text blocks into one string
+			// because Ollama's assistant content is a plain
+			// string, not an array.
+			msg := ollamaToolMessage{Role: "assistant"}
+			var textBuf bytes.Buffer
+			for _, b := range m.Content {
+				switch b.Type {
+				case "text":
+					textBuf.WriteString(b.Text)
+				case "tool_use":
+					msg.ToolCalls = append(msg.ToolCalls, ollamaToolCall{
+						Function: ollamaToolCallFunction{
+							Name:      b.ToolName,
+							Arguments: b.ToolInput,
+						},
+					})
+				default:
+					return nil, fmt.Errorf("assistant message: unknown content block type %q", b.Type)
+				}
+			}
+			msg.Content = textBuf.String()
+			out = append(out, msg)
+
+		default:
+			return nil, fmt.Errorf("unknown message role %q", m.Role)
+		}
+	}
+	return out, nil
+}
+
+// fromOllamaResponse translates an Ollama chat response into
+// aidev's internal ToolAwareResponse. Synthesizes correlation IDs
+// for tool_calls (Ollama's wire format omits them) using the
+// position in the tool_calls array.
+func fromOllamaResponse(resp *ollamaToolResp) ToolAwareResponse {
+	var (
+		toolUses []ToolUse
+		blocks   []ToolContentBlock
+	)
+
+	if resp.Message.Content != "" {
+		blocks = append(blocks, ToolContentBlock{
+			Type: "text",
+			Text: resp.Message.Content,
+		})
+	}
+	for i, call := range resp.Message.ToolCalls {
+		id := "ollama_" + strconv.Itoa(i)
+		toolUses = append(toolUses, ToolUse{
+			ID:    id,
+			Name:  call.Function.Name,
+			Input: call.Function.Arguments,
+		})
+		blocks = append(blocks, ToolContentBlock{
+			Type:      "tool_use",
+			ToolUseID: id,
+			ToolName:  call.Function.Name,
+			ToolInput: call.Function.Arguments,
+		})
+	}
+
+	// Derive a stop_reason in the same vocabulary the Anthropic
+	// path uses so the caller doesn't need provider-specific
+	// switches. Ollama's done_reason is "stop" on a clean end,
+	// "length" on max_tokens, or empty on some daemon versions;
+	// the presence of tool_calls overrides to "tool_use".
+	stopReason := "end_turn"
+	if len(resp.Message.ToolCalls) > 0 {
+		stopReason = "tool_use"
+	} else if resp.DoneReason == "length" {
+		stopReason = "max_tokens"
+	}
+
+	return ToolAwareResponse{
+		Content:    resp.Message.Content,
+		ToolUses:   toolUses,
+		StopReason: stopReason,
+		Model:      resp.Model,
+		Usage: Usage{
+			InputTokens:  resp.PromptEvalCount,
+			OutputTokens: resp.EvalCount,
+		},
+		AssistantMessage: ToolMessage{
+			Role:    "assistant",
+			Content: blocks,
+		},
+	}
+}

--- a/internal/llm/ollama_tools_test.go
+++ b/internal/llm/ollama_tools_test.go
@@ -1,0 +1,423 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestToOllamaMessagesTranslatesSimpleConversation verifies the
+// baseline translation: system + user text + assistant text rounds
+// trip to the flat Ollama message list without losing any fields.
+func TestToOllamaMessagesTranslatesSimpleConversation(t *testing.T) {
+	in := []ToolMessage{
+		{
+			Role: "user",
+			Content: []ToolContentBlock{
+				{Type: "text", Text: "find the bug"},
+			},
+		},
+		{
+			Role: "assistant",
+			Content: []ToolContentBlock{
+				{Type: "text", Text: "here it is"},
+			},
+		},
+	}
+	got, err := toOllamaMessages("You are a dev.", in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d messages, want 3 (system+user+assistant)", len(got))
+	}
+	if got[0].Role != "system" || got[0].Content != "You are a dev." {
+		t.Errorf("system message = %+v", got[0])
+	}
+	if got[1].Role != "user" || got[1].Content != "find the bug" {
+		t.Errorf("user message = %+v", got[1])
+	}
+	if got[2].Role != "assistant" || got[2].Content != "here it is" {
+		t.Errorf("assistant message = %+v", got[2])
+	}
+}
+
+// TestToOllamaMessagesFansOutToolResults verifies that a user turn
+// containing multiple tool_result blocks becomes multiple
+// role="tool" messages on the Ollama side — each tool_result in
+// the user ToolMessage becomes its own {role:"tool", content}
+// message, because Ollama matches tool responses positionally.
+func TestToOllamaMessagesFansOutToolResults(t *testing.T) {
+	in := []ToolMessage{
+		{
+			Role: "user",
+			Content: []ToolContentBlock{
+				{Type: "text", Text: "consolidate the CTA"},
+			},
+		},
+		{
+			Role: "assistant",
+			Content: []ToolContentBlock{
+				{
+					Type:      "tool_use",
+					ToolUseID: "ollama_0",
+					ToolName:  "read_file",
+					ToolInput: json.RawMessage(`{"path":"a.json"}`),
+				},
+				{
+					Type:      "tool_use",
+					ToolUseID: "ollama_1",
+					ToolName:  "read_file",
+					ToolInput: json.RawMessage(`{"path":"b.json"}`),
+				},
+			},
+		},
+		{
+			Role: "user",
+			Content: []ToolContentBlock{
+				{
+					Type:              "tool_result",
+					ToolUseID:         "ollama_0",
+					ToolResultContent: `{"contactSales":"Contact Sales"}`,
+				},
+				{
+					Type:              "tool_result",
+					ToolUseID:         "ollama_1",
+					ToolResultContent: `{"contactSales":"Contacter les ventes"}`,
+				},
+			},
+		},
+	}
+
+	got, err := toOllamaMessages("", in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Expected: user(1) + assistant(1 with 2 tool_calls) + tool(1) + tool(1) = 4 messages.
+	if len(got) != 4 {
+		t.Fatalf("got %d messages, want 4; got=%+v", len(got), got)
+	}
+
+	if got[0].Role != "user" || got[0].Content != "consolidate the CTA" {
+		t.Errorf("msg[0] = %+v", got[0])
+	}
+	if got[1].Role != "assistant" {
+		t.Errorf("msg[1].Role = %q, want assistant", got[1].Role)
+	}
+	if len(got[1].ToolCalls) != 2 {
+		t.Errorf("assistant should carry 2 tool_calls, got %d", len(got[1].ToolCalls))
+	}
+	if got[1].ToolCalls[0].Function.Name != "read_file" {
+		t.Errorf("tool_call[0] name = %q", got[1].ToolCalls[0].Function.Name)
+	}
+	if got[2].Role != "tool" || !strings.Contains(got[2].Content, "Contact Sales") {
+		t.Errorf("msg[2] = %+v", got[2])
+	}
+	if got[3].Role != "tool" || !strings.Contains(got[3].Content, "Contacter les ventes") {
+		t.Errorf("msg[3] = %+v", got[3])
+	}
+}
+
+// TestToOllamaMessagesMarksErroredToolResults verifies that tool
+// results with IsError=true get an "error: " prefix in the
+// content field — Ollama's wire format has no IsError flag so we
+// encode the signal into the text.
+func TestToOllamaMessagesMarksErroredToolResults(t *testing.T) {
+	in := []ToolMessage{
+		{
+			Role: "user",
+			Content: []ToolContentBlock{
+				{
+					Type:              "tool_result",
+					ToolUseID:         "x",
+					ToolResultContent: "file not found: foo.go",
+					ToolResultIsError: true,
+				},
+			},
+		},
+	}
+	got, err := toOllamaMessages("", in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Role != "tool" {
+		t.Fatalf("got %+v", got)
+	}
+	if !strings.HasPrefix(got[0].Content, "error:") {
+		t.Errorf("error flag should be encoded in content, got: %q", got[0].Content)
+	}
+}
+
+// TestFromOllamaResponseEndTurn is the terminal-response case: no
+// tool_calls, clean text output, StopReason should be "end_turn".
+func TestFromOllamaResponseEndTurn(t *testing.T) {
+	resp := &ollamaToolResp{
+		Model:      "qwen2.5-coder:14b",
+		DoneReason: "stop",
+	}
+	resp.Message.Role = "assistant"
+	resp.Message.Content = "diff --git a/x b/x\n..."
+	resp.PromptEvalCount = 42
+	resp.EvalCount = 100
+
+	got := fromOllamaResponse(resp)
+	if got.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", got.StopReason)
+	}
+	if !strings.HasPrefix(got.Content, "diff --git") {
+		t.Errorf("Content = %q", got.Content)
+	}
+	if len(got.ToolUses) != 0 {
+		t.Errorf("end_turn response should have no tool uses")
+	}
+	if got.Usage.InputTokens != 42 || got.Usage.OutputTokens != 100 {
+		t.Errorf("usage = %+v", got.Usage)
+	}
+}
+
+// TestFromOllamaResponseExtractsToolCallsAndSynthesizesIDs verifies
+// the tool-use response path: Ollama's tool_calls (which have no
+// IDs) get turned into internal ToolUse entries with synthesized
+// "ollama_<idx>" IDs so the caller's correlation model still works.
+func TestFromOllamaResponseExtractsToolCallsAndSynthesizesIDs(t *testing.T) {
+	resp := &ollamaToolResp{
+		Model: "qwen2.5-coder:14b",
+	}
+	resp.Message.Role = "assistant"
+	resp.Message.Content = ""
+	resp.Message.ToolCalls = []ollamaToolCall{
+		{
+			Function: ollamaToolCallFunction{
+				Name:      "glob",
+				Arguments: json.RawMessage(`{"pattern":"apps/marketing/**/*.tsx"}`),
+			},
+		},
+		{
+			Function: ollamaToolCallFunction{
+				Name:      "read_file",
+				Arguments: json.RawMessage(`{"path":"README.md"}`),
+			},
+		},
+	}
+
+	got := fromOllamaResponse(resp)
+	if got.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use", got.StopReason)
+	}
+	if len(got.ToolUses) != 2 {
+		t.Fatalf("got %d tool uses, want 2", len(got.ToolUses))
+	}
+	if got.ToolUses[0].ID != "ollama_0" || got.ToolUses[0].Name != "glob" {
+		t.Errorf("tool[0] = %+v", got.ToolUses[0])
+	}
+	if got.ToolUses[1].ID != "ollama_1" || got.ToolUses[1].Name != "read_file" {
+		t.Errorf("tool[1] = %+v", got.ToolUses[1])
+	}
+	// AssistantMessage must round-trip the tool_use blocks so the
+	// caller can append it to history for the next turn.
+	if got.AssistantMessage.Role != "assistant" {
+		t.Errorf("AssistantMessage.Role = %q", got.AssistantMessage.Role)
+	}
+	toolUseBlocks := 0
+	for _, b := range got.AssistantMessage.Content {
+		if b.Type == "tool_use" {
+			toolUseBlocks++
+		}
+	}
+	if toolUseBlocks != 2 {
+		t.Errorf("AssistantMessage should carry 2 tool_use blocks, got %d", toolUseBlocks)
+	}
+}
+
+// TestFromOllamaResponseMaxTokens is the "model hit the output
+// token cap" case. Ollama encodes this as done_reason=="length";
+// we translate to StopReason=="max_tokens" so the Implementer's
+// loop treats it the same way the Anthropic path does.
+func TestFromOllamaResponseMaxTokens(t *testing.T) {
+	resp := &ollamaToolResp{DoneReason: "length"}
+	resp.Message.Role = "assistant"
+	resp.Message.Content = "partial output"
+	got := fromOllamaResponse(resp)
+	if got.StopReason != "max_tokens" {
+		t.Errorf("StopReason = %q", got.StopReason)
+	}
+}
+
+// TestToOllamaToolsShapeMatchesOpenAIStyle spot-checks the wire
+// shape of the tools array: Ollama wants OpenAI's
+// {type: "function", function: {name, description, parameters}}
+// wrapper, not Anthropic's flat {name, description, input_schema}.
+func TestToOllamaToolsShapeMatchesOpenAIStyle(t *testing.T) {
+	defs := []ToolDefinition{
+		{
+			Name:        "read_file",
+			Description: "Read a file",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`),
+		},
+	}
+	got := toOllamaTools(defs)
+	if len(got) != 1 {
+		t.Fatalf("got %d tools, want 1", len(got))
+	}
+	if got[0].Type != "function" {
+		t.Errorf("tool type = %q, want function", got[0].Type)
+	}
+	if got[0].Function.Name != "read_file" {
+		t.Errorf("function name = %q", got[0].Function.Name)
+	}
+	// Marshal and verify the wire shape matches Ollama's expectation.
+	data, err := json.Marshal(got[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	for _, want := range []string{
+		`"type":"function"`,
+		`"function":{`,
+		`"name":"read_file"`,
+		`"description":"Read a file"`,
+		`"parameters":{`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("wire shape missing %q; got:\n%s", want, s)
+		}
+	}
+}
+
+// TestOllamaCompleteWithToolsWiresAgainstFakeServer is the
+// full-stack round-trip: stand up an httptest server that mimics
+// the Ollama /api/chat endpoint, point an *Ollama at it, fire a
+// tool-aware request, and verify both the outgoing request body
+// AND the incoming response parsing.
+func TestOllamaCompleteWithToolsWiresAgainstFakeServer(t *testing.T) {
+	var gotBody map[string]any
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"model": "qwen2.5-coder:14b",
+			"message": {
+				"role": "assistant",
+				"content": "",
+				"tool_calls": [
+					{"function": {"name": "read_file", "arguments": {"path": "foo.go"}}}
+				]
+			},
+			"done": true,
+			"done_reason": "stop",
+			"prompt_eval_count": 15,
+			"eval_count": 42
+		}`))
+	}))
+	defer fake.Close()
+
+	o := &Ollama{
+		endpoint:    fake.URL,
+		model:       "qwen2.5-coder:14b",
+		maxTokens:   2048,
+		temperature: 0.2,
+		http:        fake.Client(),
+	}
+
+	req := ToolAwareRequest{
+		System: "You are an implementer.",
+		Tools: []ToolDefinition{
+			{
+				Name:        "read_file",
+				Description: "Read a file",
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`),
+			},
+		},
+		Messages: []ToolMessage{
+			{
+				Role:    "user",
+				Content: []ToolContentBlock{{Type: "text", Text: "Fix foo.go"}},
+			},
+		},
+	}
+
+	resp, err := o.CompleteWithTools(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Response side: one tool_use block extracted, stop_reason tool_use.
+	if resp.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use", resp.StopReason)
+	}
+	if len(resp.ToolUses) != 1 || resp.ToolUses[0].Name != "read_file" {
+		t.Errorf("tool uses = %+v", resp.ToolUses)
+	}
+
+	// Request side: the body the fake server saw must have the
+	// right Ollama shape.
+	tools, ok := gotBody["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("request tools = %+v", gotBody["tools"])
+	}
+	toolObj := tools[0].(map[string]any)
+	if toolObj["type"] != "function" {
+		t.Errorf("tool.type = %v", toolObj["type"])
+	}
+
+	msgs, ok := gotBody["messages"].([]any)
+	if !ok || len(msgs) != 2 {
+		// expected: system + user
+		t.Fatalf("request messages = %+v", gotBody["messages"])
+	}
+	if msgs[0].(map[string]any)["role"] != "system" {
+		t.Errorf("msg[0] role = %v", msgs[0])
+	}
+	if msgs[1].(map[string]any)["role"] != "user" {
+		t.Errorf("msg[1] role = %v", msgs[1])
+	}
+}
+
+// TestOllamaCompleteWithToolsSurfacesDaemonError verifies that
+// when Ollama returns an error envelope (typical for models that
+// don't support tool use — the daemon rejects the request), we
+// propagate it as a Go error with a hint about compatible models.
+func TestOllamaCompleteWithToolsSurfacesDaemonError(t *testing.T) {
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"error": "registry.ollama.ai/library/outdated-model does not support tools"}`))
+	}))
+	defer fake.Close()
+
+	o := &Ollama{
+		endpoint: fake.URL,
+		model:    "outdated-model",
+		http:     fake.Client(),
+	}
+	_, err := o.CompleteWithTools(context.Background(), ToolAwareRequest{
+		Messages: []ToolMessage{{
+			Role:    "user",
+			Content: []ToolContentBlock{{Type: "text", Text: "hi"}},
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected error on non-tool-capable model")
+	}
+	if !strings.Contains(err.Error(), "does not support tools") {
+		t.Errorf("error should mention lack of tool support; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "qwen2.5-coder") {
+		t.Errorf("error should suggest compatible models; got: %v", err)
+	}
+}
+
+// TestOllamaImplementsToolAwareProvider is a compile-time guard.
+// If someone removes or renames CompleteWithTools on *Ollama, this
+// fails at build time.
+func TestOllamaImplementsToolAwareProvider(t *testing.T) {
+	var _ ToolAwareProvider = (*Ollama)(nil)
+}


### PR DESCRIPTION
## Summary

User's run hit two problems:

1. **`claude-cli` Implementer subprocess killed with signal** (OOM or sandbox timeout on `claude --print`). Legacy NEED_FILES path was firing because `claude-cli` doesn't implement `ToolAwareProvider` — v0.4 only wired Anthropic REST.
2. **User's explicit directive**: 'I think we should use the ollama tool use setup.'

Done. The `Ollama` provider now implements `ToolAwareProvider`, so routing the Implementer to a tool-capable local model (qwen2.5, qwen2.5-coder, llama3.1, llama3.2, mistral-nemo, command-r-plus, firefunction-v2) gives the full v0.4 tool-use loop with zero cloud dependency. The default `--preset local` now dispatches the Implementer through native tool calls instead of the legacy picker + NEED_FILES path.

## Translation layer

Ollama's tool wire format is OpenAI-style function calling, meaningfully different from Anthropic's content-block model that aidev's internal types are shaped around:

| | Anthropic | Ollama |
|---|---|---|
| Assistant content | Array of typed blocks | Plain string + separate `tool_calls` field |
| Tool results | `tool_result` blocks inside a user message | Separate top-level `role: "tool"` messages |
| Correlation | By `tool_use_id` | Positional (by order) |

`internal/llm/ollama_tools.go` handles the translation in both directions.

- `toOllamaMessages`: A user ToolMessage with multiple tool_result blocks fans out to multiple `role: "tool"` messages. An assistant ToolMessage with text + tool_use blocks combines into one assistant message with a `tool_calls` array.
- `fromOllamaResponse`: Synthesizes `ollama_<i>` correlation IDs since Ollama's wire format doesn't carry them. Maps `done_reason` to the internal `StopReason` vocabulary (`tool_use` / `max_tokens` / `end_turn`).
- `toOllamaTools`: Wraps each `ToolDefinition` in OpenAI's `{type: "function", function: {...}}` shape. The hand-written JSON Schemas from #39 pass through verbatim — no per-tool rewriting needed.

## Error handling

Non-tool-capable Ollama models get their error envelope propagated with an explicit hint pointing at compatible models. No automatic fallback to `Complete()` — silent fallback would hide the user's intent and defeat the point of asking for Ollama tool use. Users who pick an incompatible model get a clear failure and a specific remediation.

## Tests

10 new cases in `internal/llm/ollama_tools_test.go`:

- `TestToOllamaMessagesTranslatesSimpleConversation` — baseline round-trip
- `TestToOllamaMessagesFansOutToolResults` — the interesting case: user tool_result blocks → multiple `role: "tool"` messages
- `TestToOllamaMessagesMarksErroredToolResults` — IsError gets encoded as `"error: "` prefix
- `TestFromOllamaResponseEndTurn` — terminal response path
- `TestFromOllamaResponseExtractsToolCallsAndSynthesizesIDs` — synthetic correlation IDs
- `TestFromOllamaResponseMaxTokens` — `done_reason: "length"` handling
- `TestToOllamaToolsShapeMatchesOpenAIStyle` — wire shape check (OpenAI not Anthropic)
- `TestOllamaCompleteWithToolsWiresAgainstFakeServer` — full round-trip against httptest fake
- `TestOllamaCompleteWithToolsSurfacesDaemonError` — daemon error propagation with hint
- `TestOllamaImplementsToolAwareProvider` — compile-time interface check

## Config docs

`config/models.local.yaml` (and the embedded install copy) updated with:

- New v0.4a section explaining Ollama now supports tool use
- Explicit list of compatible Ollama model families
- Quality expectation bump: local Implementer diffs now 85-95% of cloud (up from 80-90%) because NEED_FILES failure modes are gone
- Coordinator cross-reference updated: Gate-1 safety net still runs, 'local horse, cloud jockey' shape still recommended for users with Claude CLI available

## Not in scope

- `claude-cli` OOM investigation (orthogonal runtime issue; sidestepped by swapping providers)
- Sketch-numbering non-determinism (#38)
- Coordinator/Reviewer tool use (#39 follow-up)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all 10 new tests + full existing suite pass
- [ ] User runs `/aidev-run 533` with either `--preset local` OR after swapping their `medium` tier to `provider: ollama, model: qwen2.5-coder:14b` (or similar tool-capable model). Expected: Implementer dispatches to `runWithTools` via the Ollama path, makes native tool calls (glob → read_file → grep → diff), produces a real unified diff without NEED_FILES or claude-cli OOM.