### PR TITLE
fix: headless-auto Critic=unclear emits structured needs-refinement comment

### DIFF
--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -1147,6 +1147,37 @@ func runHeadless(ctx context.Context, orch *orchestrator.Orchestrator, cfg *conf
 		rpt.Recommendation = forceVerdict
 	}
 
+	// Issue #46: when auto-run ends with Critic=unclear and we didn't
+	// resolve it (either no TTY so no interview ran, or the interview
+	// ran but couldn't drive the verdict to build), emit the structured
+	// needs-refinement audit trail instead of silently landing on
+	// StateAwaitUser with the vague aidev:awaiting-decision label.
+	// The slash command's STEP 6 depends on grep'ing
+	// AIDEV_NEEDS_REFINEMENT=1 — without this emission that grep
+	// silently fails and the slash command barrels past a state the
+	// user should have been told about.
+	if auto && rpt != nil && rpt.Recommendation == "unclear" {
+		// The full Critic report with its sharp questions is already
+		// posted to the issue by the Critic's own reporter path;
+		// postNeedsRefinement points the reader at it via
+		// "see the Critic comment above", so we don't need to parse
+		// the sharp-questions block out of the Critic markdown here.
+		// A short static reason is enough to anchor the audit comment.
+		reason := "Critic verdict: unclear. The Clarifier couldn't resolve the ambiguity (no TTY for an interactive interview, or the interview ran but the verdict stayed unclear). See the Critic report above for the sharp questions that need human answers before aidev can proceed."
+		for ev := range orch.MarkNeedsRefinement(ctx, reason) {
+			if ev.Err != nil {
+				fmt.Fprintf(os.Stderr, "aidev: mark needs-refinement: %v\n", ev.Err)
+			}
+		}
+		fmt.Println()
+		fmt.Println("## ⚠ aidev needs refinement before implementing")
+		fmt.Println()
+		fmt.Println("The Critic couldn't reach a decisive verdict. See the GH issue for the structured refinement comment with actionable next steps. The slash command should NOT proceed to implementation.")
+		fmt.Println()
+		fmt.Println("AIDEV_NEEDS_REFINEMENT=1")
+		return
+	}
+
 	if !auto || rpt == nil || rpt.Recommendation != "build" {
 		return
 	}

