### PR TITLE
docs: keep license link on Pages site + simplify Source section labels

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ The rest of the pipeline is built around the same principle: every decision has 
 
 ## Source
 
-- Repo: [github.com/AiSU-AI/aidev](https://github.com/AiSU-AI/aidev)
-- License: [MIT](https://github.com/AiSU-AI/aidev/blob/main/LICENSE)
-- Issues: [github.com/AiSU-AI/aidev/issues](https://github.com/AiSU-AI/aidev/issues)
+- [Repository](https://github.com/AiSU-AI/aidev)
+- [License (MIT)](license.md)
+- [Issues](https://github.com/AiSU-AI/aidev/issues)
+- [Releases](https://github.com/AiSU-AI/aidev/releases)

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,33 @@
+---
+title: License
+---
+
+# License
+
+aidev is released under the **MIT License**. The canonical text lives
+at [LICENSE](https://github.com/AiSU-AI/aidev/blob/main/LICENSE) in the
+repository root; this page mirrors it so you stay on the docs site.
+
+---
+
+MIT License
+
+Copyright (c) 2026 AiSU-AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Fixes two small Pages-landing issues flagged by user review:

1. **License link popped off the Pages site.** Clicking `[MIT]` in the Source section navigated to `github.com/.../blob/main/LICENSE` (GitHub's rendering) instead of staying on the docs site. Mirrored the MIT text into `docs/license.md` and relinked locally. The canonical `LICENSE` at repo root is unchanged; `docs/license.md` is a Pages-only mirror that points back to the canonical.
2. **Link text showed full URLs** (`github.com/AiSU-AI/aidev` etc) instead of clean labels. Replaced with simple noun labels ("Repository", "Issues", "Releases") — the URL stays in the href but the rendered link text is now readable.

## Changes

- NEW: `docs/license.md` — MIT text mirror with a pointer to the canonical `LICENSE`
- MODIFY: `docs/index.md` — Source section links simplified:
  ```
  - [Repository](https://github.com/AiSU-AI/aidev)
  - [License (MIT)](license.md)
  - [Issues](https://github.com/AiSU-AI/aidev/issues)
  - [Releases](https://github.com/AiSU-AI/aidev/releases)
  ```

## Test plan

- [x] `go build ./...` green (docs-only; covered by existing CI)
- [ ] After merge + Pages rebuild: `https://aisu-ai.github.io/aidev/` Source section shows clean labels; clicking MIT stays on the Pages site
