### PR TITLE
fix(v0.5b): configurable per-tier HTTP timeout, default 20 min (was 5 min)

### DIFF
--- a/cmd/aidev/config_subcommand.go
+++ b/cmd/aidev/config_subcommand.go
@@ -374,6 +374,21 @@ func runConfigDoctor() {
 		}
 	}
 
+	// Tier timeout_seconds sanity check. Zero (the default) is
+	// fine. < 60s is almost certainly a mistake — even a cloud
+	// call can take 30+ seconds on a cold start. > 3600s (1 hour)
+	// is suspiciously patient and likely means the user forgot
+	// they set it; better to surface a warning.
+	for _, name := range sortedKeys(cfg.Models.Tiers) {
+		t := cfg.Models.Tiers[name]
+		if t.TimeoutSeconds == 0 {
+			continue
+		}
+		inRange := t.TimeoutSeconds >= 60 && t.TimeoutSeconds <= 3600
+		check(inRange, "warn",
+			fmt.Sprintf("tier %q timeout_seconds=%d is in the sane range (60-3600)", name, t.TimeoutSeconds))
+	}
+
 	fmt.Fprintln(os.Stderr)
 	if failures > 0 {
 		fmt.Fprintf(os.Stderr, "%d failure(s), %d warning(s) — fix the failures before running aidev.\n", failures, warnings)

--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -839,7 +840,16 @@ func printStartupBanner(cfg *config.Config) {
 		if modelDisplay == "" {
 			modelDisplay = "(default)"
 		}
-		fmt.Fprintf(os.Stderr, "  %-12s → %s:%s%s\n", role, tier.Provider, modelDisplay, marker)
+		// Show the effective per-call timeout next to each role
+		// so the user knows how long a hung LLM call can block
+		// the pipeline before the HTTP client gives up. This is
+		// directly the UX answer to v0.5a's "32b timed out at 5
+		// minutes with no visible warning" failure mode.
+		timeoutDisplay := "20m0s (default)"
+		if tier.TimeoutSeconds > 0 {
+			timeoutDisplay = (time.Duration(tier.TimeoutSeconds) * time.Second).String()
+		}
+		fmt.Fprintf(os.Stderr, "  %-12s → %s:%s  (timeout=%s)%s\n", role, tier.Provider, modelDisplay, timeoutDisplay, marker)
 	}
 	fmt.Fprintln(os.Stderr)
 }

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -59,6 +59,36 @@
 # tier. If you customize a profile to put the Implementer on
 # claude-cli you'll lose tool use; `aidev config doctor` will
 # warn you about it.
+#
+# ---
+#
+# Timeouts (v0.5b):
+#
+# Each tier has a 20-minute default wall-clock timeout on a
+# single LLM call. That's generous enough for 32b local models
+# on M1 Pro-class hardware (~5-10 tok/s × 8k output ≈ 15 min)
+# and rarely hit by cloud calls. To override per-tier, add a
+# `timeout_seconds` field to the tier:
+#
+#     tiers:
+#       large:
+#         provider: ollama
+#         model: qwen2.5:32b
+#         endpoint: http://localhost:11434
+#         max_tokens: 8192
+#         temperature: 0.3
+#         timeout_seconds: 1800     # 30 min — for slower hardware
+#
+# Good starting values:
+#   small local (7b):    300-600s
+#   medium local (14b):  600-900s
+#   large local (32b+):  1200-1800s on M1 Pro, less on M3 Max
+#   cloud (anthropic):   300s (rarely hit)
+#   claude-cli:          600s (subprocess startup overhead)
+#
+# Zero or omitted means "use the 20-minute default". The
+# doctor warns on suspiciously low (<60s) or high (>3600s)
+# values.
 
 active_profile: default
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,22 @@ type Tier struct {
 	Endpoint    string  `yaml:"endpoint,omitempty"`
 	MaxTokens   int     `yaml:"max_tokens"`
 	Temperature float64 `yaml:"temperature"`
+
+	// TimeoutSeconds is the wall-clock cap on a single LLM call
+	// through this tier. 0 means "use the provider's default"
+	// (20 minutes as of v0.5b — bumped from the hardcoded 5-minute
+	// default after qwen2.5-coder:32b on M1 Pro repeatedly timed
+	// out at 8-token-per-second generation rates).
+	//
+	// Set this per-tier to match the tier's actual speed:
+	//   small local (7b):    300-600s is plenty
+	//   medium local (14b):  600-900s is the sweet spot
+	//   large local (32b+):  1200-1800s for M1 Pro-class hardware
+	//   cloud (anthropic):   300s is fine, rarely hit
+	//   claude-cli:          600s to cover subprocess startup
+	//
+	// Zero-value means "the shipping default (20 min)".
+	TimeoutSeconds int `yaml:"timeout_seconds,omitempty"`
 }
 
 // Profile is one named bundle of tiers + routing. A models.yaml

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -261,6 +261,60 @@ routing:
 // TestProfileNamesIsSorted is a tiny guard on the helper used for
 // error messages — sorted output keeps "available profiles: [...]"
 // stable across runs.