--- a/internal/orchestrator/needs_refinement_test.go
+++ b/internal/orchestrator/needs_refinement_test.go
@@ -1,0 +1,100 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aisu-ai/aidev/internal/agents"
+)
+
+// TestMarkNeedsRefinementFromAwaitUser verifies the happy path: a
+// headless auto-run that ended on the natural StateAwaitUser resting
+// place (after Critic=unclear with no Clarifier possible) can be
+// marked into StateNeedsRefinement by the caller.
+//
+// The emitted event must carry the supplied reason so the
+// GitHubReporter's postNeedsRefinement path has context to include
+// in the structured 🤔 audit comment.
+//
+// This is the regression test that closes issue #46 — without
+// MarkNeedsRefinement, callers in cmd/aidev.runHeadless had no clean
+// way to promote an `unclear` verdict to the structured refinement
+// comment, and silently landed on the vague `aidev:awaiting-decision`
+// label instead.
+func TestMarkNeedsRefinementFromAwaitUser(t *testing.T) {
+	o := &Orchestrator{
+		state:    StateAwaitUser,
+		ctx:      &agents.Context{},
+		reporter: NullReporter{},
+	}
+	reason := "Critic verdict: unclear. See the Critic report above."
+
+	ch := o.MarkNeedsRefinement(context.Background(), reason)
+
+	var events []Event
+	for ev := range ch {
+		events = append(events, ev)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 event, got %d", len(events))
+	}
+	ev := events[0]
+	if ev.Err != nil {
+		t.Errorf("expected no error, got %v", ev.Err)
+	}
+	if ev.State != StateNeedsRefinement {
+		t.Errorf("expected State=%q, got %q", StateNeedsRefinement, ev.State)
+	}
+	if !strings.Contains(ev.Message, reason) {
+		t.Errorf("expected Message to contain reason %q, got %q", reason, ev.Message)
+	}
+	if o.state != StateNeedsRefinement {
+		t.Errorf("expected orchestrator.state=%q after MarkNeedsRefinement, got %q",
+			StateNeedsRefinement, o.state)
+	}
+}
+
+// TestMarkNeedsRefinementRefusesFromWrongState mirrors the
+// TestRecritiqueRefusesFromWrongState pattern: calling
+// MarkNeedsRefinement from any state other than StateAwaitUser is a
+// misuse and must fail loudly rather than corrupt the audit trail.
+// Specifically we care about:
+//
+//   - StateInit: before the first Run()
+//   - StateScouting / StateCritiquing / StateArchitecting: mid-pipeline
+//   - StateSketchesReady: after Architect but before Selector
+//   - StateDone / StateKilled / StateNeedsRefinement: terminal states
+//
+// For every non-await_user state, we expect a StateError emission and
+// the orchestrator state pinned to StateError.
+func TestMarkNeedsRefinementRefusesFromWrongState(t *testing.T) {
+	cases := []State{
+		StateInit,
+		StateScouting,
+		StateCritiquing,
+		StateArchitecting,
+		StateSketchesReady,
+		StateDone,
+		StateKilled,
+		StateNeedsRefinement, // already in the target state — still rejected
+	}
+	for _, s := range cases {
+		t.Run(string(s), func(t *testing.T) {
+			o := &Orchestrator{state: s, ctx: &agents.Context{}, reporter: NullReporter{}}
+			ch := o.MarkNeedsRefinement(context.Background(), "test reason")
+			var sawErr bool
+			for ev := range ch {
+				if ev.Err != nil && ev.State == StateError {
+					sawErr = true
+				}
+			}
+			if !sawErr {
+				t.Errorf("expected MarkNeedsRefinement to emit an error event from state %q", s)
+			}
+			if o.state != StateError {
+				t.Errorf("expected orchestrator.state=error after rejected MarkNeedsRefinement, got %q", o.state)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -837,6 +837,46 @@ func (o *Orchestrator) Recritique(ctx context.Context) <-chan Event {
 	return out
 }
 
+// MarkNeedsRefinement transitions the orchestrator into
+// StateNeedsRefinement with the supplied reason. It exists so the
+// headless auto-run path in `cmd/aidev` can emit the structured
+// "🤔 needs refinement" audit comment when the Critic returns unclear
+// in an environment where the Clarifier interview couldn't resolve it
+// (no TTY, or the interview ran and the verdict stayed unclear).
+//
+// This is the missing transition that issue #46 tracks: today, that
+// codepath returns silently and the reporter applies the vague
+// `aidev:awaiting-decision` label instead of the structured refinement
+// comment + `aidev:needs-refinement` label the Selector-refusal path
+// already produces. Reusing the existing StateNeedsRefinement
+// emission keeps the contract (label, comment template, stdout marker
+// via the caller) in one place.
+//
+// Valid from StateAwaitUser (the natural resting place after the
+// first Run() pass when the Critic verdict didn't auto-advance the
+// pipeline). Any other state is a misuse — we surface a StateError
+// rather than corrupt the audit trail.
+func (o *Orchestrator) MarkNeedsRefinement(ctx context.Context, reason string) <-chan Event {
+	out := make(chan Event, 2)
+	go func() {
+		defer close(out)
+		if o.state != StateAwaitUser {
+			o.emit(ctx, out, Event{
+				State: StateError,
+				Err:   fmt.Errorf("orchestrator: MarkNeedsRefinement called from state %q, expected await_user", o.state),
+			})
+			o.state = StateError
+			return
+		}
+		o.state = StateNeedsRefinement
+		o.emit(ctx, out, Event{
+			State:   o.state,
+			Message: reason,
+		})
+	}()
+	return out
+}
+
 // emit fans an event out to both the TUI channel and the Reporter. It
 // stamps the event with a pointer to the current agents.Context so the
 // Reporter can read downstream artifacts (ScoutReport, CriticReport,


### PR DESCRIPTION
## Summary

Closes #46.

When aidev runs in \`-headless -auto\` mode and the Critic returns \`unclear\` in an environment where the Clarifier interview cannot resolve it (no TTY for interactive input, or interview ran but verdict stayed unclear), the orchestrator previously landed silently on \`StateAwaitUser\`. The reporter then applied the vague \`aidev:awaiting-decision\` label and the slash command's \`grep AIDEV_NEEDS_REFINEMENT=1\` in STEP 6 silently failed — the user got no actionable guidance.

This PR wires the missing state transition.

## Implementation — Sketch 1 (Selector's pick, score 2.50)

Selector chose the \"wire missing transition, defer label rename\" approach over the larger refactor options because it's a one-transition fix with minimal blast radius. Verdict rationale: *\"Sketch 3's RefinementPolicy abstraction and golden-file harness are speculative infrastructure for a single missed branch. Deferring the label rename to a follow-up issue is the right call; the bug report's AC #4 explicitly allows either migrate-or-document, and bundling a taxonomy migration into a wiring fix enlarges blast radius unnecessarily.\"*

### Changes

- **\`internal/orchestrator/orchestrator.go\`**: new \`MarkNeedsRefinement(ctx, reason)\` method. Transitions \`StateAwaitUser → StateNeedsRefinement\` with the supplied reason, emits the event so the reporter picks it up. Rejects misuse (any non-\`StateAwaitUser\` source state) with a StateError.
- **\`cmd/aidev/main.go\`**: in \`runHeadless\` after the optional Clarifier interview, if \`auto && rpt.Recommendation == \"unclear\"\`, call \`MarkNeedsRefinement\` with a reason pointing at the Critic's sharp questions. The existing reporter's \`StateNeedsRefinement\` handler then posts the structured 🤔 comment and applies the \`aidev:needs-refinement\` label (replacing the transitional \`aidev:awaiting-decision\`). Also prints the \`AIDEV_NEEDS_REFINEMENT=1\` stdout marker the slash command's STEP 6 depends on.
- **\`internal/orchestrator/needs_refinement_test.go\`**: table-driven test covering the happy path + 8 misuse cases (every non-\`await_user\` state rejected).

### Out of scope

Following the Critic's sharp question #1 (migration plan for \`aidev:awaiting-decision\` → \`aidev:needs-refinement\`): this PR only ensures the Critic-unclear path now applies \`aidev:needs-refinement\` on fresh runs. Existing open issues carrying the transitional \`awaiting-decision\` label are untouched; a dedicated follow-up issue should track the label migration (rename in-place vs dual-emit) independently.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./...\` — all packages pass, new \`TestMarkNeedsRefinementFromAwaitUser\` + 8-case \`TestMarkNeedsRefinementRefusesFromWrongState\` green
- [ ] End-to-end: run \`aidev -headless -auto -n 3 -issue <vague> -repo .\` against an issue that produces Critic=unclear; verify \`AIDEV_NEEDS_REFINEMENT=1\` appears in stdout, the 🤔 comment lands on the issue, and the label is \`aidev:needs-refinement\`.

🤖 aidev autonomous run — decision (Scout → Critic → Architect → Selector) via aidev, implementation + tests + PR via Claude Code.