### PR TITLE
docs: restructure into landing README + topic pages + Jekyll Pages config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,308 +1,43 @@
 # aidev
 
-> A local multi-agent coding assistant that **argues with you before it writes code**. Built in Go. Works with your Claude Max/Pro subscription — no API key required.
+> A local multi-agent coding pipeline for Claude Code that **argues with you before it writes code**, then ships the approved work autonomously — branch cut, implementation, tests, PR, autonomous review loop — all without line-by-line human intervention. Built in Go. Works with your Claude Max/Pro subscription — no API key required.
 
-```sh
-gh repo clone AiSU-AI/aidev ~/code/personal/aidev   # or git clone with SSH
-cd ~/code/personal/aidev
-./install.sh
-```
-
-Then, from inside any Claude Code session:
-
-```
-/aidev-run https://github.com/your-org/your-repo/issues/42 ~/code/your-repo
-```
-
-...or from your terminal:
-
-```sh
-aidev -issue https://github.com/your-org/your-repo/issues/42 -repo ~/code/your-repo
-```
-
----
-
-## What aidev actually does
-
-You give aidev a GitHub issue and a local repo. It runs a sequence of agents that each do one thing well:
-
-1. **Scout** reads your repo (README, `CLAUDE.md`, `ARCHITECTURE.md`, file layout) and produces a factual brief.
-2. **Critic** takes the issue + brief + your engineering principles and argues both sides: is this change worth making? It ends with `RECOMMENDATION: build | defer | kill | unclear`. This is the feature aidev is built around — everything else exists because the Critic said *yes*.
-3. You approve (or kill).
-4. **Architect** produces N meaningfully different solution sketches (default 3) with trade-offs, risks, and principle alignment for each. You pick one.
-5. **Implementer** generates a unified git diff. Two turns: it asks which files it needs, you get those, it writes the patch. Saved to `.aidev/proposed.patch` — aidev never touches your source files directly, you `git apply` when you're ready.
-6. **Tester** runs your project's detected test suite (go / cargo / pytest / npm / gradle / make). Optionally inside a Docker sandbox.
-7. **Reviewer** does a Boy Scout pass on the patch: blockers, suggestions, and proposed follow-up issues.
-
-Every step posts to the issue's GitHub thread as a running audit trail, with one pinned status comment + one-shot artifact comments per phase, and a rotating `aidev:<phase>` label so the Issues page becomes a kanban view of what aidev is doing across every repo.
-
-## Why this shape
-
-Several tools already turn issues into patches (aider, plandex, opencode, goose, Claude Code itself). None of them *argue with you first*. If the Critic decides the feature shouldn't exist, aidev tells you that and stops — it doesn't sheepishly try to implement a thing it thinks is a bad idea. That's the differentiator.
-
-The rest of the pipeline is designed around the same principle: **propose, never mutate**. Implementer writes a diff, doesn't apply it. Reviewer proposes follow-up issues, doesn't file them. Tester can run inside a container if you don't trust the patch yet. Every safety decision defaults to the narrower option.
-
-## Install
-
-**Quick install** (downloads the latest pre-built binary, no Go required):
+## Quick install
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/AiSU-AI/aidev/main/install.sh | bash -s -- --from-release
 ```
 
-**From source** (requires Go 1.24+, useful for contributors or if you want to track `main`):
+See [docs/install.md](docs/install.md) for the from-source path, installer flags, and full prereqs.
 
-```sh
-gh repo clone AiSU-AI/aidev ~/code/personal/aidev    # or: git clone git@github.com:AiSU-AI/aidev.git ~/code/personal/aidev
-cd ~/code/personal/aidev
-./install.sh
-```
+## First run
 
-The installer:
-
-1. Builds the binary with `go build`
-2. Copies it to `~/.local/bin/aidev` (or `~/bin` or `/usr/local/bin`, first writable dir on PATH)
-3. Writes default config to `~/.config/aidev/{models,principles}.yaml`
-4. Installs Claude Code slash commands to `~/.claude/commands/aidev-*.md`
-5. Runs `aidev doctor` to smoke-test the environment
-6. Prints next steps
-
-If the install dir isn't on your PATH already, the script will tell you the exact `export PATH=...` line to add to `~/.zshrc` or `~/.bashrc`.
-
-### Flags
-
-```sh
-./install.sh --bin ~/bin        # override target bin directory
-./install.sh --from-source      # force build mode (the default when Go is present)
-./install.sh --from-release     # download from a GitHub release (requires the repo to be public OR GITHUB_TOKEN with contents:read access)
-./install.sh --version v0.2f    # pin a specific release tag (release mode only)
-./install.sh --force            # overwrite existing binary/config/plugin files
-./install.sh --no-doctor        # skip the post-install smoke test
-./install.sh --no-prereqs       # skip the 'suggest installing ollama' check
-```
-
-### Future: one-line install via release binaries
-
-The install script has a release-download mode that would let anyone run:
-
-```sh
-curl -sSL https://raw.githubusercontent.com/AiSU-AI/aidev/main/install.sh | bash
-```
-
-without cloning the repo or having Go installed. That flow only works when `AiSU-AI/aidev` is public or when the user has a `GITHUB_TOKEN` with read access. The `v*` tag → GitHub Actions → release-asset pipeline is in place (`.github/workflows/release.yaml`); once the repo goes public, the `curl | bash` one-liner becomes the canonical install path and replaces the clone-first flow above.
-
-### Requirements
-
-- **macOS or Linux.** Windows is not supported yet — the TUI has POSIX-isms.
-- **Go 1.24+** to build from source. Install from https://go.dev/dl/.
-- **[Claude Code](https://claude.ai/download)** installed and logged in (`claude /login`). aidev's medium and large tiers route through `claude --print`, so agent calls bill against your Max/Pro subscription. No `ANTHROPIC_API_KEY` required for the default config.
-- **[Ollama](https://ollama.com)** for the small tier (Scout, Tester failure summary). Optional — you can route the small tier through the claude CLI too by editing `config/models.yaml`, at the cost of subscription tokens.
-- **`GITHUB_TOKEN`** in your environment for reading private issues and posting the audit trail (`Issues: Read and write` scope). The same token is also used for `git push` if your repo access is HTTPS-based.
-
-Run `aidev doctor` at any point to verify the environment. If Ollama is installed but not running, doctor will spawn `ollama serve` in the background automatically.
-
-## Usage
-
-### Typical flow (interactive TUI)
-
-```sh
-aidev -issue https://github.com/your-org/your-repo/issues/42 -repo ~/code/your-repo
-```
-
-| Key | Action |
-|-----|--------|
-| `r` | Run Scout + Critic |
-| `a` | Approve Critic's recommendation → kick off Architect |
-| `1`–`9` | After sketches appear, pick one → kick off Implementer |
-| `t` | After patch is ready: run the test suite |
-| `v` | After patch is ready: run the Reviewer |
-| `k` | Kill the proposal |
-| `tab` | Cycle pane focus |
-| `q` / `ctrl+c` | Quit |
-
-The rightmost pane retitles as the pipeline advances: **Critic report** → **Architect sketches** → **Implementer patch** → **Test result** → **Review**. Earlier phases live in the GitHub audit trail on the issue, so the TUI doesn't try to preserve history.
-
-### From inside Claude Code (slash commands)
-
-Once `aidev plugin install` has dropped the slash commands, type `/` in any Claude Code session and you'll see:
-
-| Command | Effect |
-|---|---|
-| `/aidev-run <issue-url> <repo-path>` | Full pipeline: scout → critic → architect → sketch 1 → implementer |
-| `/aidev-doctor` | Environment audit |
-| `/aidev-charter <repo-path>` | 5-question interview to produce `.aidev/charter.md` |
-| `/aidev-test <repo-path>` | Run detected test suite, summarise failures |
-| `/aidev-review <issue-url> <repo-path>` | Boy Scout pass on the current proposed patch |
-
-### Headless (CI-friendly)
-
-```sh
-# Scout + Critic only
-aidev -headless -issue <url> -repo <path>
-
-# + auto-run Architect when Critic recommends "build"
-aidev -headless -auto -n 3 -issue <url> -repo <path>
-
-# + auto-run Implementer on sketch 1
-aidev -headless -auto -sketch 1 -issue <url> -repo <path>
-```
-
-Writes the diff to `.aidev/proposed.patch` and prints the full Markdown report to stdout.
-
-### Standalone subcommands
-
-```sh
-aidev doctor                                # environment audit
-aidev charter -repo <path>                  # interactive product charter interview
-aidev clarify -issue <url> -repo <path>     # structured question graph for ambiguities
-aidev test -repo <path>                     # run detected test suite
-aidev test -repo <path> --sandbox --image golang:1.24   # run tests inside Docker
-aidev review -issue <url> -repo <path>      # Boy Scout pass on .aidev/proposed.patch
-aidev followups -repo <path>                # dry-run review of proposed follow-up issues
-aidev followups -repo <path> --file-issues --target owner/repo   # actually file them
-aidev plugin install                        # install Claude Code slash commands
-aidev install                               # (re)install default config to ~/.config/aidev
-aidev --version                             # print the embedded build version
-```
-
-## Configuration
-
-### `~/.config/aidev/models.yaml`
-
-Three tiers (`small`, `medium`, `large`) mapped to providers (`ollama`, `anthropic`, `claude-cli`), plus a role-to-tier routing table. The shipped defaults:
-
-```yaml
-tiers:
-  small:  { provider: ollama,     model: qwen2.5-coder:7b,  ... }
-  medium: { provider: claude-cli, model: "" }
-  large:  { provider: claude-cli, model: "" }
-routing:
-  scout: small
-  critic: large
-  architect: large
-  charter: large
-  clarifier: large
-  implementer: medium
-  reviewer: medium
-  tester: small
-```
-
-Want the Critic on the direct Anthropic API with a specific model? Change one line:
-
-```yaml
-large: { provider: anthropic, model: claude-opus-4-6 }
-```
-
-and export `ANTHROPIC_API_KEY`. Want Scout on Claude instead of local Ollama? Change `scout: small` to `scout: large`.
-
-### `~/.config/aidev/principles.yaml`
-
-The living charter the Critic uses when arguing whether a feature should ship. Starts with "Should this exist?", Boy Scout Rule, DRY, YAGNI, Well-Architected, Single Responsibility, Fail Loudly at Boundaries, Tests Describe Intent, and Reversibility. Add your own; the Critic cites them by name.
-
-A target repo can also ship its own `.aidev/principles.yaml` which is merged on top of the global set — useful when an organisation has a standards repo (`ai-dev-standards`) that downstream projects inherit from.
-
-### `.aidev/charter.md` (per-repo)
-
-When a target repo has no strong signal — no README, no `CLAUDE.md`, no `ARCHITECTURE.md` — the Critic has nothing to anchor against. Run `aidev charter -repo <path>` to sit through a 5-question interview and produce `<repo>/.aidev/charter.md`. The Scout automatically absorbs it on every subsequent run and the Critic cites it when pushing back on proposals.
-
-### `.aidev/clarifier.md` (per-repo, per-session)
-
-After the Critic flags ambiguities in a proposal, run `aidev clarify -issue ... -repo ...` to get a structured dependency-aware question graph. Independent questions batch, chained questions serialise. Your answers get written to `.aidev/clarifier.md` and the next Architect run absorbs them as context.
-
-## The full agent pipeline
+From inside any Claude Code session in the target repo:
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│ Orchestrator (state machine + Reporter fanout)                      │
-└──┬──────┬──────┬─────┬──────┬──────┬─────┬──────┬──────┬────────────┘
-   │      │      │     │      │      │     │      │      │
- Scout  Critic  (Clarifier) Architect Charter Implementer Tester Reviewer
- (sm)   (lg)    (lg)        (lg)      (lg)    (md, 2-turn) (sm)  (md)
-
- sm = small tier, ollama by default
- md = medium tier, claude-cli by default
- lg = large tier,  claude-cli by default
+/aidev-run 42 .
 ```
 
