### PR TITLE
fix(v0.5a): salvage content-embedded tool calls from Ollama + format-correct malformed final turns

### DIFF
--- a/internal/agents/implementer_tools.go
+++ b/internal/agents/implementer_tools.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/aisu-ai/aidev/internal/llm"
@@ -35,6 +36,15 @@ import (
 // the budget.
 const maxToolIterations = 25
 
+// maxToolFormatCorrections is the cap on how many times
+// runWithTools will send a corrective follow-up when the model
+// ends its turn with invalid final content (not a diff, not an
+// ERROR: line). One correction is enough for cloud Claude; local
+// Ollama models occasionally need two but anything beyond that
+// is a model that simply cannot follow the output format and
+// deserves a hard failure with a clear error.
+const maxToolFormatCorrections = 2
+
 // runWithTools drives the native tool-use loop. Called from
 // Implementer.Run() when the provider implements ToolAwareProvider.
 //
@@ -51,11 +61,19 @@ const maxToolIterations = 25
 //  5. Bounded at maxToolIterations to prevent runaway cost.
 //
 // Unlike the legacy path, there is NO picker turn, NO NEED_FILES
-// protocol, NO harvest step, NO missing-path tracking, and NO
-// format-correction retry. All of those were workarounds for the
-// missing tool-use capability. The model now has direct access to
-// the filesystem via tools and the conversation state is the only
-// thing the loop has to manage.
+// protocol, NO harvest step, and NO missing-path tracking. The
+// model has direct access to the filesystem via tools and the
+// conversation state is the only thing the loop has to manage.
+//
+// Format correction (v0.5a): the loop DOES include one layer of
+// format correction, because even tool-capable local models
+// (qwen2.5-coder:14b especially) sometimes produce an end_turn
+// response whose content isn't a valid diff. The provider layer
+// now salvages content-embedded tool calls before we get here,
+// so the cases that reach this loop are genuine format misses —
+// the model thought it was done but emitted the wrong shape. We
+// send one corrective follow-up asking for either a valid diff
+// or a real tool_use, and only fail hard if it's wrong twice.
 func (i *Implementer) runWithTools(ctx context.Context, provider llm.ToolAwareProvider, c *Context, chosen *Sketch) (*Patch, error) {
 	exec := NewToolExecutor(c.Snapshot.Root)
 	toolDefs := exec.Definitions()
@@ -75,6 +93,13 @@ func (i *Implementer) runWithTools(ctx context.Context, provider llm.ToolAwarePr
 		},
 	}
 
+	// formatCorrectionsUsed tracks how many times we've sent a
+	// corrective follow-up to recover from a malformed final
+	// turn (an end_turn response whose content isn't a diff).
+	// Capped at maxToolFormatCorrections so a model that
+	// refuses to comply can't loop forever.
+	formatCorrectionsUsed := 0
+
 	for iter := 0; iter < maxToolIterations; iter++ {
 		resp, err := provider.CompleteWithTools(ctx, llm.ToolAwareRequest{
 			System:   system,
@@ -92,8 +117,46 @@ func (i *Implementer) runWithTools(ctx context.Context, provider llm.ToolAwarePr
 
 		switch resp.StopReason {
 		case "end_turn":
-			// Model is done iterating. Its final text is the patch.
-			return validateDiffResponse(resp.Content)
+			// Model is done iterating. Its final text is supposed
+			// to be a unified diff. If validation passes, return
+			// the patch.
+			patch, err := validateDiffResponse(resp.Content)
+			if err == nil {
+				return patch, nil
+			}
+			// ERROR: is an intentional terminal state — the
+			// model is saying the task is impossible. Propagate
+			// immediately instead of trying to format-correct it
+			// into a diff.
+			if errors.Is(err, errDeclaredError) {
+				return nil, err
+			}
+			// Otherwise it's a format miss. Try ONE format
+			// correction before failing hard.
+			if formatCorrectionsUsed >= maxToolFormatCorrections {
+				// Dump the raw output so the user can see exactly
+				// what the model produced. This is the debugging
+				// signal v0.4a missed — we'd just see "first
+				// line was X" and have to guess at the rest.
+				return nil, fmt.Errorf("implementer: end_turn output is not a valid diff after %d format corrections: %w\n\nraw output:\n%s",
+					formatCorrectionsUsed, err, truncateForError(resp.Content, 2048))
+			}
+			// Stage a corrective user message that quotes the
+			// broken output and tells the model what to do.
+			messages = append(messages, llm.ToolMessage{
+				Role: "user",
+				Content: []llm.ToolContentBlock{
+					{
+						Type: "text",
+						Text: buildFormatCorrectionMessage(resp.Content, err),
+					},
+				},
+			})
+			formatCorrectionsUsed++
+			// Fall through to the next loop iteration, which
+			// re-calls the provider with the corrective message
+			// appended.
+			continue
 
 		case "tool_use":
 			if len(resp.ToolUses) == 0 {
@@ -207,6 +270,22 @@ WORKFLOW:
    final assistant message (without any more tool calls). The loop
    ends when your turn contains only text.
 
+3. CRITICAL — how to actually call tools: use the native tool_call
+   mechanism provided by your runtime. Do NOT emit a JSON object
+   in your message text like {"name": "read_file", "arguments":
+   {"path": "..."}} and expect it to be interpreted as a tool
+   call. The harness expects tool calls via the structured
+   tool_calls field of your response, not JSON in the content.
+   If you emit raw JSON in content the harness will treat it as
+   your final diff output and reject it for not being a diff.
+
+4. CRITICAL — when you are DONE and ready to produce the diff,
+   your response content must be the LITERAL unified diff text,
+   starting with the line "diff --git a/...". Do NOT wrap the
+   diff in a JSON object, do NOT put it in a Markdown code
+   fence, do NOT prefix it with prose. The raw diff is what
+   goes straight to the 'git apply' command.
+
 OUTPUT REQUIREMENTS for the final diff:
 
 1. Standard git unified diff format:
@@ -269,12 +348,18 @@ review it. A diff that applies cleanly and finishes the scope is
 worth ten drafts that need human cleanup.`
 }
 
+// errDeclaredError is the sentinel wrapping an `ERROR:` escape
+// hatch from the model. runWithTools uses errors.Is to
+// distinguish an ERROR: (terminal, propagate immediately) from
+// a generic validation miss (format-correction candidate).
+var errDeclaredError = errors.New("implementer: declared ERROR")
+
 // validateDiffResponse checks that a model's final text looks like a
 // unified git diff and returns a Patch. Uses the same grammar the
 // legacy path used, minus the NEED_FILES branch (not valid in
-// tool-use mode) and minus the format-correction retry (the model
-// can iterate inside the tool loop, so a bad final turn is a real
-// failure, not a format slip).
+// tool-use mode). Returns an error wrapping errDeclaredError for
+// ERROR: responses so the caller can distinguish them from
+// format misses.
 func validateDiffResponse(raw string) (*Patch, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -287,22 +372,102 @@ func validateDiffResponse(raw string) (*Patch, error) {
 		if reason == "" {
 			reason = "(no reason given)"
 		}
-		return nil, fmt.Errorf("implementer: declared ERROR: %s", reason)
+		// Wrap errDeclaredError so runWithTools can detect this
+		// via errors.Is and propagate immediately instead of
+		// trying to format-correct the ERROR: back to a diff.
+		return nil, fmt.Errorf("%w: %s", errDeclaredError, reason)
 	}
 
-	// Tolerate a short prose preamble before `diff --git` in the
+	// Tolerate a SHORT prose preamble before `diff --git` in the
 	// tool-use path — models sometimes narrate the final turn
-	// ("Here's the diff:") before the real content. We look for
-	// the first `diff --git` anywhere in the response and treat
-	// everything from there to the end as the patch body.
-	idx := strings.Index(raw, "diff --git")
-	if idx < 0 {
-		return nil, fmt.Errorf("implementer: final response contains no 'diff --git' marker; got first line: %q", firstLine(raw))
+	// ("Here's the diff:") before the real content. But only
+	// match `diff --git` at the START of a line after an optional
+	// prose preamble, NOT anywhere in the raw string. Using a
+	// plain strings.Index would match inside a JSON string
+	// literal like {"diff": "diff --git ..."} and we'd extract
+	// a garbled half-JSON as the patch body.
+	//
+	// Valid shapes we accept:
+	//
+	//   diff --git a/... b/...      ← the common case
+	//
+	//   Here's the diff:
+	//
+	//   diff --git a/... b/...      ← short prose preamble
+	//
+	// Anything else (JSON wrapper, tool-call JSON, random
+	// garbage) triggers the format-correction retry in
+	// runWithTools.
+	if strings.HasPrefix(raw, "diff --git") {
+		return &Patch{
+			Diff:         raw,
+			FilesTouched: parseFilesFromDiff(raw),
+		}, nil
 	}
-	diff := raw[idx:]
+	// Prose preamble: allow up to 500 chars of prose followed by
+	// a blank line followed by `diff --git` at the start of a
+	// line. Anything else falls through to the error.
+	if m := proseDiffRe.FindStringSubmatchIndex(raw); m != nil {
+		// m[0..1] is full match; m[2..3] is the `diff --git` group.
+		diffStart := m[2]
+		if diffStart <= 500 {
+			diff := raw[diffStart:]
+			return &Patch{
+				Diff:         diff,
+				FilesTouched: parseFilesFromDiff(diff),
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("implementer: final response does not start with 'diff --git'; got first line: %q", firstLine(raw))
+}
 
-	return &Patch{
-		Diff:         diff,
-		FilesTouched: parseFilesFromDiff(diff),
-	}, nil
+// proseDiffRe matches a prose preamble (any content) followed
+// by a blank line and `diff --git` at the start of a line. The
+// capture group is on the `diff --git` start so we can extract
+// the diff body without the prose prefix. We use `(?m)` so `^`
+// matches at the start of a line, not just the start of the
+// whole string.
+var proseDiffRe = regexp.MustCompile(`(?m)(^diff --git )`)
+
+// buildFormatCorrectionMessage composes the corrective user
+// message we send to the model when its end_turn content isn't
+// a valid diff. Quotes the broken output verbatim (truncated to
+// keep prompt size bounded) and tells the model exactly what
+// the next response must look like.
+//
+// Pattern is the same as the legacy tryGenerateDiff format
+// correction (#34), adapted for the tool-use loop: we can
+// mention tools because the model has real tool access here,
+// so the correction allows either "try more tool_use turns" or
+// "emit a clean diff" or "emit ERROR: <reason>".
+func buildFormatCorrectionMessage(brokenContent string, validationErr error) string {
+	var b strings.Builder
+	b.WriteString("## Your previous response was not a valid final output\n\n")
+	fmt.Fprintf(&b, "The validator rejected your end_turn response with: %v\n\n", validationErr)
+	b.WriteString("What you wrote (first 500 chars):\n\n> ")
+	b.WriteString(strings.ReplaceAll(truncateForError(brokenContent, 500), "\n", "\n> "))
+	b.WriteString("\n\n")
+	b.WriteString("Your next response MUST be EXACTLY ONE of:\n\n")
+	b.WriteString("1. A complete unified git diff starting with `diff --git a/...`. ")
+	b.WriteString("This is the success path — the diff is what the user will `git apply`.\n\n")
+	b.WriteString("2. More tool calls (read_file, glob, grep, list_dir) if you need more ")
+	b.WriteString("repository context before you can produce the diff. Use the native ")
+	b.WriteString("tool-call mechanism, not a JSON object in your content.\n\n")
+	b.WriteString("3. A single line `ERROR: <reason>` if the task is genuinely impossible ")
+	b.WriteString("(e.g. sketch contradicts itself, required files don't exist).\n\n")
+	b.WriteString("Do NOT emit prose describing what you would do. Do NOT emit a JSON ")
+	b.WriteString("wrapper around the diff (like `{\"diff\": \"...\"}`). The diff itself ")
+	b.WriteString("must be the literal content of your response.\n")
+	return b.String()
+}
+
+// truncateForError clips a string to n bytes, appending an
+// ellipsis marker if truncation happened. Used for error
+// messages and correction prompts so a runaway output can't
+// balloon the log or the next turn's context.
+func truncateForError(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "\n...[truncated at " + fmt.Sprint(n) + " bytes]"
 }

--- a/internal/agents/implementer_tools_test.go
+++ b/internal/agents/implementer_tools_test.go
@@ -415,3 +415,231 @@ func TestImplementerRunLegacyPathStillFiresForNonToolProviders(t *testing.T) {
 		t.Errorf("legacy diff wrong: %s", patch.Diff)
 	}
 }
+
+// recordingToolProvider captures every ToolAwareRequest it
+// receives so tests can inspect the full multi-turn
+// conversation. Used by the format-correction tests below to
+// verify that the corrective follow-up actually quoted the
+// broken output back to the model.
+type recordingToolProvider struct {
+	responses []llm.ToolAwareResponse
+	requests  []llm.ToolAwareRequest
+}
+
+func (p *recordingToolProvider) Name() string { return "recording-tool" }
+func (p *recordingToolProvider) Complete(_ context.Context, _ llm.Request) (llm.Response, error) {
+	panic("recordingToolProvider.Complete called")
+}
+func (p *recordingToolProvider) CompleteWithTools(_ context.Context, req llm.ToolAwareRequest) (llm.ToolAwareResponse, error) {
+	p.requests = append(p.requests, req)
+	idx := len(p.requests) - 1
+	if idx >= len(p.responses) {
+		idx = len(p.responses) - 1
+	}
+	return p.responses[idx], nil
+}
+
+var _ llm.ToolAwareProvider = (*recordingToolProvider)(nil)
+
+// TestImplementerRunToolPathRecoversFromMalformedFinalContent
+// is the regression guard for v0.5a. When the model ends its
+// turn with content that isn't a diff (and not an ERROR:), the
+// harness must send a corrective follow-up and let the model
+// produce a valid diff on the retry.
+//
+// Covers the exact scenario the user hit: qwen2.5-coder:14b
+// emitted a `{` on its final turn instead of a `diff --git`.
+// The embedded-tool-call salvage in fromOllamaResponse catches
+// the most common subset of this failure mode, but when the
+// content doesn't match any known tool-call shape (e.g. the
+// model wrote `{"diff": "..."}` or just random JSON garbage)
+// the format-correction retry is the backstop.
+func TestImplementerRunToolPathRecoversFromMalformedFinalContent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &recordingToolProvider{
+		responses: []llm.ToolAwareResponse{
+			// Turn 1: model ends with malformed content (a JSON
+			// wrapper around the diff — not a tool-call shape,
+			// not a valid diff).
+			{
+				StopReason: "end_turn",
+				Content:    `{"diff": "diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-package x\n+package y\n"}`,
+				AssistantMessage: llm.ToolMessage{
+					Role: "assistant",
+					Content: []llm.ToolContentBlock{
+						makeTextBlock(`{"diff": "..."}`),
+					},
+				},
+			},
+			// Turn 2: after the corrective follow-up, the model
+			// emits a real unified diff.
+			{
+				StopReason: "end_turn",
+				Content: "diff --git a/x.go b/x.go\n" +
+					"--- a/x.go\n" +
+					"+++ b/x.go\n" +
+					"@@ -1 +1 @@\n" +
+					"-package x\n" +
+					"+package y\n",
+				AssistantMessage: llm.ToolMessage{
+					Role:    "assistant",
+					Content: []llm.ToolContentBlock{makeTextBlock("diff --git a/x.go b/x.go\n...")},
+				},
+			},
+		},
+	}
+
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "t", Body: "body"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+
+	patch, err := impl.Run(context.Background(), ctx, sketch)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if patch == nil {
+		t.Fatal("nil patch")
+	}
+	if !strings.Contains(patch.Diff, "+package y") {
+		t.Errorf("final patch wrong: %s", patch.Diff)
+	}
+
+	// Two turns total: one rejected + one corrected.
+	if len(provider.requests) != 2 {
+		t.Fatalf("provider called %d times, want 2", len(provider.requests))
+	}
+
+	// The SECOND turn's user message list must end with a
+	// corrective user message that quotes the broken content.
+	secondReq := provider.requests[1]
+	if len(secondReq.Messages) == 0 {
+		t.Fatal("second request has no messages")
+	}
+	lastMsg := secondReq.Messages[len(secondReq.Messages)-1]
+	if lastMsg.Role != "user" {
+		t.Errorf("last message role = %q, want user", lastMsg.Role)
+	}
+	var foundCorrection bool
+	for _, b := range lastMsg.Content {
+		if b.Type == "text" && strings.Contains(b.Text, "Your previous response was not a valid final output") {
+			foundCorrection = true
+		}
+		if b.Type == "text" && !strings.Contains(b.Text, `{"diff":`) {
+			continue
+		}
+		if b.Type == "text" && strings.Contains(b.Text, `{"diff":`) {
+			// The correction message should echo the broken
+			// JSON wrapper back to the model so it sees what
+			// it wrote.
+			foundCorrection = true
+		}
+	}
+	if !foundCorrection {
+		t.Errorf("corrective follow-up missing or malformed; last message:\n%+v", lastMsg)
+	}
+}
+
+// TestImplementerRunToolPathFailsAfterRepeatedMalformedOutput
+// guards the format-correction cap. A model that refuses to
+// emit a valid diff across multiple corrections must fail
+// hard with a clear error that includes the raw output for
+// debugging.
+func TestImplementerRunToolPathFailsAfterRepeatedMalformedOutput(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Every response is malformed — no diff marker anywhere.
+	malformed := llm.ToolAwareResponse{
+		StopReason: "end_turn",
+		Content:    `{"i": "wrote", "more": "nonsense"}`,
+		AssistantMessage: llm.ToolMessage{
+			Role:    "assistant",
+			Content: []llm.ToolContentBlock{makeTextBlock(`{"i": "wrote", "more": "nonsense"}`)},
+		},
+	}
+	script := make([]llm.ToolAwareResponse, maxToolFormatCorrections+3)
+	for i := range script {
+		script[i] = malformed
+	}
+	provider := &scriptedToolProvider{responses: script}
+
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "t", Body: "body"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+
+	_, err := impl.Run(context.Background(), ctx, sketch)
+	if err == nil {
+		t.Fatal("expected hard failure after format-correction cap")
+	}
+	// The error must include the raw output so the user can
+	// debug without re-running — this is the debuggability
+	// fix #35/#36 were missing at the tool-use path.
+	if !strings.Contains(err.Error(), "raw output:") {
+		t.Errorf("error should include raw output section; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), `{"i": "wrote"`) {
+		t.Errorf("error should quote the malformed content; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "format corrections") {
+		t.Errorf("error should mention format corrections; got: %v", err)
+	}
+}
+
+// TestImplementerRunToolPathFormatCorrectionNotTriggeredOnERROR
+// verifies that an ERROR: escape hatch from the model is
+// surfaced immediately without going through format
+// correction. ERROR: is an intentional terminal state, not a
+// malformed output.
+func TestImplementerRunToolPathFormatCorrectionNotTriggeredOnERROR(t *testing.T) {
+	dir := t.TempDir()
+
+	provider := &scriptedToolProvider{
+		responses: []llm.ToolAwareResponse{
+			{
+				StopReason: "end_turn",
+				Content:    "ERROR: sketch references a file that does not exist",
+				AssistantMessage: llm.ToolMessage{
+					Role:    "assistant",
+					Content: []llm.ToolContentBlock{makeTextBlock("ERROR: sketch references a file that does not exist")},
+				},
+			},
+			// This second response should NEVER be reached —
+			// ERROR: terminates immediately.
+			{
+				StopReason: "end_turn",
+				Content:    "diff --git a/x b/x\n",
+			},
+		},
+	}
+	impl := &Implementer{Provider: provider}
+	ctx := &Context{
+		Issue:    &github.Issue{Owner: "a", Repo: "b", Number: 1, Title: "t", Body: "body"},
+		Snapshot: &repo.Snapshot{Root: dir},
+	}
+	sketch := &Sketch{Number: 1, Title: "t", Markdown: "m"}
+
+	_, err := impl.Run(context.Background(), ctx, sketch)
+	if err == nil {
+		t.Fatal("ERROR: should propagate as a Go error")
+	}
+	if !strings.Contains(err.Error(), "declared ERROR") {
+		t.Errorf("ERROR: should surface as 'declared ERROR', got: %v", err)
+	}
+	// Only one provider call — the second scripted response
+	// must not have been reached.
+	if provider.calls != 1 {
+		t.Errorf("provider called %d times, want 1 (ERROR should terminate immediately)", provider.calls)
+	}
+}

--- a/internal/llm/ollama_tools.go
+++ b/internal/llm/ollama_tools.go
@@ -45,6 +45,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 // ollamaToolReq is the chat request shape for tool-aware calls.
@@ -297,18 +298,58 @@ func toOllamaMessages(system string, in []ToolMessage) ([]ollamaToolMessage, err
 // aidev's internal ToolAwareResponse. Synthesizes correlation IDs
 // for tool_calls (Ollama's wire format omits them) using the
 // position in the tool_calls array.
+//
+// CONTENT-EMBEDDED TOOL CALL FALLBACK (v0.5a):
+// Some tool-capable Ollama models — qwen2.5-coder:14b is the
+// primary offender I've seen in the wild — sometimes emit tool
+// calls as a JSON object in message.content instead of
+// populating the structured tool_calls field. The daemon
+// faithfully passes the content string through, and our caller
+// gets a response with empty tool_calls and content that looks
+// like `{"name": "read_file", "arguments": {"path": "foo.go"}}`.
+//
+// Without a fallback, we'd treat this as stop_reason=end_turn
+// and pass the JSON through to the Implementer's diff
+// validator, which rejects anything that doesn't start with
+// `diff --git`. The result is a hard failure with no recovery
+// path — exactly the issue aidev hit on the v0.5 + qwen
+// smoke-test run.
+//
+// The fix: if tool_calls is empty AND content parses as a
+// recognizable tool-call shape, synthesize a ToolUse from the
+// content and treat the response as stop_reason=tool_use. We
+// accept three field-name variants that cover ~all
+// OpenAI/Anthropic-compatible models that botch the structured
+// output:
+//
+//	{"name": "...", "arguments": {...}}
+//	{"function": "...", "parameters": {...}}
+//	{"tool": "...", "input": {...}}
+//
+// If content is non-JSON or doesn't match any of these shapes,
+// we fall through to the normal end_turn path and let the
+// caller's format-correction retry handle it.
 func fromOllamaResponse(resp *ollamaToolResp) ToolAwareResponse {
 	var (
 		toolUses []ToolUse
 		blocks   []ToolContentBlock
 	)
 
-	if resp.Message.Content != "" {
+	// Content-embedded tool-call salvage. Runs BEFORE the text
+	// block is emitted so that if we successfully extract a tool
+	// call, the AssistantMessage only contains the synthesized
+	// tool_use block and not the raw JSON as text (which would
+	// confuse the next turn's prompt).
+	embeddedCalls := extractEmbeddedToolCalls(resp.Message.Content)
+
+	if len(embeddedCalls) == 0 && resp.Message.Content != "" {
 		blocks = append(blocks, ToolContentBlock{
 			Type: "text",
 			Text: resp.Message.Content,
 		})
 	}
+
+	// Structured tool_calls from the Ollama response.
 	for i, call := range resp.Message.ToolCalls {
 		id := "ollama_" + strconv.Itoa(i)
 		toolUses = append(toolUses, ToolUse{
@@ -324,20 +365,49 @@ func fromOllamaResponse(resp *ollamaToolResp) ToolAwareResponse {
 		})
 	}
 
+	// Content-embedded tool_calls salvaged above. ID numbering
+	// continues past any real tool_calls so there's no collision.
+	for i, call := range embeddedCalls {
+		id := "ollama_embedded_" + strconv.Itoa(len(resp.Message.ToolCalls)+i)
+		toolUses = append(toolUses, ToolUse{
+			ID:    id,
+			Name:  call.Name,
+			Input: call.Arguments,
+		})
+		blocks = append(blocks, ToolContentBlock{
+			Type:      "tool_use",
+			ToolUseID: id,
+			ToolName:  call.Name,
+			ToolInput: call.Arguments,
+		})
+	}
+
 	// Derive a stop_reason in the same vocabulary the Anthropic
 	// path uses so the caller doesn't need provider-specific
 	// switches. Ollama's done_reason is "stop" on a clean end,
 	// "length" on max_tokens, or empty on some daemon versions;
-	// the presence of tool_calls overrides to "tool_use".
+	// the presence of tool_calls (real or salvaged from content)
+	// overrides to "tool_use".
 	stopReason := "end_turn"
-	if len(resp.Message.ToolCalls) > 0 {
+	if len(toolUses) > 0 {
 		stopReason = "tool_use"
 	} else if resp.DoneReason == "length" {
 		stopReason = "max_tokens"
 	}
 
+	// Content that survived the embedded-parse salvage is the
+	// one we expose to the caller. If we extracted tool calls,
+	// the content string is cleared (since the "text" was
+	// actually the tool call JSON, which is already represented
+	// as ToolUses) so the Implementer's validator doesn't
+	// mistake it for a diff.
+	content := resp.Message.Content
+	if len(embeddedCalls) > 0 {
+		content = ""
+	}
+
 	return ToolAwareResponse{
-		Content:    resp.Message.Content,
+		Content:    content,
 		ToolUses:   toolUses,
 		StopReason: stopReason,
 		Model:      resp.Model,
@@ -350,4 +420,140 @@ func fromOllamaResponse(resp *ollamaToolResp) ToolAwareResponse {
 			Content: blocks,
 		},
 	}
+}
+
+// embeddedToolCall is the parsed shape of a content-embedded
+// tool call. Used internally by extractEmbeddedToolCalls; the
+// caller converts these into proper ToolUses.
+type embeddedToolCall struct {
+	Name      string
+	Arguments json.RawMessage
+}
+
+// extractEmbeddedToolCalls scans Ollama's content string for
+// JSON objects that look like tool calls in any of the common
+// wire shapes, and returns parsed results. Returns nil when the
+// content isn't a tool call (most responses).
+//
+// The parser is conservative: it only treats content as a tool
+// call when the ENTIRE content string is a single JSON object
+// with recognizable fields. A string like "I'll read the file.
+// {"name": ...}" is NOT salvaged because the model clearly
+// mixed prose and JSON, which is a different failure mode and
+// should go through format-correction instead.
+//
+// Accepted shapes:
+//
+//	{"name": "read_file", "arguments": {"path": "foo.go"}}
+//	{"function": "read_file", "parameters": {"path": "foo.go"}}
+//	{"tool": "read_file", "input": {"path": "foo.go"}}
+//
+// A JSON array of such objects is also accepted (some models
+// emit multiple tool calls as an array).
+func extractEmbeddedToolCalls(content string) []embeddedToolCall {
+	trimmed := trimCodeFence(content)
+	if trimmed == "" {
+		return nil
+	}
+	// Quick rejection: if the first non-whitespace char isn't
+	// `{` or `[`, it can't be a tool-call JSON.
+	first := byte(' ')
+	for i := 0; i < len(trimmed); i++ {
+		if trimmed[i] != ' ' && trimmed[i] != '\t' && trimmed[i] != '\n' && trimmed[i] != '\r' {
+			first = trimmed[i]
+			break
+		}
+	}
+	if first != '{' && first != '[' {
+		return nil
+	}
+
+	// Try as a single object first.
+	var single map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(trimmed), &single); err == nil {
+		if call, ok := parseEmbeddedToolCallObject(single); ok {
+			return []embeddedToolCall{call}
+		}
+	}
+	// Try as an array of objects.
+	var array []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(trimmed), &array); err == nil {
+		var out []embeddedToolCall
+		for _, obj := range array {
+			if call, ok := parseEmbeddedToolCallObject(obj); ok {
+				out = append(out, call)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	return nil
+}
+
+// parseEmbeddedToolCallObject tries every accepted shape on
+// a single JSON object and returns the first match.
+func parseEmbeddedToolCallObject(obj map[string]json.RawMessage) (embeddedToolCall, bool) {
+	// Shape 1: {"name": "...", "arguments": {...}}
+	if nameRaw, ok := obj["name"]; ok {
+		if argsRaw, ok := obj["arguments"]; ok {
+			if name, ok := jsonString(nameRaw); ok && name != "" {
+				return embeddedToolCall{Name: name, Arguments: argsRaw}, true
+			}
+		}
+	}
+	// Shape 2: {"function": "...", "parameters": {...}}
+	if nameRaw, ok := obj["function"]; ok {
+		if argsRaw, ok := obj["parameters"]; ok {
+			if name, ok := jsonString(nameRaw); ok && name != "" {
+				return embeddedToolCall{Name: name, Arguments: argsRaw}, true
+			}
+		}
+	}
+	// Shape 3: {"tool": "...", "input": {...}}
+	if nameRaw, ok := obj["tool"]; ok {
+		if argsRaw, ok := obj["input"]; ok {
+			if name, ok := jsonString(nameRaw); ok && name != "" {
+				return embeddedToolCall{Name: name, Arguments: argsRaw}, true
+			}
+		}
+	}
+	return embeddedToolCall{}, false
+}
+
+// jsonString decodes a json.RawMessage into a Go string when it
+// is a JSON string. Returns ok=false when the raw message is
+// anything else (object, array, number, etc.).
+func jsonString(raw json.RawMessage) (string, bool) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, true
+	}
+	return "", false
+}
+
+// trimCodeFence strips a leading and trailing ``` fence if
+// present. Used before JSON parsing because some models wrap
+// their tool-call JSON in a Markdown code fence despite being
+// told not to.
+func trimCodeFence(s string) string {
+	lines := splitLines(s)
+	if len(lines) == 0 {
+		return s
+	}
+	// Strip leading fence.
+	if strings.HasPrefix(strings.TrimSpace(lines[0]), "```") {
+		lines = lines[1:]
+	}
+	// Strip trailing fence.
+	if n := len(lines); n > 0 && strings.HasPrefix(strings.TrimSpace(lines[n-1]), "```") {
+		lines = lines[:n-1]
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+// splitLines is a strings.Split on "\n" kept in a helper so the
+// trimCodeFence logic reads a little more naturally.
+func splitLines(s string) []string {
+	return strings.Split(s, "\n")
 }

--- a/internal/llm/ollama_tools_embedded_test.go
+++ b/internal/llm/ollama_tools_embedded_test.go
@@ -1,0 +1,254 @@
+package llm
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// extractEmbeddedToolCalls — content-embedded tool call salvage
+// ---------------------------------------------------------------------------
+//
+// The regression we're guarding against: tool-capable Ollama
+// models (qwen2.5-coder:14b specifically) sometimes emit tool
+// calls as JSON in the message.content field instead of
+// populating the structured tool_calls field. When that
+// happens, fromOllamaResponse needs to salvage the intent so
+// the pipeline doesn't hard-fail on "content doesn't start
+// with diff --git".
+//
+// We accept three wire shapes in priority order:
+//   {"name": "...", "arguments": {...}}            (Qwen, LLaMA)
+//   {"function": "...", "parameters": {...}}      (OpenAI legacy)
+//   {"tool": "...", "input": {...}}                (Anthropic-ish)
+
+func TestExtractEmbeddedToolCallsNameArguments(t *testing.T) {
+	in := `{"name": "read_file", "arguments": {"path": "apps/marketing/src/foo.tsx"}}`
+	got := extractEmbeddedToolCalls(in)
+	if len(got) != 1 {
+		t.Fatalf("got %d calls, want 1", len(got))
+	}
+	if got[0].Name != "read_file" {
+		t.Errorf("Name = %q, want read_file", got[0].Name)
+	}
+	if !strings.Contains(string(got[0].Arguments), "apps/marketing") {
+		t.Errorf("Arguments lost the path; got %q", got[0].Arguments)
+	}
+}
+
+func TestExtractEmbeddedToolCallsFunctionParameters(t *testing.T) {
+	in := `{"function": "glob", "parameters": {"pattern": "**/*.tsx"}}`
+	got := extractEmbeddedToolCalls(in)
+	if len(got) != 1 || got[0].Name != "glob" {
+		t.Errorf("got %+v, want one call with name=glob", got)
+	}
+}
+
+func TestExtractEmbeddedToolCallsToolInput(t *testing.T) {
+	in := `{"tool": "grep", "input": {"pattern": "contactSales"}}`
+	got := extractEmbeddedToolCalls(in)
+	if len(got) != 1 || got[0].Name != "grep" {
+		t.Errorf("got %+v, want one call with name=grep", got)
+	}
+}
+
+func TestExtractEmbeddedToolCallsArrayOfCalls(t *testing.T) {
+	// Some models emit multiple tool calls as a JSON array in one response.
+	in := `[
+		{"name": "read_file", "arguments": {"path": "a.go"}},
+		{"name": "read_file", "arguments": {"path": "b.go"}}
+	]`
+	got := extractEmbeddedToolCalls(in)
+	if len(got) != 2 {
+		t.Fatalf("got %d calls, want 2", len(got))
+	}
+	if got[0].Name != "read_file" || got[1].Name != "read_file" {
+		t.Errorf("names wrong: %+v", got)
+	}
+}
+
+func TestExtractEmbeddedToolCallsStripsCodeFence(t *testing.T) {
+	in := "```json\n" + `{"name": "list_dir", "arguments": {"path": "."}}` + "\n```"
+	got := extractEmbeddedToolCalls(in)
+	if len(got) != 1 || got[0].Name != "list_dir" {
+		t.Errorf("fenced JSON should parse; got %+v", got)
+	}
+}
+
+func TestExtractEmbeddedToolCallsRejectsProseWithJSON(t *testing.T) {
+	// Conservative: if the content has prose mixed with JSON,
+	// we do NOT salvage it — that's a different failure mode
+	// (model is confused about output format) and format
+	// correction is the right path, not silent salvage.
+	in := `Let me read the file. {"name": "read_file", "arguments": {"path": "foo.go"}}`
+	got := extractEmbeddedToolCalls(in)
+	if len(got) != 0 {
+		t.Errorf("prose + JSON should not salvage, got %+v", got)
+	}
+}
+
+func TestExtractEmbeddedToolCallsRejectsNonToolJSON(t *testing.T) {
+	// A JSON object that isn't a tool call — e.g. the model
+	// emits a config blob or a diff metadata wrapper — should
+	// NOT be salvaged. extractEmbeddedToolCalls only returns
+	// calls when it recognizes one of the three accepted shapes.
+	in := `{"status": "ok", "result": [1,2,3]}`
+	got := extractEmbeddedToolCalls(in)
+	if len(got) != 0 {
+		t.Errorf("non-tool-call JSON should return nothing; got %+v", got)
+	}
+}
+
+func TestExtractEmbeddedToolCallsRejectsEmpty(t *testing.T) {
+	if got := extractEmbeddedToolCalls(""); len(got) != 0 {
+		t.Errorf("empty input should return nothing; got %+v", got)
+	}
+	if got := extractEmbeddedToolCalls("   \n\n   "); len(got) != 0 {
+		t.Errorf("whitespace input should return nothing; got %+v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// fromOllamaResponse with content-embedded salvage
+// ---------------------------------------------------------------------------
+
+func TestFromOllamaResponseSalvagesContentEmbeddedToolCall(t *testing.T) {
+	// This is the exact scenario that v0.5 hit on the user's
+	// smoke test: qwen2.5-coder:14b emits a tool call as JSON
+	// in content instead of populating tool_calls. Without
+	// salvage, stop_reason becomes end_turn and the content
+	// goes to the diff validator which rejects it.
+	resp := &ollamaToolResp{
+		Model: "qwen2.5-coder:14b",
+	}
+	resp.Message.Role = "assistant"
+	resp.Message.Content = `{"name": "read_file", "arguments": {"path": "apps/marketing/src/foo.tsx"}}`
+	resp.DoneReason = "stop"
+
+	got := fromOllamaResponse(resp)
+
+	if got.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use (should have salvaged the embedded call)", got.StopReason)
+	}
+	if len(got.ToolUses) != 1 {
+		t.Fatalf("got %d tool uses, want 1", len(got.ToolUses))
+	}
+	if got.ToolUses[0].Name != "read_file" {
+		t.Errorf("tool name = %q", got.ToolUses[0].Name)
+	}
+	// Content must be cleared so downstream validators don't
+	// see the raw JSON as a diff attempt.
+	if got.Content != "" {
+		t.Errorf("Content should be cleared after salvage, got %q", got.Content)
+	}
+	// The AssistantMessage must carry the tool_use block (not
+	// a text block with the raw JSON) so the next turn's
+	// history is clean.
+	var sawToolUse, sawText bool
+	for _, b := range got.AssistantMessage.Content {
+		if b.Type == "tool_use" {
+			sawToolUse = true
+		}
+		if b.Type == "text" {
+			sawText = true
+		}
+	}
+	if !sawToolUse {
+		t.Errorf("AssistantMessage should contain a tool_use block")
+	}
+	if sawText {
+		t.Errorf("AssistantMessage should NOT contain the raw JSON as a text block")
+	}
+}
+
+func TestFromOllamaResponseMixesStructuredAndEmbeddedCalls(t *testing.T) {
+	// Unlikely real-world case but worth covering: a response
+	// that has both a structured tool_call AND a content-embedded
+	// one should end up with both tool uses, with unique
+	// correlation IDs.
+	resp := &ollamaToolResp{
+		Model: "qwen2.5-coder:14b",
+	}
+	resp.Message.Role = "assistant"
+	resp.Message.Content = `{"name": "grep", "arguments": {"pattern": "foo"}}`
+	resp.Message.ToolCalls = []ollamaToolCall{
+		{
+			Function: ollamaToolCallFunction{
+				Name:      "read_file",
+				Arguments: json.RawMessage(`{"path": "x.go"}`),
+			},
+		},
+	}
+
+	got := fromOllamaResponse(resp)
+
+	if got.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q", got.StopReason)
+	}
+	if len(got.ToolUses) != 2 {
+		t.Fatalf("got %d tool uses, want 2", len(got.ToolUses))
+	}
+	// Structured call first, embedded call second.
+	if got.ToolUses[0].Name != "read_file" {
+		t.Errorf("tool[0] = %q, want read_file (structured)", got.ToolUses[0].Name)
+	}
+	if got.ToolUses[1].Name != "grep" {
+		t.Errorf("tool[1] = %q, want grep (embedded)", got.ToolUses[1].Name)
+	}
+	if got.ToolUses[0].ID == got.ToolUses[1].ID {
+		t.Error("tool use IDs should be unique")
+	}
+}
+
+func TestFromOllamaResponsePlainContentPassesThrough(t *testing.T) {
+	// Sanity check: content that isn't a tool call (a real
+	// diff, prose, anything) passes through unchanged and
+	// stop_reason stays end_turn.
+	resp := &ollamaToolResp{
+		Model: "qwen2.5-coder:14b",
+	}
+	resp.Message.Role = "assistant"
+	resp.Message.Content = "diff --git a/x.go b/x.go\n--- a/x.go\n+++ b/x.go"
+	resp.DoneReason = "stop"
+
+	got := fromOllamaResponse(resp)
+	if got.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", got.StopReason)
+	}
+	if !strings.HasPrefix(got.Content, "diff --git") {
+		t.Errorf("Content should pass through; got %q", got.Content)
+	}
+	if len(got.ToolUses) != 0 {
+		t.Errorf("plain diff should not produce tool uses; got %+v", got.ToolUses)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// trimCodeFence helper — used by extractEmbeddedToolCalls
+// ---------------------------------------------------------------------------
+
+func TestTrimCodeFenceStripsMarkdownWrap(t *testing.T) {
+	in := "```json\n{\"name\": \"read_file\"}\n```"
+	got := trimCodeFence(in)
+	if got != `{"name": "read_file"}` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestTrimCodeFenceLeavesBareJSONAlone(t *testing.T) {
+	in := `{"name": "read_file"}`
+	got := trimCodeFence(in)
+	if got != in {
+		t.Errorf("got %q, want %q", got, in)
+	}
+}
+
+func TestTrimCodeFenceStripsPartialFences(t *testing.T) {
+	// Missing closing fence — still strip the opening one.
+	in := "```\n{\"name\": \"x\"}"
+	got := trimCodeFence(in)
+	if got != `{"name": "x"}` {
+		t.Errorf("got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

The user's first real end-to-end run on v0.5 made it all the way to the Implementer and failed with:

```
implementer: final response contains no 'diff --git' marker;
got first line: "{"
```

**Diagnosis**: qwen2.5-coder:14b via the tool-use path emitted a tool call as a JSON object in `message.content` instead of populating the structured `tool_calls` field. Known rough edge with Qwen-family tool-use training — the structured-output emitter has gaps, and in those cases the model falls back to emitting tool calls as plain JSON in the text field. LiteLLM and similar OpenAI-compatible wrappers handle it with a fallback parser. aidev now does too.

## Four fixes, layered defense in depth

### 1. Content-embedded tool-call salvage (`internal/llm/ollama_tools.go`)

New `extractEmbeddedToolCalls` scans Ollama's content string for JSON objects in any of the common tool-call wire shapes:

```json
{"name": "...", "arguments": {...}}        (Qwen, LLaMA)
{"function": "...", "parameters": {...}}   (OpenAI legacy)
{"tool": "...", "input": {...}}            (Anthropic-ish)
```

Also accepts a JSON array of calls. Strips a leading code fence. Conservative: only salvages when the ENTIRE content is a single JSON object or array. Prose + JSON mixes are NOT salvaged — that's a different failure mode and format correction (fix #2) handles it.

`fromOllamaResponse` now runs the salvage before emitting text blocks. On success, Content is cleared (so the diff validator doesn't mistake raw JSON for a diff) and the `AssistantMessage` carries `tool_use` blocks, not text blocks with JSON in them.

### 2. Format-correction retry in `runWithTools` (`internal/agents/implementer_tools.go`)

Mirrors the legacy path's format correction from #34, inside the tool-use loop. When an `end_turn` response has content that doesn't validate as a diff (and isn't an `ERROR:`), runWithTools:

1. Appends a corrective user message quoting the broken output back (first 500 chars) and tells the model what the next response must be: diff OR more tool_use OR `ERROR: <reason>`.
2. Re-calls the provider with extended history.
3. Caps at `maxToolFormatCorrections = 2`.

**Raw output is embedded in the final error message when the cap is reached** — first 2 KB of the model's output quoted verbatim. This is the debugging signal v0.4/v0.5 was missing: the user's error used to be `"first line was {"` with no way to see what came after. Now the full broken output is in the error message.

### 3. `errDeclaredError` sentinel

`validateDiffResponse` now wraps `errDeclaredError` for `ERROR:` escape-hatch responses so `runWithTools` can `errors.Is`-distinguish them from format misses. `ERROR:` propagates immediately as a terminal state; format misses go through correction. Without this, the correction loop would try to "correct" an `ERROR:` into a diff, which is silly.

### 4. Tightened `validateDiffResponse` (no more `strings.Index` scan)

**The v0.4 validator had a silent bug**: it used `strings.Index(raw, "diff --git")` to tolerate a short prose preamble. Regression: it also matched inside JSON string literals like `{"diff": "diff --git ..."}`, so a JSON-wrapped diff sneaked through as a valid diff with trailing `"}` garbage. `git apply` would then choke on the extracted "diff."

Replaced with:
- **Fast path**: `HasPrefix("diff --git")`.
- **Prose path**: regexp match for `diff --git` at the START of a line (not inside a string literal), capped at 500 chars of preamble.
- **Everything else**: reject, trigger format correction.

The new regression test `TestImplementerRunToolPathRecoversFromMalformedFinalContent` actually caught this bug — the validator used to accept `{"diff": "diff --git ..."}` silently; now it rejects and the format-correction retry recovers.

### 5. Tool-use system prompt strengthening

Two new CRITICAL rules:
- **How to call tools**: use native `tool_calls`, NOT JSON in content. Explicitly tells the model that content-embedded JSON will be rejected.
- **How to emit the final diff**: literal unified diff text, not a JSON wrapper, not a code fence, not prefaced with prose.

Belt-and-braces. Fixes 1 + 2 catch the cases where the model ignores these rules, but the rules reduce the probability of the rules being ignored in the first place.

## Tests — 17 new cases

**`extractEmbeddedToolCalls`** (8): three wire-shape variants, array form, code fence stripping, prose-with-JSON rejection, non-tool-call JSON rejection, empty input rejection.

**`fromOllamaResponse`** (3): salvage path, mixed structured+embedded calls with unique IDs, plain content passes through unchanged.

**`trimCodeFence`** (3): wrapped, bare, partial fence.

**`runWithTools` format correction** (3):
- `TestImplementerRunToolPathRecoversFromMalformedFinalContent` — the regression guard for the user's exact failure (JSON-wrapper content, correction turn produces a clean diff, round-trip verified)
- `TestImplementerRunToolPathFailsAfterRepeatedMalformedOutput` — format-correction cap + raw output in final error
- `TestImplementerRunToolPathFormatCorrectionNotTriggeredOnERROR` — ERROR: propagates as terminal state, format correction is NOT attempted

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all 17 new tests + existing suite pass
- [ ] User runs `/aidev-run 533` against the new stack. Expected flow:
  1. Scout runs → Gate 0 monitor → Critic runs → Gate 1 monitor → Architect → Gate 2 monitor → Implementer dispatches to runWithTools via Ollama tool-use path.
  2. If qwen2.5-coder:14b emits a content-embedded tool call, fromOllamaResponse salvages it transparently and the pipeline continues.
  3. If the model's final turn is malformed, runWithTools sends a format correction and the model produces a real diff on the retry.
  4. Coordinator Gate 4 reviews the final diff.
  5. If anything STILL fails, the error message includes the first 2 KB of the model's raw output so we can see exactly what happened.