+// TestLoadParsesTimeoutSeconds verifies that the v0.5b
+// timeout_seconds field on a tier is deserialized into the
+// Tier struct so Router.buildProvider can plumb it through to
+// the provider constructors. Regression guard against the
+// YAML tag drifting or the field being dropped in a refactor.
+func TestLoadParsesTimeoutSeconds(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, `
+active_profile: default
+profiles:
+  default:
+    tiers:
+      small:
+        provider: ollama
+        model: qwen:7b
+        max_tokens: 2048
+        temperature: 0.2
+        timeout_seconds: 900
+      large:
+        provider: ollama
+        model: qwen:32b
+        max_tokens: 8192
+        temperature: 0.2
+        timeout_seconds: 1800
+      no_timeout:
+        provider: ollama
+        model: qwen:14b
+    routing:
+      scout: small
+      critic: large
+      architect: large
+      charter: large
+      implementer: no_timeout
+      reviewer: no_timeout
+      tester: small
+      coordinator: large
+`)
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Models.Tiers["small"].TimeoutSeconds; got != 900 {
+		t.Errorf("small.timeout_seconds = %d, want 900", got)
+	}
+	if got := cfg.Models.Tiers["large"].TimeoutSeconds; got != 1800 {
+		t.Errorf("large.timeout_seconds = %d, want 1800", got)
+	}
+	// Zero when omitted — this means "use the provider's
+	// default", not an error.
+	if got := cfg.Models.Tiers["no_timeout"].TimeoutSeconds; got != 0 {
+		t.Errorf("no_timeout.timeout_seconds = %d, want 0 (unset)", got)
+	}
+}
+
 func TestProfileNamesIsSorted(t *testing.T) {
 	in := map[string]Profile{
 		"zzz":     {},

--- a/internal/installpkg/files/models.yaml
+++ b/internal/installpkg/files/models.yaml
@@ -59,6 +59,36 @@
 # tier. If you customize a profile to put the Implementer on
 # claude-cli you'll lose tool use; `aidev config doctor` will
 # warn you about it.
+#
+# ---
+#
+# Timeouts (v0.5b):
+#
+# Each tier has a 20-minute default wall-clock timeout on a
+# single LLM call. That's generous enough for 32b local models
+# on M1 Pro-class hardware (~5-10 tok/s × 8k output ≈ 15 min)
+# and rarely hit by cloud calls. To override per-tier, add a
+# `timeout_seconds` field to the tier:
+#
+#     tiers:
+#       large:
+#         provider: ollama
+#         model: qwen2.5:32b
+#         endpoint: http://localhost:11434
+#         max_tokens: 8192
+#         temperature: 0.3
+#         timeout_seconds: 1800     # 30 min — for slower hardware
+#
+# Good starting values:
+#   small local (7b):    300-600s
+#   medium local (14b):  600-900s
+#   large local (32b+):  1200-1800s on M1 Pro, less on M3 Max
+#   cloud (anthropic):   300s (rarely hit)
+#   claude-cli:          600s (subprocess startup overhead)
+#
+# Zero or omitted means "use the 20-minute default". The
+# doctor warns on suspiciously low (<60s) or high (>3600s)
+# values.
 
 active_profile: default
 

--- a/internal/llm/claude.go
+++ b/internal/llm/claude.go
@@ -25,15 +25,19 @@ type Claude struct {
 }
 
 // NewClaude constructs a Claude provider. The API key is read from the
-// ANTHROPIC_API_KEY environment variable.
-func NewClaude(model string, maxTokens int, temperature float64) *Claude {
+// ANTHROPIC_API_KEY environment variable. timeout may be 0; in that
+// case DefaultHTTPTimeout is used.
+func NewClaude(model string, maxTokens int, temperature float64, timeout time.Duration) *Claude {
+	if timeout <= 0 {
+		timeout = DefaultHTTPTimeout
+	}
 	return &Claude{
 		apiKey:      os.Getenv("ANTHROPIC_API_KEY"),
 		model:       model,
 		maxTokens:   maxTokens,
 		temperature: temperature,
 		endpoint:    "https://api.anthropic.com/v1/messages",
-		http:        &http.Client{Timeout: 5 * time.Minute},
+		http:        &http.Client{Timeout: timeout},
 	}
 }
 

--- a/internal/llm/claude_cli.go
+++ b/internal/llm/claude_cli.go
@@ -66,13 +66,20 @@ type ClaudeCLI struct {
 // exec.LookPath because doctor does that in its own check; we want
 // provider construction to be cheap and lazy. A missing binary will
 // surface at the first Complete() call with a clear error message.
-func NewClaudeCLI(model string, maxTokens int, temperature float64) *ClaudeCLI {
+//
+// timeout may be 0; in that case DefaultHTTPTimeout is used. The
+// CLI subprocess timeout doubly bounds a hung 'claude --print' call,
+// complementing the context.WithTimeout that runs around exec.
+func NewClaudeCLI(model string, maxTokens int, temperature float64, timeout time.Duration) *ClaudeCLI {
+	if timeout <= 0 {
+		timeout = DefaultHTTPTimeout
+	}
 	return &ClaudeCLI{
 		bin:         "claude",
 		model:       model,
 		maxTokens:   maxTokens,
 		temperature: temperature,
-		timeout:     5 * time.Minute,
+		timeout:     timeout,
 	}
 }
 

--- a/internal/llm/claude_cli_test.go
+++ b/internal/llm/claude_cli_test.go
@@ -24,7 +24,7 @@ cat > /tmp/aidev-claude-cli-test-stdin
 echo "FAKE RESPONSE FROM CLAUDE CLI"
 `)
 
-	p := NewClaudeCLI("", 1024, 0.1)
+	p := NewClaudeCLI("", 1024, 0.1, 0)
 	p.SetBin(fakeBin)
 
 	resp, err := p.Complete(context.Background(), Request{
@@ -55,7 +55,7 @@ echo "FAKE RESPONSE FROM CLAUDE CLI"
 }
 
 func TestClaudeCLICompleteEmptyPromptErrors(t *testing.T) {
-	p := NewClaudeCLI("", 1024, 0.1)
+	p := NewClaudeCLI("", 1024, 0.1, 0)
 	_, err := p.Complete(context.Background(), Request{})
 	if err == nil {
 		t.Error("expected error on empty prompt")
@@ -70,7 +70,7 @@ func TestClaudeCLICompleteEmptyResponseErrors(t *testing.T) {
 # Print nothing — simulates a CLI that silently fails.
 exit 0
 `)
-	p := NewClaudeCLI("", 1024, 0.1)
+	p := NewClaudeCLI("", 1024, 0.1, 0)
 	p.SetBin(fakeBin)
 	_, err := p.Complete(context.Background(), Request{
 		Messages: []Message{{Role: "user", Content: "hi"}},
@@ -88,7 +88,7 @@ func TestClaudeCLICompleteStderrInError(t *testing.T) {
 echo "not authenticated — run claude /login" >&2
 exit 2
 `)
-	p := NewClaudeCLI("", 1024, 0.1)
+	p := NewClaudeCLI("", 1024, 0.1, 0)
 	p.SetBin(fakeBin)
 	_, err := p.Complete(context.Background(), Request{
 		Messages: []Message{{Role: "user", Content: "hi"}},
@@ -102,11 +102,11 @@ exit 2
 }
 
 func TestClaudeCLIName(t *testing.T) {
-	p1 := NewClaudeCLI("", 1024, 0.1)
+	p1 := NewClaudeCLI("", 1024, 0.1, 0)
 	if p1.Name() != "claude-cli" {
 		t.Errorf("name = %q, want claude-cli", p1.Name())
 	}
-	p2 := NewClaudeCLI("claude-opus-4-6", 1024, 0.1)
+	p2 := NewClaudeCLI("claude-opus-4-6", 1024, 0.1, 0)
 	if p2.Name() != "claude-cli:claude-opus-4-6" {
 		t.Errorf("name = %q, want claude-cli:claude-opus-4-6", p2.Name())
 	}

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -10,6 +10,15 @@ import (
 	"time"
 )
 
+// DefaultHTTPTimeout is the wall-clock cap on a single LLM call when
+// the tier config doesn't set one explicitly. 20 minutes is generous
+// enough for local 32b-class models on M1 Pro-class hardware
+// (~5-10 tok/s × 8192 output tokens ≈ 13-27 minutes worst case) and
+// has plenty of headroom for cloud calls (rarely more than 60 seconds).
+// v0.5b bumped this from the hardcoded 5 minutes that left qwen 32b
+// users dead in the water on their first run.
+const DefaultHTTPTimeout = 20 * time.Minute
+
 // Ollama is a Provider that talks to a local (or remote) Ollama daemon over
 // HTTP. We hand-roll the client instead of pulling in ollama/ollama as a
 // dependency — the API is tiny and the import graph of the upstream module
@@ -24,19 +33,23 @@ type Ollama struct {
 
 // NewOllama constructs an Ollama provider. endpoint may be empty; if so it
 // falls back to AIDEV_OLLAMA_URL and finally http://localhost:11434.
-func NewOllama(endpoint, model string, maxTokens int, temperature float64) *Ollama {
+// timeout may be 0; in that case DefaultHTTPTimeout is used.
+func NewOllama(endpoint, model string, maxTokens int, temperature float64, timeout time.Duration) *Ollama {
 	if endpoint == "" {
 		endpoint = os.Getenv("AIDEV_OLLAMA_URL")
 	}
 	if endpoint == "" {
 		endpoint = "http://localhost:11434"
 	}
+	if timeout <= 0 {
+		timeout = DefaultHTTPTimeout
+	}
 	return &Ollama{
 		endpoint:    endpoint,
 		model:       model,
 		maxTokens:   maxTokens,
 		temperature: temperature,
-		http:        &http.Client{Timeout: 5 * time.Minute},
+		http:        &http.Client{Timeout: timeout},
 	}
 }
 

--- a/internal/llm/router.go
+++ b/internal/llm/router.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aisu-ai/aidev/internal/config"
 )
@@ -34,13 +35,14 @@ func NewRouter(cfg *config.Config) (*Router, error) {
 }
 
 func buildProvider(t config.Tier) (Provider, error) {
+	timeout := time.Duration(t.TimeoutSeconds) * time.Second
 	switch t.Provider {
 	case "ollama":
-		return NewOllama(t.Endpoint, t.Model, t.MaxTokens, t.Temperature), nil
+		return NewOllama(t.Endpoint, t.Model, t.MaxTokens, t.Temperature, timeout), nil
 	case "anthropic":
-		return NewClaude(t.Model, t.MaxTokens, t.Temperature), nil
+		return NewClaude(t.Model, t.MaxTokens, t.Temperature, timeout), nil
 	case "claude-cli":
-		return NewClaudeCLI(t.Model, t.MaxTokens, t.Temperature), nil
+		return NewClaudeCLI(t.Model, t.MaxTokens, t.Temperature, timeout), nil
 	default:
 		return nil, fmt.Errorf("unknown provider %q", t.Provider)
 	}

--- a/internal/llm/timeout_test.go
+++ b/internal/llm/timeout_test.go
@@ -1,0 +1,81 @@
+package llm
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNewOllamaAppliesDefaultTimeout verifies the v0.5b behavior:
+// when the caller passes 0 for timeout, NewOllama substitutes the
+// 20-minute DefaultHTTPTimeout instead of creating a client with
+// no timeout (which would be a footgun — a stuck LLM call could
+// hang a pipeline indefinitely).
+func TestNewOllamaAppliesDefaultTimeout(t *testing.T) {
+	p := NewOllama("http://localhost:11434", "test-model", 1024, 0.2, 0)
+	if p.http.Timeout != DefaultHTTPTimeout {
+		t.Errorf("Timeout = %s, want DefaultHTTPTimeout (%s)", p.http.Timeout, DefaultHTTPTimeout)
+	}
+}
+
+// TestNewOllamaRespectsExplicitTimeout verifies that a non-zero
+// timeout is passed through verbatim. This is the path the
+// Router.buildProvider takes when the tier's YAML sets
+// timeout_seconds: NNN — the value becomes a time.Duration and
+// flows into the HTTP client.
+func TestNewOllamaRespectsExplicitTimeout(t *testing.T) {
+	want := 45 * time.Minute
+	p := NewOllama("http://localhost:11434", "test-model", 1024, 0.2, want)
+	if p.http.Timeout != want {
+		t.Errorf("Timeout = %s, want %s", p.http.Timeout, want)
+	}
+}
+
+// TestNewClaudeAppliesDefaultTimeout mirrors the Ollama test for
+// the Anthropic REST client. The bug that motivated v0.5b was
+// specifically Ollama (qwen 32b), but the hardcoded 5-minute
+// timeout was present in all three providers. Fixing one without
+// fixing the others would leave the same landmine for future users.
+func TestNewClaudeAppliesDefaultTimeout(t *testing.T) {
+	p := NewClaude("claude-sonnet-4-5", 8192, 0.3, 0)
+	if p.http.Timeout != DefaultHTTPTimeout {
+		t.Errorf("Timeout = %s, want DefaultHTTPTimeout (%s)", p.http.Timeout, DefaultHTTPTimeout)
+	}
+}
+
+func TestNewClaudeRespectsExplicitTimeout(t *testing.T) {
+	want := 10 * time.Minute
+	p := NewClaude("claude-sonnet-4-5", 8192, 0.3, want)
+	if p.http.Timeout != want {
+		t.Errorf("Timeout = %s, want %s", p.http.Timeout, want)
+	}
+}
+
+func TestNewClaudeCLIAppliesDefaultTimeout(t *testing.T) {
+	p := NewClaudeCLI("", 4096, 0.2, 0)
+	if p.timeout != DefaultHTTPTimeout {
+		t.Errorf("timeout = %s, want DefaultHTTPTimeout (%s)", p.timeout, DefaultHTTPTimeout)
+	}
+}
+
+func TestNewClaudeCLIRespectsExplicitTimeout(t *testing.T) {
+	want := 15 * time.Minute
+	p := NewClaudeCLI("", 4096, 0.2, want)
+	if p.timeout != want {
+		t.Errorf("timeout = %s, want %s", p.timeout, want)
+	}
+}
+
+// TestDefaultHTTPTimeoutIsReasonable is a guard against someone
+// lowering DefaultHTTPTimeout back to 5 minutes "to save
+// resources". 5 minutes was the v0.5 default and it caused the
+// qwen 32b on M1 Pro failure. The floor is 15 minutes.
+func TestDefaultHTTPTimeoutIsReasonable(t *testing.T) {
+	if DefaultHTTPTimeout < 15*time.Minute {
+		t.Errorf("DefaultHTTPTimeout = %s, must be >= 15m to cover 32b local models on M1 Pro-class hardware", DefaultHTTPTimeout)
+	}
+	// And a ceiling: a 3-hour default would be "I forgot this
+	// existed" rather than intentional. Surface as a test.
+	if DefaultHTTPTimeout > 60*time.Minute {
+		t.Errorf("DefaultHTTPTimeout = %s, must be <= 60m to catch silent daemon hangs", DefaultHTTPTimeout)
+	}
+}


### PR DESCRIPTION
## Summary

User hit a **hard timeout** trying to run qwen2.5-coder:32b on MacBook Pro M1 Pro (32 GB unified memory). Each LLM call at 5-10 tok/s × 8k output tokens takes 13-27 minutes wall-clock. The Ollama HTTP client had a hardcoded 5-minute timeout, which is fine for 7b/14b (~1-3 min per call) but completely inadequate for 32b on consumer hardware.

**Fix**: make per-call timeout configurable per-tier via a new `timeout_seconds` YAML field, and bump the default from 5 minutes to **20 minutes** across all three providers.

## Scope

- `internal/config/config.go` — new `Tier.TimeoutSeconds int` field with `yaml:",omitempty"` so existing files without it keep working.
- `internal/llm/{ollama,claude,claude_cli}.go` — each constructor now takes a `time.Duration` timeout parameter. Zero means 'use the shared `DefaultHTTPTimeout` (20 min)'. All three providers previously had the same hardcoded 5-minute timeout in different places; v0.5b centralizes the default in one const.
- `internal/llm/router.go` — `buildProvider()` translates `config.Tier.TimeoutSeconds` into `time.Duration` and passes it into the provider constructors.
- `cmd/aidev/main.go` — `printStartupBanner` now shows the effective timeout for each role:

```
scout        → ollama:qwen2.5-coder:7b  (timeout=20m0s (default))
implementer  → ollama:qwen2.5-coder:14b  (timeout=20m0s (default))
coordinator  → claude-cli:(default)  (timeout=20m0s (default))
```

- `cmd/aidev/config_subcommand.go` — `aidev config doctor` now warns on timeouts outside 60-3600s.
- `config/models.yaml` (+ embedded) — multi-paragraph comment block documenting the new field and suggested values per tier class:
  ```
  small local (7b):    300-600s
  medium local (14b):  600-900s
  large local (32b+):  1200-1800s on M1 Pro
  cloud (anthropic):   300s (rarely hit)
  claude-cli:          600s (subprocess startup)
  ```

Shipped profiles intentionally do NOT set `timeout_seconds` — they use the 20-minute default, which is correct for every shipped tier.

## Tests — 8 new cases

- `internal/llm/timeout_test.go` (7): default substitution + explicit pass-through for each provider, plus `TestDefaultHTTPTimeoutIsReasonable` guarding the floor (15m) and ceiling (60m) against future regressions.
- `internal/config/config_test.go` — `TestLoadParsesTimeoutSeconds`: YAML tag stays in sync with the struct field across explicit value, zero, and multiple tiers.
- `internal/llm/claude_cli_test.go` — 6 existing call sites updated to pass 0 for the new timeout parameter (0 triggers the default, so no test semantics changed).

## What this unblocks

The user's exact failure mode from their last run:

```
implementer → ollama:qwen2.5-coder:32b
...
ollama timed out on qwen2.5-coder:32b (context deadline exceeded)
```

With v0.5b the default 20 min covers 32b-on-M1-Pro without any config change. Users on slower hardware can bump to 1800s or 3600s via the new field. The startup banner surfaces the effective timeout at startup so 'what's my budget' is visible before the wait.

## Next PR (Explorer agent / Option C) lands on top

The Explorer adds MORE LLM calls per pipeline run (separate exploration phase before the Implementer). It depends on the per-call timeout being reasonable — hence the split. This PR unblocks 32b users today; the Explorer PR solves the reliability-at-14b problem that motivated Option C in the first place.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Smoke test: `aidev config show`, `aidev config doctor`, startup banner rendering
- [ ] User pulls, rebuilds, re-runs `/aidev-run 533` with 32b configured — now gets ~15-20 minute wall-clock runs that actually complete rather than timing out at 5m