-- **Scout** (extractive, small tier)
-- **Critic** (adversarial, large tier) — the keystone
-- **Architect** (divergent sketches, large tier)
-- **Charter / Clarifier** (opt-in standalone subcommands)
-- **Implementer** (generative, medium tier, two-turn file-content loading)
-- **Tester** (detected test runner, small tier for failure summaries, optional Docker sandbox)
-- **Reviewer** (Boy Scout pass, medium tier)
+(The first arg is an issue number or URL; the second is the local repo path.) aidev runs the full autonomous pipeline — Scout → Critic → Architect → Selector → implementation → tests → PR → review loop — and lands a mergeable PR in your tree.
 
-## Troubleshooting
+## Docs
 
-| Problem | Fix |
-|---|---|
-| `aidev doctor` says `FAIL claude-cli-binary` | Install Claude Code from https://claude.ai/download and log in (`claude /login`). Or edit `config/models.yaml` to route medium/large tiers to `anthropic` and set `ANTHROPIC_API_KEY`. |
-| `aidev doctor` says `FAIL ollama-daemon` | Should auto-spawn as of v0.2e. If it doesn't, run `ollama serve` manually, or pass `-skip-doctor` if you're managing the daemon yourself. |
-| `FAIL ollama-models — missing qwen2.5-coder:7b` | Interactive runs will offer to pull or swap. Manual fix: `ollama pull qwen2.5-coder:7b`, or edit `models.yaml` to point at a model you already have. |
-| Agent calls return `not authenticated` | Run `claude /login`. |
-| Private repo issue returns 404 | Export `GITHUB_TOKEN` with `Issues: Read and write`. |
-| Proposed.patch doesn't `git apply` cleanly | Known rough edge for complex diffs; read it manually and use it as a guide. File an issue with the failing diff if it's consistently bad. |
-| Tests touch the working tree in ways you don't trust | `aidev test --sandbox --image golang:1.24` runs inside Docker with the repo read-only. |
+- **[Install](docs/install.md)** — prereqs, install modes, flags, updating
+- **[Usage](docs/usage.md)** — slash commands, CLI, examples, headless/CI mode
+- **[Architecture](docs/architecture.md)** — the agent pipeline, the two load-bearing insights, extensibility
+- **[Review loop](docs/review-loop.md)** — the autonomous fix/rebut/defer/escalate cycle, the safety envelope, the hooks
+- **[Configuration](docs/configuration.md)** — models.yaml, principles, charter, clarifier, sketch rubric
+- **[Troubleshooting](docs/troubleshooting.md)** — when `aidev doctor` complains
+- **[Roadmap](docs/roadmap.md)** — shipped + planned
 
