### PR TITLE
feat: local issue-management slash commands (triage / release / implement-bundle)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,11 +14,14 @@ Once `aidev plugin install` (part of the installer) has dropped the slash comman
 |---|---|
 | `/aidev-run <issue> <repo-path>` | Full autonomous pipeline — Scout → Critic → Architect → Selector → implement → test → PR → review loop |
 | `/aidev-review <issue> <repo-path> [--loop]` | Boy Scout pass on the current PR; `--loop` drives the autonomous review→fix cycle against an existing PR |
+| `/aidev-triage [repo-path]` | Bulk Critic pass over every un-triaged open issue, applying verdict labels (`aidev:approved` / `deferred` / `killed` / `needs-refinement`) |
+| `/aidev-release <milestone> [repo-path]` | Assemble / inspect a release bundle around a GitHub milestone — pick from `aidev:approved` candidates |
+| `/aidev-implement-bundle <milestone> [repo-path]` | Run the full autonomous `/aidev-run` pipeline against every open issue in a milestone, producing one PR per issue |
 | `/aidev-doctor` | Environment audit |
 | `/aidev-charter <repo-path>` | 5-question interview to produce `.aidev/charter.md` |
 | `/aidev-test <repo-path>` | Run detected test suite, summarise failures |
 
-`<issue>` accepts either a bare issue number (resolved against the repo's `origin` remote) or a full GitHub URL. `<repo-path>` is a local filesystem path; [URL-as-repo support](https://github.com/AiSU-AI/aidev/issues) is on the roadmap.
+`<issue>` accepts either a bare issue number (resolved against the repo's `origin` remote) or a full GitHub URL. `<repo-path>` is a local filesystem path; [URL-as-repo support](https://github.com/AiSU-AI/aidev/issues/45) is on the roadmap.
 
 ### Example — full autonomous run
 
@@ -27,6 +30,24 @@ Once `aidev plugin install` (part of the installer) has dropped the slash comman
 ```
 
 From `~/code/your-repo` this runs the whole pipeline. The Critic either argues against the issue (you'll see the case, with sharp questions on `unclear`), the Architect drafts 3 sketches, the Selector picks one via the [rubric](configuration.md#sketch-rubric), Claude Code cuts the feature branch via `gh issue develop`, implements the sketch natively, runs your test suite, opens the PR, waits for CI, and runs the [review loop](review-loop.md) until it converges or escalates.
+
+### Local issue-management workflow (no CI, no API keys)
+
+For maintainers who want to manage a repo's backlog locally using their Claude Code subscription — no `ANTHROPIC_API_KEY` in GitHub Actions, no CI budget risk:
+
+```
+/aidev-triage .                         # Critic every un-labeled open issue
+/aidev-release v0.4.0 .                 # assemble a release bundle from approved issues
+/aidev-implement-bundle v0.4.0 .        # run the full pipeline on every milestone issue
+```
+
+The flow:
+
+1. **Triage** — `/aidev-triage` finds open issues without any `aidev:*` label, runs Scout + Critic on each, applies `aidev:approved` / `aidev:deferred` / `aidev:killed` / `aidev:needs-refinement` based on the Critic's verdict. Cap of 20 issues per run; total run time roughly `N × 60s`.
+2. **Release bundling** — `/aidev-release <milestone>` shows you `aidev:approved` issues not yet assigned to a milestone, plus whatever's already in the milestone. Interactive: you pick which candidates to add to the milestone. Creates the milestone if it doesn't exist.
+3. **Bundle implementation** — `/aidev-implement-bundle <milestone>` runs the full `/aidev-run` pipeline (Scout → Critic → Architect → Selector → Claude Code → tests → PR → review loop) against every open issue in the milestone, sequentially. One PR per issue, all branched from `origin/<base>`. You merge in whatever order you prefer.
+
+Each step is human-gated at the decision points — `/aidev-triage` surfaces the candidate list before running, `/aidev-release` asks you to confirm each addition, `/aidev-implement-bundle` offers a "stop after the first issue for sanity check" option. The autonomy is opt-in per step, not blanket.
 
 ## Headless / CI-friendly
 

--- a/internal/plugin/files/aidev-implement-bundle.md
+++ b/internal/plugin/files/aidev-implement-bundle.md
@@ -1,0 +1,159 @@
+---
+description: Run the full autonomous /aidev-run pipeline against every issue in a GitHub milestone
+argument-hint: <milestone-name> [repo-path]
+allowed-tools: Bash(aidev:*), Bash(gh:*), Bash(git:*), Read, Edit, Write, AskUserQuestion
+---
+
+Run the full autonomous `/aidev-run` pipeline — Scout → Critic →
+Architect → Selector → Claude Code implementation → tests → PR → review
+loop — against every open issue in a GitHub milestone, in sequence.
+Each issue produces its own PR branched from `origin/preview`. You
+review and merge PRs in whatever order you prefer.
+
+Use this AFTER `/aidev-release <milestone>` has assembled the bundle
+you want to ship.
+
+STEP 1 — Parse `$ARGUMENTS`. First token (required) is the milestone
+name. Second token (optional) is the repo path; default `.` (cwd).
+
+If the milestone name is missing, STOP and ask the user.
+
+STEP 2 — Resolve repo owner/name:
+
+    gh repo view <PATH> --json owner,name --jq '.owner.login + "/" + .name'
+
+STEP 3 — Fetch milestone issues:
+
+    gh issue list --repo <owner>/<repo> --milestone "<name>" \
+      --state open --json number,title,labels \
+      --jq '[.[] | {number, title, labels: [.labels[].name]}]'
+
+If empty, say "Milestone `<name>` has no open issues; nothing to
+implement. Run `/aidev-release <name> <PATH>` first." and STOP.
+
+STEP 4 — Surface the bundle to the user and ask to confirm via
+`AskUserQuestion`:
+
+  - **Proceed — run pipeline on all <N> issues** (recommended)
+  - **Proceed — but stop after the first issue for a sanity check**
+  - **Show me the Critic verdict for each issue first**
+  - **Cancel**
+
+If `Show me the Critic verdict`, for each issue run:
+
+    gh issue view <num> --repo <owner>/<repo> --comments \
+      | grep -A 20 'Critic report'
+
+and display. Then re-ask the confirmation question.
+
+If `Cancel`, STOP.
+
+STEP 5 — Dirty-tree precheck on the target repo:
+
+    git -C <PATH> status --porcelain
+
+If non-empty, STOP and tell the user to commit/stash/discard their
+working-tree changes first. The pipeline will cut feature branches per
+issue; dirty tree is dangerous.
+
+STEP 6 — Sync the base branch. Because each `/aidev-run` cuts the
+feature branch from `origin/<base>`, we want the base up-to-date:
+
+    git -C <PATH> fetch origin
+
+STEP 7 — Iterate over every issue in the bundle. For each:
+
+  a. Print a progress marker:
+
+         ========================================================
+         [<i>/<N>] Issue #<num>: <title>
+         ========================================================
+
+  b. Invoke the full `/aidev-run` pipeline for this issue. This is the
+     same flow as running `/aidev-run <num> <PATH>` directly — STEPS 1
+     through 15 from `aidev-run.md`. You MUST execute all of those
+     steps for each issue, including:
+
+       - STEP 2: `aidev -headless -auto -n 3 -issue <num> -repo <PATH>`
+       - STEP 6: check for `AIDEV_NEEDS_REFINEMENT=1` marker
+       - STEP 7: dirty-tree check (should pass since we checked in STEP 5
+         above, but per-issue push commits may leave artifacts — verify)
+       - STEP 7.5: cut feature branch via `gh issue develop` from
+         `origin/<base>`
+       - STEP 8: implement the Selector's chosen sketch natively
+       - STEP 9: run the project's test suite
+       - STEP 10: commit + push + `gh pr create`
+       - STEP 11: post PR-link comment back to the issue
+       - STEPS 12-15: autonomous review loop (wait for CI, run triage,
+         fix/rebut/defer/escalate, converge)
+
+     See `aidev-run.md` for the full specification of each step.
+
+  c. Record the outcome for the final summary:
+
+       - PR number opened (if reached STEP 10)
+       - Final review-loop convergence (`approve` / `rebut_to_ship` /
+         `escalate` / `needs-refinement`)
+       - Any new `aidev:followup` issues filed during the run
+       - Any errors or skipped steps
+
+  d. If the user chose `Proceed — but stop after the first issue` in
+     STEP 4, STOP now and go to STEP 9.
+
+  e. Between issues, switch back to the base branch so the next issue's
+     `gh issue develop` has a clean starting point:
+
+         git -C <PATH> checkout <base-branch>
+
+     (`<base-branch>` is whatever STEP 7.5 resolved — typically
+     `preview`.)
+
+STEP 8 — Continue until all issues are processed.
+
+STEP 9 — Print the final bundle summary:
+
+    === Bundle <name> complete ===
+    Processed: <N> issues
+    PRs opened: <list of #<PRNUM>>
+    Review loop converged (approve): <count>
+    Rebutted to ship: <count>
+    Escalated (needs human): <count>
+    Needs refinement (Critic=unclear): <count>
+    Errors: <count>
+
+    Follow-up issues filed during runs:
+      - #<num>  <title>
+
+    Next actions:
+      - Merge PRs in preferred order (PRs targeting <base-branch>)
+      - For escalated PRs: review the escalation comment + resolve manually
+      - For needs-refinement issues: edit body + re-run /aidev-triage
+
+    When all PRs merge and the milestone is complete, tag the release:
+      git tag v<name> && git push origin v<name>
+
+STEP 10 — Done.
+
+Safety:
+  - The bundle runs PRs in PARALLEL in the sense that each PR targets
+    the same base branch; they'll have merge conflicts if they touch
+    overlapping files. aidev does NOT sequence them by merging the
+    previous PR before running the next. You control merge order.
+  - Each issue is independent; one failing (escalate, refinement)
+    does not abort the batch. The summary shows everything.
+  - The first-issue-sanity-check option (STEP 4) is the safe way to
+    try this on a new repo — run one end-to-end, verify the PR looks
+    right, then re-run for the rest.
+  - Total wall-clock time is roughly `N × 5-10 minutes` depending on
+    sketch count, test suite duration, and CI latency. For a 5-issue
+    bundle, budget 30-60 minutes.
+
+Cost: all autonomous decisions run through your Claude Code
+subscription (claude-cli). No Anthropic API budget required.
+Implementation is Claude Code native tools — same subscription.
+Only cost outside your subscription is GitHub Actions CI minutes for
+the review-loop's CI-wait step.
+
+See `aidev-run.md` for the full single-issue pipeline spec.
+See `aidev-release.md` for how to assemble a bundle before running
+this command.

--- a/internal/plugin/files/aidev-release.md
+++ b/internal/plugin/files/aidev-release.md
@@ -1,0 +1,142 @@
+---
+description: Show + confirm a release bundle for a given GitHub milestone
+argument-hint: <milestone-name> [repo-path]
+allowed-tools: Bash(gh:*), Bash(aidev:*), Read
+---
+
+Assemble (or inspect) a release bundle around a GitHub milestone. Takes
+you from "these issues are `aidev:approved`" to "these issues are in
+milestone v0.4.0 and ready for `/aidev-implement-bundle`."
+
+Workflow this command supports:
+
+  1. You triage new issues with `/aidev-triage` — those with Critic
+     verdict `build` get the `aidev:approved` label.
+  2. You run `/aidev-release v0.4.0 <repo>` — this command shows you
+     (a) what's already in the milestone, and (b) approved-but-unassigned
+     candidates. You pick which candidates to add.
+  3. When the milestone looks right, you run
+     `/aidev-implement-bundle v0.4.0 <repo>` to ship it.
+
+STEP 1 — Parse `$ARGUMENTS`. First token (required) is the milestone
+name. Second token (optional) is the repo path; default `.` (cwd).
+
+If `$ARGUMENTS` is missing the milestone name, STOP and ask the user
+for one.
+
+STEP 2 — Resolve repo owner/name:
+
+    gh repo view <PATH> --json owner,name --jq '.owner.login + "/" + .name'
+
+STEP 3 — Ensure the milestone exists. Look it up:
+
+    gh api repos/<owner>/<repo>/milestones?state=open \
+      --jq '.[] | select(.title == "<name>") | {number, title, url, due_on}'
+
+If not found, ask the user via `AskUserQuestion`:
+
+  - **Create milestone `<name>` now** — `gh api repos/<owner>/<repo>/milestones -X POST -f title=<name>`
+  - **Use a different name** — prompt for a new name
+  - **Cancel**
+
+STEP 4 — List what's currently in the milestone:
+
+    gh issue list --repo <owner>/<repo> --milestone "<name>" --state open \
+      --json number,title,labels,body \
+      --jq '.'
+
+Show the user each one as: `#<num>  [<verdict>]  <title>` where
+`<verdict>` is inferred from the `aidev:*` labels (`approved` →
+`approved`, `needs-refinement` → `⚠ needs refinement`, etc).
+
+STEP 5 — List candidate issues (approved, no milestone assigned):
+
+    gh issue list --repo <owner>/<repo> --state open --label aidev:approved \
+      --no-milestone --json number,title,body \
+      --jq '.'
+
+Note: `--no-milestone` filter; only the issues that have
+`aidev:approved` AND are currently unassigned to any milestone.
+
+STEP 6 — Show the user the two lists in this order:
+
+    Milestone <name> (N issues):
+      - #<num>  <title>                    [verdict]
+      ...
+
+    Approved candidates (M available, no milestone yet):
+      - #<num>  <title>                    [Critic one-line]
+      ...
+
+If there are zero candidates AND zero in-milestone issues, say
+"Milestone `<name>` is empty; run `/aidev-triage` first to approve
+issues." and STOP.
+
+STEP 7 — Ask the user what to do via `AskUserQuestion`:
+
+  - **Add all candidates to the milestone** — bundle everything approved
+  - **Pick specific candidates** — interactive pick (next step)
+  - **Remove an issue from the milestone** — unbundle one
+  - **Show details of a candidate** — paste the Critic rationale for a specific issue
+  - **Done — bundle looks good** — finalize and show next steps
+  - **Cancel**
+
+STEP 8 — Handle the user's choice:
+
+  - `Add all candidates`: for each candidate issue, run:
+
+        gh issue edit <num> --repo <owner>/<repo> \
+          --milestone "<name>" \
+          --remove-label aidev:approved \
+          --add-label aidev:bundled
+
+    Then loop back to STEP 4 to show the updated state.
+
+  - `Pick specific candidates`: use `AskUserQuestion` with each
+    candidate as an option (up to 4 per question; for larger lists,
+    iterate in pages of 4). For each `Yes` answer, apply the same
+    milestone edit + label swap as above.
+
+  - `Remove an issue`: ask for the issue number, then:
+
+        gh issue edit <num> --repo <owner>/<repo> \
+          --milestone "" \
+          --remove-label aidev:bundled \
+          --add-label aidev:approved
+
+  - `Show details of a candidate`: ask for the number, then print:
+
+        gh issue view <num> --repo <owner>/<repo> --comments
+
+  - `Done`: jump to STEP 9.
+
+  - `Cancel`: STOP.
+
+STEP 9 — Finalize. Print a summary of the milestone:
+
+    Release candidate: <name>
+      <N> issues bundled:
+        #<num>  <title>
+        ...
+
+      Ready to ship? Run:
+        /aidev-implement-bundle <name> <PATH>
+
+      That will run the full autonomous pipeline on each issue in
+      sequence, opening one PR per issue against origin/preview.
+
+STEP 10 — Optional: post a tracking comment to a pinned meta-issue
+(if one exists with label `aidev:release-tracker` and title matching
+`Release <name>`) so the bundle state is visible publicly. Skip if no
+such issue exists; don't auto-create one.
+
+Safety:
+  - Never delete a milestone or close issues. This command only
+    assigns / unassigns.
+  - Label swaps are idempotent; running this command multiple times
+    converges on the same state.
+  - If `<name>` contains shell-special chars (quotes, `$`), wrap in
+    single quotes when passing to `gh`.
+
+This command is interactive by design — bundling release scope is a
+human-in-the-loop decision. aidev shows you the material; you pick.

--- a/internal/plugin/files/aidev-triage.md
+++ b/internal/plugin/files/aidev-triage.md
@@ -1,0 +1,117 @@
+---
+description: Bulk Critic pass over every un-triaged open issue in a repo, apply verdict labels
+argument-hint: [repo-path]
+allowed-tools: Bash(aidev:*), Bash(gh:*), Bash(git:*), Read
+---
+
+Run a bulk Critic triage over every open issue in a target repo that
+doesn't yet have an `aidev:*` label. For each such issue, runs Scout +
+Critic locally via your Claude Code subscription (no Anthropic API key,
+no CI, no API budget risk), then applies one of four labels based on
+the verdict:
+
+  - `aidev:approved`         — Critic recommended `build` (ready for bundling)
+  - `aidev:deferred`         — Critic recommended `defer` (not the right time)
+  - `aidev:killed`           — Critic recommended `kill` (bad idea)
+  - `aidev:needs-refinement` — Critic returned `unclear` (issue body needs refinement)
+
+Use this when you sit down to do backlog work and want to know which
+issues deserve your time.
+
+STEP 1 — Parse `$ARGUMENTS`. The first token (optional) is the repo
+path. Default to `.` (cwd). Expand `~` to `$HOME`.
+
+Do NOT use `!` shell execution — use the Bash tool directly.
+
+STEP 2 — Resolve the repo owner/name from its git remote:
+
+    gh repo view <PATH> --json owner,name --jq '.owner.login + "/" + .name'
+
+Capture as `<owner>/<repo>`.
+
+STEP 3 — Find un-triaged issues:
+
+    gh issue list --repo <owner>/<repo> --state open --limit 200 \
+      --json number,title,labels \
+      --jq '[.[] | select([.labels[].name] | any(startswith("aidev:")) | not)]'
+
+Filter: any issue whose label set does NOT contain any `aidev:*` entry.
+If the result is empty, tell the user "no untriaged issues — backlog is
+clean" and STOP.
+
+STEP 4 — Show the user the candidate list (just titles + numbers) and
+ask via `AskUserQuestion`:
+
+  - **Proceed** (recommended) — run Critic on all candidates
+  - **Preview only** — show the commands that would run, don't execute
+  - **Cancel**
+
+If `Cancel`, STOP.
+If `Preview only`, print the exact `aidev` command for each candidate
+and STOP.
+
+STEP 5 — For each candidate issue (sequentially):
+
+  a. Print a progress line: `--- [i/N] Triaging #<num>: <title> ---`
+
+  b. Run Critic locally:
+
+         aidev -headless -issue <num> -repo <PATH>
+
+     This runs Scout + Critic only (no Architect without `-auto`). It
+     prints the Critic report to stdout and posts the report as a
+     comment to the GH issue via the existing reporter path.
+
+  c. Parse the verdict from the last line of stdout. The report
+     emits `RECOMMENDATION: build`, `RECOMMENDATION: defer`,
+     `RECOMMENDATION: kill`, or `RECOMMENDATION: unclear`.
+
+  d. Map verdict → label:
+
+         build   → aidev:approved
+         defer   → aidev:deferred
+         kill    → aidev:killed
+         unclear → aidev:needs-refinement
+
+  e. Create the label if missing (idempotent):
+
+         gh label create <label> --repo <owner>/<repo> \
+           --color <rrggbb> --description "<desc>" --force
+
+     Color suggestions: approved=0E8A16 (green), deferred=FBCA04
+     (yellow), killed=B60205 (red), needs-refinement=D93F0B (orange).
+
+  f. Apply the label + remove any stale `aidev:awaiting-decision`:
+
+         gh issue edit <num> --repo <owner>/<repo> \
+           --add-label <label> --remove-label aidev:awaiting-decision
+
+  g. Capture the verdict + one-line Critic rationale (first bullet of
+     the "Arguments FOR" or "AGAINST" section, depending on verdict)
+     for the final summary.
+
+STEP 6 — Print a final summary table. Columns: `#`, `Title`,
+`Verdict`, `Label`, `Rationale (one line)`. Group by verdict so the
+`aidev:approved` rows (your next-action candidates) are at the top.
+
+STEP 7 — Tell the user what to do next:
+
+  - If there are `aidev:approved` issues: "Run `/aidev-release
+    <milestone-name> <PATH>` to bundle approved issues into a release."
+  - If there are only `aidev:needs-refinement` / `aidev:deferred` /
+    `aidev:killed` issues: suggest they edit issue bodies to address
+    the Critic's sharp questions, then re-run `/aidev-triage`.
+
+Safety:
+  - Skip any issue whose title starts with `[follow-up #` — those
+    are aidev-generated follow-up issues and already have context.
+  - Cap the run at 20 issues by default; if the candidate list is
+    longer, ask the user whether to process all or just the first 20.
+  - If `aidev -headless` fails for any issue (exit != 0), capture the
+    error into the summary row as `Verdict: ERROR` and continue with
+    the next issue. Don't let one bad issue halt the batch.
+
+Remember: this runs on YOUR machine using YOUR Claude Code
+subscription. No API keys in CI, no cloud costs surprises. The total
+run time is roughly `N × 60s` for N issues — typically 5-10 minutes
+for a normal backlog.

--- a/plugin/aidev/commands/aidev-implement-bundle.md
+++ b/plugin/aidev/commands/aidev-implement-bundle.md
@@ -1,0 +1,159 @@
+---
+description: Run the full autonomous /aidev-run pipeline against every issue in a GitHub milestone
+argument-hint: <milestone-name> [repo-path]
+allowed-tools: Bash(aidev:*), Bash(gh:*), Bash(git:*), Read, Edit, Write, AskUserQuestion
+---
+
+Run the full autonomous `/aidev-run` pipeline — Scout → Critic →
+Architect → Selector → Claude Code implementation → tests → PR → review
+loop — against every open issue in a GitHub milestone, in sequence.
+Each issue produces its own PR branched from `origin/preview`. You
+review and merge PRs in whatever order you prefer.
+
+Use this AFTER `/aidev-release <milestone>` has assembled the bundle
+you want to ship.
+
+STEP 1 — Parse `$ARGUMENTS`. First token (required) is the milestone
+name. Second token (optional) is the repo path; default `.` (cwd).
+
+If the milestone name is missing, STOP and ask the user.
+
+STEP 2 — Resolve repo owner/name:
+
+    gh repo view <PATH> --json owner,name --jq '.owner.login + "/" + .name'
+
+STEP 3 — Fetch milestone issues:
+
+    gh issue list --repo <owner>/<repo> --milestone "<name>" \
+      --state open --json number,title,labels \
+      --jq '[.[] | {number, title, labels: [.labels[].name]}]'
+
+If empty, say "Milestone `<name>` has no open issues; nothing to
+implement. Run `/aidev-release <name> <PATH>` first." and STOP.
+
+STEP 4 — Surface the bundle to the user and ask to confirm via
+`AskUserQuestion`:
+
+  - **Proceed — run pipeline on all <N> issues** (recommended)
+  - **Proceed — but stop after the first issue for a sanity check**
+  - **Show me the Critic verdict for each issue first**
+  - **Cancel**
+
+If `Show me the Critic verdict`, for each issue run:
+
+    gh issue view <num> --repo <owner>/<repo> --comments \
+      | grep -A 20 'Critic report'
+
+and display. Then re-ask the confirmation question.
+
+If `Cancel`, STOP.
+
+STEP 5 — Dirty-tree precheck on the target repo:
+
+    git -C <PATH> status --porcelain
+
+If non-empty, STOP and tell the user to commit/stash/discard their
+working-tree changes first. The pipeline will cut feature branches per
+issue; dirty tree is dangerous.
+
+STEP 6 — Sync the base branch. Because each `/aidev-run` cuts the
+feature branch from `origin/<base>`, we want the base up-to-date:
+
+    git -C <PATH> fetch origin
+
+STEP 7 — Iterate over every issue in the bundle. For each:
+
+  a. Print a progress marker:
+
+         ========================================================
+         [<i>/<N>] Issue #<num>: <title>
+         ========================================================
+
+  b. Invoke the full `/aidev-run` pipeline for this issue. This is the
+     same flow as running `/aidev-run <num> <PATH>` directly — STEPS 1
+     through 15 from `aidev-run.md`. You MUST execute all of those
+     steps for each issue, including:
+
+       - STEP 2: `aidev -headless -auto -n 3 -issue <num> -repo <PATH>`
+       - STEP 6: check for `AIDEV_NEEDS_REFINEMENT=1` marker
+       - STEP 7: dirty-tree check (should pass since we checked in STEP 5
+         above, but per-issue push commits may leave artifacts — verify)
+       - STEP 7.5: cut feature branch via `gh issue develop` from
+         `origin/<base>`
+       - STEP 8: implement the Selector's chosen sketch natively
+       - STEP 9: run the project's test suite
+       - STEP 10: commit + push + `gh pr create`
+       - STEP 11: post PR-link comment back to the issue
+       - STEPS 12-15: autonomous review loop (wait for CI, run triage,
+         fix/rebut/defer/escalate, converge)
+
+     See `aidev-run.md` for the full specification of each step.
+
+  c. Record the outcome for the final summary:
+
+       - PR number opened (if reached STEP 10)
+       - Final review-loop convergence (`approve` / `rebut_to_ship` /
+         `escalate` / `needs-refinement`)
+       - Any new `aidev:followup` issues filed during the run
+       - Any errors or skipped steps
+
+  d. If the user chose `Proceed — but stop after the first issue` in
+     STEP 4, STOP now and go to STEP 9.
+
+  e. Between issues, switch back to the base branch so the next issue's
+     `gh issue develop` has a clean starting point:
+
+         git -C <PATH> checkout <base-branch>
+
+     (`<base-branch>` is whatever STEP 7.5 resolved — typically
+     `preview`.)
+
+STEP 8 — Continue until all issues are processed.
+
+STEP 9 — Print the final bundle summary:
+
+    === Bundle <name> complete ===
+    Processed: <N> issues
+    PRs opened: <list of #<PRNUM>>
+    Review loop converged (approve): <count>
+    Rebutted to ship: <count>
+    Escalated (needs human): <count>
+    Needs refinement (Critic=unclear): <count>
+    Errors: <count>
+
+    Follow-up issues filed during runs:
+      - #<num>  <title>
+
+    Next actions:
+      - Merge PRs in preferred order (PRs targeting <base-branch>)
+      - For escalated PRs: review the escalation comment + resolve manually
+      - For needs-refinement issues: edit body + re-run /aidev-triage
+
+    When all PRs merge and the milestone is complete, tag the release:
+      git tag v<name> && git push origin v<name>
+
+STEP 10 — Done.
+
+Safety:
+  - The bundle runs PRs in PARALLEL in the sense that each PR targets
+    the same base branch; they'll have merge conflicts if they touch
+    overlapping files. aidev does NOT sequence them by merging the
+    previous PR before running the next. You control merge order.
+  - Each issue is independent; one failing (escalate, refinement)
+    does not abort the batch. The summary shows everything.
+  - The first-issue-sanity-check option (STEP 4) is the safe way to
+    try this on a new repo — run one end-to-end, verify the PR looks
+    right, then re-run for the rest.
+  - Total wall-clock time is roughly `N × 5-10 minutes` depending on
+    sketch count, test suite duration, and CI latency. For a 5-issue
+    bundle, budget 30-60 minutes.
+
+Cost: all autonomous decisions run through your Claude Code
+subscription (claude-cli). No Anthropic API budget required.
+Implementation is Claude Code native tools — same subscription.
+Only cost outside your subscription is GitHub Actions CI minutes for
+the review-loop's CI-wait step.
+
+See `aidev-run.md` for the full single-issue pipeline spec.
+See `aidev-release.md` for how to assemble a bundle before running
+this command.

--- a/plugin/aidev/commands/aidev-release.md
+++ b/plugin/aidev/commands/aidev-release.md
@@ -1,0 +1,142 @@
+---
+description: Show + confirm a release bundle for a given GitHub milestone
+argument-hint: <milestone-name> [repo-path]
+allowed-tools: Bash(gh:*), Bash(aidev:*), Read
+---
+
+Assemble (or inspect) a release bundle around a GitHub milestone. Takes
+you from "these issues are `aidev:approved`" to "these issues are in
+milestone v0.4.0 and ready for `/aidev-implement-bundle`."
+
+Workflow this command supports:
+
+  1. You triage new issues with `/aidev-triage` — those with Critic
+     verdict `build` get the `aidev:approved` label.
+  2. You run `/aidev-release v0.4.0 <repo>` — this command shows you
+     (a) what's already in the milestone, and (b) approved-but-unassigned
+     candidates. You pick which candidates to add.
+  3. When the milestone looks right, you run
+     `/aidev-implement-bundle v0.4.0 <repo>` to ship it.
+
+STEP 1 — Parse `$ARGUMENTS`. First token (required) is the milestone
+name. Second token (optional) is the repo path; default `.` (cwd).
+
+If `$ARGUMENTS` is missing the milestone name, STOP and ask the user
+for one.
+
+STEP 2 — Resolve repo owner/name:
+
+    gh repo view <PATH> --json owner,name --jq '.owner.login + "/" + .name'
+
+STEP 3 — Ensure the milestone exists. Look it up:
+
+    gh api repos/<owner>/<repo>/milestones?state=open \
+      --jq '.[] | select(.title == "<name>") | {number, title, url, due_on}'
+
+If not found, ask the user via `AskUserQuestion`:
+
+  - **Create milestone `<name>` now** — `gh api repos/<owner>/<repo>/milestones -X POST -f title=<name>`
+  - **Use a different name** — prompt for a new name
+  - **Cancel**
+
+STEP 4 — List what's currently in the milestone:
+
+    gh issue list --repo <owner>/<repo> --milestone "<name>" --state open \
+      --json number,title,labels,body \
+      --jq '.'
+
+Show the user each one as: `#<num>  [<verdict>]  <title>` where
+`<verdict>` is inferred from the `aidev:*` labels (`approved` →
+`approved`, `needs-refinement` → `⚠ needs refinement`, etc).
+
+STEP 5 — List candidate issues (approved, no milestone assigned):
+
+    gh issue list --repo <owner>/<repo> --state open --label aidev:approved \
+      --no-milestone --json number,title,body \
+      --jq '.'
+
+Note: `--no-milestone` filter; only the issues that have
+`aidev:approved` AND are currently unassigned to any milestone.
+
+STEP 6 — Show the user the two lists in this order:
+
+    Milestone <name> (N issues):
+      - #<num>  <title>                    [verdict]
+      ...
+
+    Approved candidates (M available, no milestone yet):
+      - #<num>  <title>                    [Critic one-line]
+      ...
+
+If there are zero candidates AND zero in-milestone issues, say
+"Milestone `<name>` is empty; run `/aidev-triage` first to approve
+issues." and STOP.
+
+STEP 7 — Ask the user what to do via `AskUserQuestion`:
+
+  - **Add all candidates to the milestone** — bundle everything approved
+  - **Pick specific candidates** — interactive pick (next step)
+  - **Remove an issue from the milestone** — unbundle one
+  - **Show details of a candidate** — paste the Critic rationale for a specific issue
+  - **Done — bundle looks good** — finalize and show next steps
+  - **Cancel**
+
+STEP 8 — Handle the user's choice:
+
+  - `Add all candidates`: for each candidate issue, run:
+
+        gh issue edit <num> --repo <owner>/<repo> \
+          --milestone "<name>" \
+          --remove-label aidev:approved \
+          --add-label aidev:bundled
+
+    Then loop back to STEP 4 to show the updated state.
+
+  - `Pick specific candidates`: use `AskUserQuestion` with each
+    candidate as an option (up to 4 per question; for larger lists,
+    iterate in pages of 4). For each `Yes` answer, apply the same
+    milestone edit + label swap as above.
+
+  - `Remove an issue`: ask for the issue number, then:
+
+        gh issue edit <num> --repo <owner>/<repo> \
+          --milestone "" \
+          --remove-label aidev:bundled \
+          --add-label aidev:approved
+
+  - `Show details of a candidate`: ask for the number, then print:
+
+        gh issue view <num> --repo <owner>/<repo> --comments
+
+  - `Done`: jump to STEP 9.
+
+  - `Cancel`: STOP.
+
+STEP 9 — Finalize. Print a summary of the milestone:
+
+    Release candidate: <name>
+      <N> issues bundled:
+        #<num>  <title>
+        ...
+
+      Ready to ship? Run:
+        /aidev-implement-bundle <name> <PATH>
+
+      That will run the full autonomous pipeline on each issue in
+      sequence, opening one PR per issue against origin/preview.
+
+STEP 10 — Optional: post a tracking comment to a pinned meta-issue
+(if one exists with label `aidev:release-tracker` and title matching
+`Release <name>`) so the bundle state is visible publicly. Skip if no
+such issue exists; don't auto-create one.
+
+Safety:
+  - Never delete a milestone or close issues. This command only
+    assigns / unassigns.
+  - Label swaps are idempotent; running this command multiple times
+    converges on the same state.
+  - If `<name>` contains shell-special chars (quotes, `$`), wrap in
+    single quotes when passing to `gh`.
+
+This command is interactive by design — bundling release scope is a
+human-in-the-loop decision. aidev shows you the material; you pick.

--- a/plugin/aidev/commands/aidev-triage.md
+++ b/plugin/aidev/commands/aidev-triage.md
@@ -1,0 +1,117 @@
+---
+description: Bulk Critic pass over every un-triaged open issue in a repo, apply verdict labels
+argument-hint: [repo-path]
+allowed-tools: Bash(aidev:*), Bash(gh:*), Bash(git:*), Read
+---
+
+Run a bulk Critic triage over every open issue in a target repo that
+doesn't yet have an `aidev:*` label. For each such issue, runs Scout +
+Critic locally via your Claude Code subscription (no Anthropic API key,
+no CI, no API budget risk), then applies one of four labels based on
+the verdict:
+
+  - `aidev:approved`         — Critic recommended `build` (ready for bundling)
+  - `aidev:deferred`         — Critic recommended `defer` (not the right time)
+  - `aidev:killed`           — Critic recommended `kill` (bad idea)
+  - `aidev:needs-refinement` — Critic returned `unclear` (issue body needs refinement)
+
+Use this when you sit down to do backlog work and want to know which
+issues deserve your time.
+
+STEP 1 — Parse `$ARGUMENTS`. The first token (optional) is the repo
+path. Default to `.` (cwd). Expand `~` to `$HOME`.
+
+Do NOT use `!` shell execution — use the Bash tool directly.
+
+STEP 2 — Resolve the repo owner/name from its git remote:
+
+    gh repo view <PATH> --json owner,name --jq '.owner.login + "/" + .name'
+
+Capture as `<owner>/<repo>`.
+
+STEP 3 — Find un-triaged issues:
+
+    gh issue list --repo <owner>/<repo> --state open --limit 200 \
+      --json number,title,labels \
+      --jq '[.[] | select([.labels[].name] | any(startswith("aidev:")) | not)]'
+
+Filter: any issue whose label set does NOT contain any `aidev:*` entry.
+If the result is empty, tell the user "no untriaged issues — backlog is
+clean" and STOP.
+
+STEP 4 — Show the user the candidate list (just titles + numbers) and
+ask via `AskUserQuestion`:
+
+  - **Proceed** (recommended) — run Critic on all candidates
+  - **Preview only** — show the commands that would run, don't execute
+  - **Cancel**
+
+If `Cancel`, STOP.
+If `Preview only`, print the exact `aidev` command for each candidate
+and STOP.
+
+STEP 5 — For each candidate issue (sequentially):
+
+  a. Print a progress line: `--- [i/N] Triaging #<num>: <title> ---`
+
+  b. Run Critic locally:
+
+         aidev -headless -issue <num> -repo <PATH>
+
+     This runs Scout + Critic only (no Architect without `-auto`). It
+     prints the Critic report to stdout and posts the report as a
+     comment to the GH issue via the existing reporter path.
+
+  c. Parse the verdict from the last line of stdout. The report
+     emits `RECOMMENDATION: build`, `RECOMMENDATION: defer`,
+     `RECOMMENDATION: kill`, or `RECOMMENDATION: unclear`.
+
+  d. Map verdict → label:
+
+         build   → aidev:approved
+         defer   → aidev:deferred
+         kill    → aidev:killed
+         unclear → aidev:needs-refinement
+
+  e. Create the label if missing (idempotent):
+
+         gh label create <label> --repo <owner>/<repo> \
+           --color <rrggbb> --description "<desc>" --force
+
+     Color suggestions: approved=0E8A16 (green), deferred=FBCA04
+     (yellow), killed=B60205 (red), needs-refinement=D93F0B (orange).
+
+  f. Apply the label + remove any stale `aidev:awaiting-decision`:
+
+         gh issue edit <num> --repo <owner>/<repo> \
+           --add-label <label> --remove-label aidev:awaiting-decision
+
+  g. Capture the verdict + one-line Critic rationale (first bullet of
+     the "Arguments FOR" or "AGAINST" section, depending on verdict)
+     for the final summary.
+
+STEP 6 — Print a final summary table. Columns: `#`, `Title`,
+`Verdict`, `Label`, `Rationale (one line)`. Group by verdict so the
+`aidev:approved` rows (your next-action candidates) are at the top.
+
+STEP 7 — Tell the user what to do next:
+
+  - If there are `aidev:approved` issues: "Run `/aidev-release
+    <milestone-name> <PATH>` to bundle approved issues into a release."
+  - If there are only `aidev:needs-refinement` / `aidev:deferred` /
+    `aidev:killed` issues: suggest they edit issue bodies to address
+    the Critic's sharp questions, then re-run `/aidev-triage`.
+
+Safety:
+  - Skip any issue whose title starts with `[follow-up #` — those
+    are aidev-generated follow-up issues and already have context.
+  - Cap the run at 20 issues by default; if the candidate list is
+    longer, ask the user whether to process all or just the first 20.
+  - If `aidev -headless` fails for any issue (exit != 0), capture the
+    error into the summary row as `Verdict: ERROR` and continue with
+    the next issue. Don't let one bad issue halt the batch.
+
+Remember: this runs on YOUR machine using YOUR Claude Code
+subscription. No API keys in CI, no cloud costs surprises. The total
+run time is roughly `N × 60s` for N issues — typically 5-10 minutes
+for a normal backlog.


### PR DESCRIPTION
## Summary

Adds three slash commands for maintainers who want to run the full backlog management workflow locally — no \`ANTHROPIC_API_KEY\` in GitHub Actions, no CI budget risk. All three use the user's Claude Code subscription via claude-cli.

## What's new

- **\`/aidev-triage [repo-path]\`** — bulk Critic pass over every open issue that doesn't yet have an \`aidev:*\` label. Applies one of four verdict labels (\`aidev:approved\` / \`aidev:deferred\` / \`aidev:killed\` / \`aidev:needs-refinement\`). Cap of 20 issues per run; total time ~\`N × 60s\`.
- **\`/aidev-release <milestone> [repo-path]\`** — interactive bundle assembly around a GitHub milestone. Shows what's in the milestone + approved-but-unassigned candidates; user picks which to add; label swap from \`aidev:approved\` → \`aidev:bundled\`. Creates the milestone if missing.
- **\`/aidev-implement-bundle <milestone> [repo-path]\`** — runs the full \`/aidev-run\` pipeline (Scout → Critic → Architect → Selector → Claude Code impl → tests → PR → review loop) on every open issue in the milestone, sequentially. One PR per issue, all branched from \`origin/<base>\`. Summary at the end: PRs opened, review-loop convergence per issue, follow-up issues filed.

## Why

User hit the \"API key abuse in public-repo Actions\" problem and wanted a local-only alternative. The three commands compose into a workflow: triage (frequent) → bundle (occasional) → implement (on-release-cadence). GH milestones are the bundle primitive — native GitHub concept, no new schema; GitLab/Jira support deferred to later.

## Design decisions

- **Verdict → label map**: \`build\` → \`aidev:approved\`, \`defer\` → \`aidev:deferred\`, \`kill\` → \`aidev:killed\`, \`unclear\` → \`aidev:needs-refinement\`. Consolidates the previously-fragmented \`aidev:awaiting-decision\` label.
- **Un-triaged = no \`aidev:*\` label**: simple, aligns with existing orchestrator's label-application flow.
- **Parallel PRs in \`implement-bundle\`**: all issues branch from \`origin/<base>\`; may conflict on merge; user sequences merges. A \`--sequential\` mode that waits between issues is future work.
- **Follow-up issues filed in the implement-bundle run** accumulate as normal \`aidev:followup\` issues; they're surfaced in the final summary but not auto-triaged.

## Test plan

- [x] \`go build ./...\` + \`go test ./internal/plugin/...\` green (embedded \`all:files\` picks up new slash commands automatically; no Go code change needed)
- [x] Plugin files mirror between \`plugin/aidev/commands/\` (canonical) and \`internal/plugin/files/\` (embedded)
- [x] \`docs/usage.md\` updated with all three commands + \"Local issue-management workflow\" section

## Follow-up (not in this PR)

- Integration test running \`/aidev-triage\` against a small synthetic repo — punted as the existing plugin tests don't exercise slash-command contents
- GitLab / Jira bundle primitives — deferred per the user's decision to start with GH milestones