-## Roadmap
+## Why this shape
 
-Shipped:
-
-- **v0.1** — Scout + Critic + Bubble Tea TUI
-- **v0.2a** — Architect with N divergent sketches, cost preview
-- **v0.2b** — `aidev doctor` + Ollama auto-spawn + first-pull consent
-- **v0.2b.1** — Controller for automatic GitHub issue audit trail
-- **v0.2c** — Charter agent + interview subcommand
-- **v0.2d** — Claude Code CLI provider + `aidev plugin install`
-- **v0.2e** — One-command `install.sh` + XDG config discovery + prebuilt release binaries
-- **v0.3a** — Implementer agent (unified git diff)
-- **v0.3a.1** — Two-turn Implementer with file-content loading
-- **v0.3a.2** — TUI keybindings for Implementer / Tester / Reviewer
-- **v0.3b** — Tester agent with detected test runner
-- **v0.4** — Reviewer agent with Boy Scout pass + follow-up proposals
-- **v0.4.1** — `aidev followups --file-issues`
-- **v0.5a** — Optional Streamer interface + Claude SSE implementation
-- **v0.5b** — Tester Docker sandbox
-- **v0.5c** — Clarifier agent with dependency-aware question graph
-
-Not yet:
-
-- Windows support (TUI portability)
-- `aidev update` self-updater
-- SHA256 checksum verification of downloaded release tarballs
-- Streaming TUI progress views
-- Ollama + Claude CLI Streamer implementations
-- Homebrew formula
-- PR-comment review-reading loop (aidev reacts to review comments on PRs it opened)
-
-## Layout
-
-```
-cmd/aidev/                entry point, flag handling, subcommand dispatch
-internal/config/          YAML loader for models + principles
-internal/llm/             Provider interface + Ollama/Claude/ClaudeCLI backends + Streamer
-internal/github/          REST client (read + write for the audit trail)
-internal/repo/            Repo scanner + repo-local principle loader
-internal/agents/          Scout · Critic · Architect · Charter · Clarifier ·
-                          Implementer · Tester · Reviewer (all pure; side effects
-                          live in the orchestrator)
-internal/orchestrator/    State machine + Reporter interface + GitHubReporter (controller)
-internal/tui/             Bubble Tea model / update / view / keybindings
-internal/doctor/          Precondition checks: config, keys, Claude CLI, Ollama
-internal/plugin/          Claude Code slash command installer (go:embed)
-internal/installpkg/      Default config installer (go:embed)
-internal/version/         Build-time version embedding
-config/                   Shipped defaults (canonical source)
-plugin/aidev/             Slash command source (canonical, also embedded in binary)
-install.sh                One-command installer (download + build modes)
-Makefile                  Minimal targets for developers who prefer make
-.github/workflows/        Release build pipeline (triggered by v* tags)
-```
+Several tools already turn issues into patches (aider, plandex, opencode, goose, Claude Code itself). None of them *argue with you first*. If the Critic decides the feature shouldn't exist, aidev tells you that and stops — it doesn't sheepishly try to implement a thing it thinks is a bad idea. That's the differentiator. The rest of the pipeline is built around the same principle: every decision has a gate that can stop it, every action has a safety envelope (Sketch-grounded rebuttals, protected paths, cycle protection), and every outcome lands in the GitHub issue thread so the audit trail survives the session.
 
 ## Contributing
 
-File issues against [`AiSU-AI/aidev`](https://github.com/AiSU-AI/aidev). PRs welcome but start with an issue first — aidev's own Critic may have opinions about whether your proposed change belongs.
+File issues at [AiSU-AI/aidev/issues](https://github.com/AiSU-AI/aidev/issues). PRs welcome but start with an issue first — aidev's own Critic may have opinions about whether your proposed change belongs.
 
 ## License
 
-See [LICENSE](LICENSE).
+[MIT](LICENSE).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,38 @@
+# Jekyll config for GitHub Pages.
+#
+# GitHub Pages auto-renders markdown in docs/ when Pages is enabled on
+# `main` / `/docs` via Settings → Pages. The cayman theme is the same
+# one Anthropic uses for their OSS tooling docs — clean, readable, zero
+# build overhead.
+
+title: aidev
+description: >-
+  A multi-agent coding pipeline for Claude Code that argues with you before
+  writing code, ships the approved work autonomously, and keeps an auditable
+  GitHub-issue trail of every architectural decision.
+
+remote_theme: pages-themes/cayman@v0.2.0
+plugins:
+  - jekyll-remote-theme
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+# Nav surfaced at the top of every page. Order matches the user journey:
+# install → usage → architecture → review loop → configuration → troubleshooting → roadmap.
+header_pages:
+  - install.md
+  - usage.md
+  - architecture.md
+  - review-loop.md
+  - configuration.md
+  - troubleshooting.md
+  - roadmap.md
+
+# Pretty URLs (e.g. /install/ instead of /install.html).
+permalink: pretty
+
+# Don't publish the older v0.2f-era ollama enhancements doc in the site
+# until it's been refreshed. Still in the repo for git history.
+exclude:
+  - ollama-enhancements.md
+  - CODEMAPS/  # if we ever add generated codemaps, don't publish them by default

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,10 @@
-# aidev Architecture
+---
+title: Architecture
+---
 
-A one-page tour of what aidev actually does under the hood, and why it's structured the way it is. Complements the [README](../README.md) (value prop + install + usage) with the internal shape.
+# Architecture
+
+A one-page tour of what aidev actually does under the hood, and why it's structured the way it is. Complements the [README](../README.md) (value prop + install + first-run) with the internal shape.
 
 ## The big picture
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,141 @@
+---
+title: Configuration
+---
+
+# Configuration
+
+aidev is driven by four config surfaces, each with a sensible default:
+
+| File | Scope | Purpose |
+|---|---|---|
+| `~/.config/aidev/models.yaml` | global | Which LLM (tier) runs which agent |
+| `~/.config/aidev/principles.yaml` | global | The Critic's argument basis |
+| `<repo>/.aidev/principles.yaml` | per-repo | Extra principles merged on top of the global set |
+| `<repo>/.aidev/charter.md` | per-repo | 5-question product charter when the Critic has nothing to anchor against |
+| `<repo>/.aidev/aidev.yaml` | per-repo | PR base branch + review loop knobs (max rounds, protected paths, etc.) |
+| `<repo>/.aidev/sketch-rubric.yaml` | per-repo | Selector's scoring weights + `min_implementable_score` override |
+
+## `~/.config/aidev/models.yaml`
+
+Three tiers (`small`, `medium`, `large`) mapped to providers (`ollama`, `anthropic`, `claude-cli`), plus a role-to-tier routing table. The shipped defaults:
+
+```yaml
+tiers:
+  small:  { provider: ollama,     model: qwen2.5-coder:7b,  ... }
+  medium: { provider: claude-cli, model: "" }
+  large:  { provider: claude-cli, model: "" }
+routing:
+  scout: small
+  critic: large
+  architect: large
+  charter: large
+  clarifier: large
+  selector: large
+  triage: large
+  coordinator: large
+  implementer: medium
+  reviewer: medium
+  tester: small
+```
+
+Want the Critic on the direct Anthropic API with a specific model?
+
+```yaml
+large: { provider: anthropic, model: claude-opus-4-6 }
+```
+
+…and export `ANTHROPIC_API_KEY`. Want Scout on Claude instead of local Ollama? Change `scout: small` to `scout: large`.
+
+Unmapped roles fall back gracefully: `selector` and `triage` fall back to `critic`'s tier when not explicitly routed, so older `models.yaml` files keep working without a migration.
+
+## `~/.config/aidev/principles.yaml`
+
+The living charter the Critic uses when arguing whether a feature should ship. Ships with:
+
+- Should this exist?
+- Boy Scout Rule
+- DRY (Rule of Three)
+- YAGNI
+- Well-Architected
+- Single Responsibility
+- Fail Loudly at Boundaries
+- Tests Describe Intent
+- Reversibility
+
+Add your own; the Critic cites them by name.
+
+## `<repo>/.aidev/principles.yaml` (per-repo)
+
+Merged on top of the global set — useful when an organisation has a standards repo that downstream projects inherit from. Repo-local principles take precedence when names collide.
+
+## `<repo>/.aidev/charter.md`
+
+When a target repo has no strong signal — no README, no `CLAUDE.md`, no `ARCHITECTURE.md` — the Critic has nothing to anchor against. Run:
+
+```sh
+aidev charter -repo <path>
+```
+
+…and sit through a 5-question interview. The output lands in `<repo>/.aidev/charter.md`. The Scout automatically absorbs it on every subsequent run and the Critic cites it when pushing back on proposals.
+
+## `<repo>/.aidev/clarifier.md` (session-scoped)
+
+After the Critic flags ambiguities in a proposal, `aidev clarify -issue ... -repo ...` runs a dependency-aware question graph. Independent questions batch; chained questions serialise. Answers write to `<runDir>/clarifier.md` and the next Critic run absorbs them as authoritative ground truth (the Critic is prompted never to re-ask already-answered questions).
+
+## `<repo>/.aidev/aidev.yaml` (per-repo behavior knobs)
+
+Shape the slash command reads:
+
+```yaml
+pr:
+  base_branch: preview    # override the default (preview if exists, else repo default)
+review:
+  max_rounds: 3           # cap on review-loop iterations before forcing escalate
+  wait_for_ci: true
+  ci_timeout_minutes: 30
+  protected_paths:        # fixes touching these paths auto-escalate
+    - "**/migrations/**"
+    - "*.sql"
+    - "**/.github/workflows/**"
+    - "**/secrets/**"
+    - "*.env"
+    - "*.env.*"
+coordinator:
+  comment_threshold: warn   # info | warn | concern — minimum severity that promotes to PR comment
+```
+
+All keys are optional; absent keys fall back to the defaults shown above.
+
+## `<repo>/.aidev/sketch-rubric.yaml` (per-repo Selector override)
+
+Overrides the shipped `defaultRubricYAML` with repo-specific weights:
+
+```yaml
+version: "1.0"
+weights:
+  aligned: 1.0
+  tension: -1.0
+  violation: -2.0     # non-critical principles only
+  risk: -0.5
+  risk_cap: -3.0      # cap on the accumulated risk penalty
+critical_principles:
+  - "Single Responsibility"
+  - "DRY (Rule of Three)"
+  - "Reversibility"
+issue_type_overrides:
+  bug:
+    scope_files_penalty: 0.1     # per file beyond threshold
+    scope_files_threshold: 5
+  feature:
+    scope_files_penalty: 0.0
+    scope_files_threshold: 0
+tie_breaker_epsilon: 1.0
+min_implementable_score: 0.0
+```
+
+Critical-principle violations produce a hard veto (score = -∞). Non-critical violations add weighted penalty. `min_implementable_score: 0.0` means "at least net-neutral alignment required" — was tightened to `1.0` earlier in v0.3.0 development; relaxed because the Critic already gates "should we build this?" and over-tight rubric floors caused false-positive refinement loops on real issues.
+
+## See also
+
+- [Architecture](architecture.md) — how the config surfaces flow through the pipeline
+- [Review loop](review-loop.md) — deep dive on `review.*` keys and the Triage safety envelope

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,74 @@
+---
+title: Install
+---
+
+# Install
+
+## Quick install
+
+Downloads the latest pre-built binary from the GitHub release, writes default config, installs Claude Code slash commands, runs a smoke test. No Go required:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/AiSU-AI/aidev/main/install.sh | bash -s -- --from-release
+```
+
+## From source
+
+Needs Go 1.24+ on your `PATH`. Use this if you want to track `main` or contribute:
+
+```sh
+gh repo clone AiSU-AI/aidev ~/code/personal/aidev    # or: git clone git@github.com:AiSU-AI/aidev.git ~/code/personal/aidev
+cd ~/code/personal/aidev
+./install.sh
+```
+
+## What the installer does
+
+1. Builds or downloads the binary.
+2. Copies it to `~/.local/bin/aidev` (or `~/bin`, `/usr/local/bin` — first writable dir on your `PATH`).
+3. Writes default config to `~/.config/aidev/{models,principles}.yaml`.
+4. Installs Claude Code slash commands to `~/.claude/commands/aidev-*.md`.
+5. Runs `aidev doctor` to smoke-test the environment.
+6. Prints next steps.
+
+If the install dir isn't already on your `PATH`, the script prints the exact `export PATH=...` line to add to `~/.zshrc` or `~/.bashrc`.
+
+## Installer flags
+
+```sh
+./install.sh --bin ~/bin          # override target bin directory
+./install.sh --from-source        # force build mode (default when Go is present)
+./install.sh --from-release       # download from a GitHub release
+./install.sh --version v0.3.0     # pin a specific release tag (release mode only)
+./install.sh --force              # overwrite existing binary / config / plugin files
+./install.sh --no-doctor          # skip the post-install smoke test
+./install.sh --no-prereqs         # skip the 'suggest installing ollama' check
+```
+
+## Requirements
+
+- **macOS or Linux.** Windows is not supported yet — the TUI has POSIX-isms.
+- **Go 1.24+** — only for from-source builds. Install from [go.dev/dl](https://go.dev/dl/).
+- **[Claude Code](https://claude.ai/download)** — installed and logged in (`claude /login`). aidev's medium/large tiers route through `claude --print`, so agent calls bill against your Max/Pro subscription. No `ANTHROPIC_API_KEY` required for the default config.
+- **[Ollama](https://ollama.com)** — for the small tier (Scout, Tester failure summary). Optional; you can route the small tier through the Claude CLI too by editing `config/models.yaml`, at the cost of subscription tokens.
+- **`GITHUB_TOKEN`** in your environment for reading private issues and posting the audit trail (`Issues: Read and write` scope). Auto-resolved from `gh auth token` if you've run `gh auth login`. Also used for HTTPS-based `git push`.
+
+Run `aidev doctor` at any time to verify the environment. If Ollama is installed but not running, `doctor` will spawn `ollama serve` in the background automatically.
+
+## Upgrading
+
+For binary installs:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/AiSU-AI/aidev/main/install.sh | bash -s -- --from-release --force
+```
+
+For source installs, `git pull` then re-run `./install.sh --force`.
+
+Self-updater (`aidev update`) is on the [roadmap](roadmap.md) but not yet implemented.
+
+## See also
+
+- [Usage](usage.md) — how to drive aidev once it's installed
+- [Configuration](configuration.md) — customize models, principles, rubric
+- [Troubleshooting](troubleshooting.md) — when `aidev doctor` reports issues

--- a/docs/review-loop.md
+++ b/docs/review-loop.md
@@ -1,0 +1,92 @@
+---
+title: Review loop
+---
+
+# The autonomous review → fix loop
+
+aidev's differentiating feature is that after the initial PR opens, it doesn't stop — the slash command enters a bounded review→fix loop that converges to either `approve`, `rebut_to_ship`, or a documented `escalate` with `aidev:needs-human-review` label.
+
+## The loop, one round
+
+```
+1. Wait for CI on the pushed branch (gh pr checks --watch --required).
+2. Capture CI status + failure logs to <runDir>/ci-status-round-<R>.json.
+3. Run: aidev review -triage -round <R> -issue ... -repo ... -ci-status ...
+4. Parse the JSON verdict. Act on `convergence`:
+     approve           → post comment, mark PR ready, DONE
+     rebut_to_ship     → post each rebuttal + citation, mark ready, DONE
+     continue          → apply fix_now actions natively, commit, push, GOTO 1
+     escalate          → add aidev:needs-human-review, leave draft, DONE
+5. Cap at review.max_rounds (default 3). After the cap, force escalate.
+```
+
+**The mandatory first action of every round is `aidev review -triage`.** The slash command never improvises from raw CI logs — the Triage agent is the source of truth for what to do with every finding.
+
+## The Triage agent
+
+Runs after the Reviewer emits findings (per-PR) and CI reports status. Decides per-finding:
+
+| Action | When |
+|---|---|
+| `fix_now` | Real, actionable, Claude Code can apply a code edit. Provides `fix_plan` naming files/lines. |
+| `rebut` | The finding contradicts the chosen Sketch's documented decisions. **Must quote the relevant Sketch section verbatim in `sketch_citation`.** |
+| `defer_to_followup` | Real but out of scope for this PR. Slash command files a child issue. |
+| `escalate` | Human required. Used when: unclear finding, protected path touched, security check failed, no Sketch citation available for rebuttal. |
+
+## The safety envelope (Go-side coercions)
+
+The LLM's judgment is one input among many. When the LLM and the safety rules disagree, the safety rules win. Every coercion lands in the verdict's `coercions_log` so the humans can see what aidev refused to do.
+
+1. **Rebut without literal `sketch_citation` → escalate.** No exceptions. The Triage prompt instructs the agent to default to `escalate` when it can't cite the Sketch; Go code enforces that.
+2. **Rebut with an invented citation (string not present in the chosen Sketch's markdown) → escalate.** Loose-match tolerance (case + whitespace normalised, minimum 12 chars) catches minor paraphrasing; completely-fabricated quotes don't pass.
+3. **Rebut on a security-tool CI failure → escalate.** Detected by substring match against `codeql`, `snyk`, `dependabot`, `trivy`, `semgrep`, `npm audit`, `pnpm audit`, `yarn audit`, `osv-scanner`, `ossf scorecard`, `socket security`. Security findings cannot be auto-rebutted regardless of how confident the LLM sounds.
+4. **`fix_plan` touching a protected path → escalate.** Default protected paths: `**/migrations/**`, `*.sql`, `**/.github/workflows/**`, `**/secrets/**`, `*.env`, `*.env.*`. Users extend via `.aidev/aidev.yaml` `review.protected_paths`. Fixes to sensitive surfaces never auto-apply.
+5. **Cycle protection.** The same finding ID appearing twice across rounds (once with `fix_now`, then again) forces `escalate`. Prevents the loop from chasing its own tail when a fix removes one symptom but introduces another.
+
+## Hooks — the deterministic backstop
+
+The Triage agent plus slash-command logic is load-bearing, but the LLM can still skip it (we observed this early in P6 development — the slash command went ad-hoc and didn't invoke `aidev review -triage` at all). Three hooks installed at `~/.claude/hooks/aidev-*.sh` run regardless of what the LLM decides:
+
+- **`aidev-pre-push.sh`** — PreToolUse on `Bash(git push*)`. When pushing to an `aidev/issue-*` branch, runs `pnpm verify` / `pnpm audit --audit-level=high` (or `go test` + `go vet`, or `cargo test` + `cargo audit`) before the push reaches origin. Blocks the push on failure.
+- **`aidev-pr-created.sh`** — PostToolUse on `Bash(gh pr create*)`. Parses the PR URL from stdout, persists it to a session-scoped state file, emits an early warning if CI is already red at PR creation time.
+- **`aidev-stop-check.sh`** — Stop event. Reads the session state file, checks every PR created this session: if any has failing CI AND no `aidev:needs-human-review` label, **blocks Claude Code's Stop event** until the human either runs `/aidev-review --loop` or adds the label to acknowledge.
+
+These run at the harness level, not inside the LLM, so they cannot be reasoned-around.
+
+## CI as a peer signal
+
+CI failures feed into Triage alongside Reviewer findings. The verdict's `actions[].source` field is either `reviewer` or `ci`, and the `ci_check` field names the specific check (e.g. `CodeQL`, `Test with Coverage`, `Security Audit`).
+
+Triage treats CI failures with finer discrimination than the Reviewer alone:
+
+- **Failing test with a clear file/line** (e.g. `load-translations.test.ts:51`) → candidate for `fix_now` with concrete `fix_plan`.
+- **Security advisory from a tool in the security-check list** → `fix_now` with `fix_plan` pointing at the dependency override mechanism, OR `escalate` if the fix is non-obvious. Never `rebut`.
+- **Build failure without an identifiable fault location** → `escalate`. Triage is instructed: "if you'd be inventing architecture, escalate."
+- **CI check the PR didn't cause** (failing on files not in the diff) → in v0.3.0 this gets folded into the current PR per the "fix-when-bounded" scope principle (see [PR #536](https://github.com/AiSU-AI/Company-Site/pull/536) for the canonical example: pre-existing `basic-ftp` CVE + `load-translations.test.ts` drift were resolved in-scope rather than filed as new PRs).
+
+## Convergence values
+
+The Triage verdict's `convergence` field drives the slash command's next step:
+
+| Value | Meaning | Slash command action |
+|---|---|---|
+| `approve` | Reviewer approved, CI green (or no CI checks failed). | Post convergence comment; mark PR ready; done. |
+| `rebut_to_ship` | Reviewer asked for changes, every finding has a Sketch-grounded rebuttal, no `fix_now` / `escalate` actions. | Post each rebuttal as a PR comment citing the Sketch section; mark ready; done. |
+| `continue` | At least one `fix_now` or `defer_to_followup`. | Apply fixes natively via Edit/Write; run tests; commit; push; re-enter round R+1. |
+| `escalate` | At least one `escalate` action, OR cap hit, OR test regression, OR malformed LLM JSON, OR CI timeout. | Post escalation comment with `escalate_reason`; add `aidev:needs-human-review` label; leave PR draft; done. |
+
+The Go-side computation prioritises: `escalate` dominates → `continue` (any `fix_now` / `defer`) → `rebut_to_ship` (only rebuts) → `approve` (clean or empty).
+
+## Rerunning the loop
+
+```
+/aidev-review <issue> <repo> --loop
+```
+
+Runs the loop standalone against whatever PR exists for the issue, without re-running Scout/Critic/Architect. Useful when a human has pushed a commit to the feature branch and wants aidev to re-triage.
+
+## See also
+
+- [Architecture](architecture.md) — where Triage sits in the broader pipeline
+- [Configuration](configuration.md) — `review.*` and `protected_paths` keys
+- [Usage](usage.md) — slash commands that drive the loop

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,73 @@
+---
+title: Roadmap
+---
+
+# Roadmap
+
+## Shipped
+
+### v0.3.0 (initial public release, 2026-04-18)
+
+- **P0 Selector** — autonomous sketch picking via deterministic rubric + LLM tie-breaker
+- **P1 runDir** — generated artifacts relocated out of the target repo into `$XDG_DATA_HOME/aidev/runs/`
+- **P2 GH audit trail** — every decision point posts as a first-class comment on the issue
+- **P3 Autonomous `/aidev-run` flow** — `-interactive` gated, default is headless
+- **P4 Auto-PR** — slash command opens PR against `preview` with safety guards (dirty-tree check, branch collision, test-run before push)
+- **P5 Needs-refinement state** — structured escalation when the Critic can't reach a verdict
+- **P6 Autonomous review → fix loop** — Triage agent + Sketch-grounded rebuttal safety + security-finding lock + protected-path forced escalation + cycle protection
+- **Deterministic safety hooks** — pre-push tests/audit, post-PR-create state persistence, Stop-blocks-on-red-CI
+- **Branch-first flow** — `gh issue develop` cuts the feature branch from `origin/<base>` before any implementation edit
+- **Open source launch** — MIT license, public repo, `docs/` site, branch protection on main with required `build-test` CI
+
+### v0.2 series (private development)
+
+- **v0.2e** — one-command `install.sh`, XDG config discovery, prebuilt release binaries
+- **v0.2d** — Claude Code CLI provider, `aidev plugin install`
+- **v0.2c** — Charter agent + interview subcommand
+- **v0.2b.1** — Controller for automatic GitHub issue audit trail
+- **v0.2b** — `aidev doctor`, Ollama auto-spawn, first-pull consent
+- **v0.2a** — Architect with N divergent sketches, cost preview
+- **v0.2f (transitional)** — 5-gate Coordinator monitor, native tool use in `llm.Provider`, profile-based config, Ollama tool use
+
+### Pre-v0.2
+
+- **v0.1** — Scout + Critic + Bubble Tea TUI (the keystone — the Critic argues before writing code)
+
+## Not yet
+
+### Near-term (filed as GitHub issues, PRs welcome)
+
+- **Repo path as URL** — accept `https://github.com/owner/repo` / `git@...` / `owner/repo` shorthand and auto-clone to `$XDG_DATA_HOME/aidev/clones/`. Today `-repo` requires a local filesystem path.
+- **`-headless -auto` + Critic `unclear` → structured needs-refinement comment** — currently that path posts only the Critic report + `aidev:awaiting-decision` label, not the 🤔 checklist comment P5 designed.
+- **CI-driven autonomous Critic** — `issues.opened` GitHub Action that runs Scout + Critic and posts the verdict as a comment. See the [GH Actions integration issue](https://github.com/AiSU-AI/aidev/issues) for the hybrid implementation plan.
+- **Homebrew formula** — `brew install aidev` for macOS one-liner install.
+- **`aidev update` self-updater** — `aidev update` checks for the latest release and reinstalls.
+- **SHA256 verification of downloaded release tarballs** — install.sh should verify `<asset>.sha256` alongside the download.
+
+### Medium-term (good-first-issue candidates)
+
+- **Windows support** — TUI currently has POSIX-isms; Windows users would need WSL today.
+- **Streaming TUI progress views** — live-stream claude-cli / Ollama output instead of batch-render.
+- **Homebrew tap** — `homebrew-aidev` with automated updates on release.
+- **Docs site upgrade** — consider mkdocs-material if traffic justifies it; currently served via plain Jekyll on GitHub Pages.
+
+### Long-term (design space)
+
+- **PR-comment review-reading loop** — aidev reacts to human review comments on PRs it opened, beyond just CI checks.
+- **Cross-PR context** — Selector evaluates how this issue interacts with other in-flight branches.
+- **Self-tuning rubric** — learn rubric weights from "implementations that landed cleanly" vs "got reverted" in the GH issue history.
+- **Enterprise GHE support** — `gh issue view` assumes github.com; needs `GITHUB_HOST` threading.
+
+## Out of scope (deliberate)
+
+These have been considered and deferred indefinitely:
+
+- **Auto-merge after convergence** — even when the review loop converges to `approve`, the human merges manually. The autonomy stops at "PR ready for human review."
+- **Claude Code API replacement** — aidev uses `claude-cli` as a subprocess; it doesn't try to reimplement Claude Code's tool harness in the Anthropic Messages API.
+- **Proprietary plugin marketplace** — slash commands ship alongside the binary, no separate package registry.
+- **Windows GUI** — the terminal / slash command surface is the product; no planned GUI client.
+
+## See also
+
+- [Architecture](architecture.md) — the extension points for adding new agents
+- [Review loop](review-loop.md) — what P6 actually does

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,35 @@
+---
+title: Troubleshooting
+---
+
+# Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| `aidev doctor` says `FAIL claude-cli-binary` | Install Claude Code from [claude.ai/download](https://claude.ai/download) and log in (`claude /login`). Or edit `~/.config/aidev/models.yaml` to route medium/large tiers to `anthropic` and set `ANTHROPIC_API_KEY`. |
+| `aidev doctor` says `FAIL ollama-daemon` | `doctor` should auto-spawn Ollama as of v0.2e. If it doesn't, run `ollama serve` manually, or pass `-no-doctor` if you're managing the daemon yourself. |
+| `FAIL ollama-models — missing qwen2.5-coder:7b` | Interactive runs offer to pull or swap. Manual: `ollama pull qwen2.5-coder:7b`, or edit `models.yaml` to point at a model you already have. |
+| Agent calls return `not authenticated` | Run `claude /login`. |
+| Private-repo issue returns 404 | Export `GITHUB_TOKEN` with `Issues: Read and write` scope. Auto-resolved from `gh auth token` if you've run `gh auth login`. |
+| `/aidev-run` stops with `AIDEV_NEEDS_REFINEMENT=1` | Selector refused to pick, or Critic returned `unclear` after the Clarifier interview. See the issue's new `🤔 refinement required` comment for the structured checklist. Refine the issue body, then re-run. |
+| Review loop escalated with `aidev:needs-human-review` label | Triage hit a blocker it couldn't safely auto-fix (security finding, protected path, cycle protection). Address manually OR push a commit that changes the finding fingerprint, then re-run `/aidev-review --loop`. |
+| Pre-push hook blocks on `pnpm verify` failure from an unrelated CI issue | Temporarily rerun with `git push --no-verify` (discouraged) or, better, fold the unrelated fix into the same PR per aidev's scope-when-bounded principle. See [review loop](review-loop.md#ci-as-a-peer-signal). |
+| Selector chose a sketch with low confidence (score barely > 0) | Increase sketch count with `-n 5` for more diversity, or set `min_implementable_score: 1.0` in `<repo>/.aidev/sketch-rubric.yaml` to force refinement on borderline cases. |
+| Tests touch the working tree in ways you don't trust | `aidev test --sandbox --image golang:1.24` runs inside Docker with the repo read-only. |
+| Generated artifacts cluttering `<repo>/.aidev/` | Shouldn't happen in v0.3.0+; artifacts now land in `$XDG_DATA_HOME/aidev/runs/<owner>-<repo>-<issue>/`. If you see them in the target repo, reinstall: `curl -fsSL https://raw.githubusercontent.com/AiSU-AI/aidev/main/install.sh \| bash -s -- --from-release --force`. |
+| Stop hook blocks Claude Code session end with "session PR has failing CI" | Expected when a fresh PR this session has red CI. Options: (1) run `/aidev-review --loop` to trigger the autonomous fix cycle; (2) `gh pr edit <PRNUM> --add-label aidev:needs-human-review` to acknowledge. |
+
+## When to file an issue
+
+If the above doesn't resolve your problem, or if you've hit an obvious bug (pipeline crashes, Critic output is malformed, Selector picks a disqualified sketch, etc.), file an issue at [AiSU-AI/aidev/issues](https://github.com/AiSU-AI/aidev/issues) with:
+
+- The exact `aidev` command you ran (including flags)
+- The output of `aidev doctor`
+- The `<runDir>/architect-output.md` contents if the pipeline reached the Architect phase
+- Your `~/.config/aidev/models.yaml` (redact API keys)
+
+## See also
+
+- [Install](install.md) — `aidev doctor` reference
+- [Configuration](configuration.md) — principles, rubric, per-repo overrides
+- [Review loop](review-loop.md) — escalation behavior + hook backstop

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,91 @@
+---
+title: Usage
+---
+
+# Usage
+
+The canonical entry point is the Claude Code slash command `/aidev-run` — it drives the full autonomous pipeline (Scout → Critic → Architect → Selector → implementation → test → PR → review loop). The standalone `aidev` CLI exposes each phase as a subcommand for scripting, CI, and one-off operations.
+
+## Slash commands (from inside Claude Code)
+
+Once `aidev plugin install` (part of the installer) has dropped the slash commands, type `/` in any Claude Code session and you'll see:
+
+| Command | Effect |
+|---|---|
+| `/aidev-run <issue> <repo-path>` | Full autonomous pipeline — Scout → Critic → Architect → Selector → implement → test → PR → review loop |
+| `/aidev-review <issue> <repo-path> [--loop]` | Boy Scout pass on the current PR; `--loop` drives the autonomous review→fix cycle against an existing PR |
+| `/aidev-doctor` | Environment audit |
+| `/aidev-charter <repo-path>` | 5-question interview to produce `.aidev/charter.md` |
+| `/aidev-test <repo-path>` | Run detected test suite, summarise failures |
+
+`<issue>` accepts either a bare issue number (resolved against the repo's `origin` remote) or a full GitHub URL. `<repo-path>` is a local filesystem path; [URL-as-repo support](https://github.com/AiSU-AI/aidev/issues) is on the roadmap.
+
+### Example — full autonomous run
+
+```
+/aidev-run 42 .
+```
+
+From `~/code/your-repo` this runs the whole pipeline. The Critic either argues against the issue (you'll see the case, with sharp questions on `unclear`), the Architect drafts 3 sketches, the Selector picks one via the [rubric](configuration.md#sketch-rubric), Claude Code cuts the feature branch via `gh issue develop`, implements the sketch natively, runs your test suite, opens the PR, waits for CI, and runs the [review loop](review-loop.md) until it converges or escalates.
+
+## Headless / CI-friendly
+
+```sh
+# Scout + Critic only (produces decision, no implementation):
+aidev -headless -issue 42 -repo ~/code/your-repo
+
+# + Architect + Selector autonomously:
+aidev -headless -auto -n 3 -issue 42 -repo ~/code/your-repo
+
+# Force a particular Critic verdict (escape hatch; use sparingly):
+aidev -headless -auto -n 3 -force-verdict build -issue 42 -repo ~/code/your-repo
+
+# Run an interactive session that pauses for human input at the Architect step:
+aidev -interactive -issue 42 -repo ~/code/your-repo
+```
+
+Writes the full report to stdout (for CI logs) and drops structured artifacts (Selector verdict, Architect sketches, Clarifier Q&A, CI status) into `$XDG_DATA_HOME/aidev/runs/<owner>-<repo>-<issue>/`.
+
+## Standalone subcommands
+
+```sh
+aidev doctor                                          # environment audit
+aidev charter -repo <path>                            # interactive product charter interview
+aidev clarify -issue <url> -repo <path>               # structured question graph for ambiguities
+aidev test -repo <path>                               # run detected test suite
+aidev test -repo <path> --sandbox --image golang:1.24 # run tests inside Docker
+aidev review -issue <url> -repo <path>                # Boy Scout pass on auto-discovered diff
+aidev review -triage -round 1 -issue <url> -repo <path>   # Reviewer + Triage meta-judgment (JSON out)
+aidev followups -repo <path>                          # dry-run review of proposed follow-up issues
+aidev followups -repo <path> --file-issues --target owner/repo  # actually file them
+aidev plugin install                                  # install Claude Code slash commands
+aidev install                                         # (re)install default config to ~/.config/aidev
+aidev --version                                       # print the embedded build version
+```
+
+## Interactive TUI (manual mode)
+
+For phase-by-phase exploration without the autonomous pipeline:
+
+```sh
+aidev -issue 42 -repo ~/code/your-repo
+```
+
+| Key | Action |
+|-----|--------|
+| `r` | Run Scout + Critic |
+| `a` | Approve Critic's recommendation → kick off Architect |
+| `1`–`9` | After sketches appear, pick one → kick off Implementer (standalone mode) |
+| `t` | After patch is ready: run the test suite |
+| `v` | After patch is ready: run the Reviewer |
+| `k` | Kill the proposal |
+| `tab` | Cycle pane focus |
+| `q` / `ctrl+c` | Quit |
+
+The rightmost pane retitles as the pipeline advances: **Critic report** → **Architect sketches** → **Implementer patch** → **Test result** → **Review**.
+
+## See also
+
+- [Architecture](architecture.md) — what each agent does and why
+- [Review loop](review-loop.md) — the autonomous fix/rebut/defer/escalate cycle
+- [Configuration](configuration.md) — customize models, principles, rubric


### PR DESCRIPTION
## Summary

Refactors the 308-line monolithic README into a slim landing page that links to seven topic pages under `docs/`, and adds a Jekyll `_config.yml` so the whole thing serves cleanly as a GitHub Pages site.

## What's new

- **`README.md`** (308 → 43 lines): value prop, quick install, first-run example, links to every topic page. That's it.
- **`docs/install.md`** — prereqs, install modes, flags, updating
- **`docs/usage.md`** — slash commands, CLI, headless/CI mode, subcommand reference
- **`docs/architecture.md`** (renamed from `ARCHITECTURE.md`) — agent pipeline + two load-bearing insights (decision/impl split, Sketch-grounded rebuttals)
- **`docs/review-loop.md`** — P6 Triage safety envelope + hooks deep dive (this is the differentiating feature — worth its own page)
- **`docs/configuration.md`** — `models.yaml`, `principles.yaml`, charter, clarifier, sketch rubric, `aidev.yaml`
- **`docs/troubleshooting.md`** — v0.3.0-aware error → fix table (the stale `proposed.patch doesn't git apply` row is gone; new rows for `AIDEV_NEEDS_REFINEMENT=1`, review-loop escalation, pre-push hook blocks, stop hook blocks)
- **`docs/roadmap.md`** — shipped section extended with v0.3.0; new \"not yet\" items for repo-URL support, CI-driven Critic, Homebrew, self-updater; explicit \"out of scope\" section for auto-merge etc.
- **`docs/_config.yml`** — cayman theme, nav order, pretty URLs, SEO + sitemap plugins

## Why restructure

- The single-page README was carrying outdated v0.2f-era content ('you approve (or kill)', 'Implementer writes a diff you git apply' — both wrong for the v0.3.0 autonomous flow).
- A topic-per-page shape plays natively with GH Pages and is more navigable for new readers.
- The review loop deep-dive (P6 safety envelope + hooks) is the differentiating feature but was buried — now front-and-center as its own page.

## Follow-up (out of scope for this PR)

- Enable GitHub Pages on `main`/`docs` via Settings → Pages (one click after this merges).
- File new issues for repo-URL support, `Critic=unclear` refinement-comment gap, and CI-driven autonomous Critic (all three are in `docs/roadmap.md` \"not yet\").

## Test plan

- [x] \`go build ./...\` green (docs-only change; covered by existing CI)
- [x] Every link in the new README resolves to a file in \`docs/\`
- [x] Every topic page has a \"See also\" section cross-linking to related pages
- [x] README line count shrunk to ~40 (achieved: 43)