### PR TITLE
fix: make Architect sketch output deterministic (stable-hash sort + temperature=0 intent)

### DIFF
--- a/internal/agents/architect.go
+++ b/internal/agents/architect.go
@@ -2,8 +2,11 @@ package agents
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/aisu-ai/aidev/internal/llm"
@@ -128,6 +131,16 @@ func (a *Architect) Run(ctx context.Context, cc *Context) ([]Sketch, error) {
 			Messages: []llm.Message{
 				{Role: "user", Content: userMsg},
 			},
+			// Temperature=0 is aspirational intent for determinism
+			// (issue #38). Honored by the anthropic provider but
+			// currently a no-op via claude-cli, which does not forward
+			// per-call temperature to the subprocess. Setting it here
+			// encodes the goal so deterministic behaviour follows
+			// automatically once claude-cli exposes --temperature or
+			// when a user routes the Architect tier through the
+			// anthropic provider. The stable-hash sort below is the
+			// actual deterministic-ordering guarantee today.
+			Temperature: 0,
 		})
 		if err != nil {
 			// Accumulate the error but keep going — partial success is
@@ -155,11 +168,68 @@ func (a *Architect) Run(ctx context.Context, cc *Context) ([]Sketch, error) {
 	if len(sketches) == 0 {
 		return nil, fmt.Errorf("architect: produced no parseable sketches after %d calls. First error: %w", a.N, firstOrNil(callErrors))
 	}
+	// Deterministic ordering (issue #38). The N sequential LLM calls
+	// can produce the same 3 "ideas" in different emission orders
+	// across runs (e.g. a small prompt-sampling nudge picks idea-X
+	// first on one run and idea-Y first on the next, then the
+	// priorTitles steer the subsequent calls differently). Sorting by
+	// a stable hash of the sketch body gives the user a consistent
+	// `-sketch N` mapping: same sketch content → same ordinal slot,
+	// regardless of the order the LLM happened to emit them.
+	//
+	// The sort key is intentionally opaque (sha256 of markdown) — no
+	// semantic ordering (smallest-diff-first, lowest-risk-first) is
+	// promised. A future refinement can introduce semantic ordering
+	// if it proves valuable; for now "stable but arbitrary" is the
+	// contract.
+	sortSketchesDeterministic(sketches)
+	// Reassign 1-based Number and renumber the header after the sort
+	// so the new ordinal slot is reflected in both the struct field
+	// and the embedded markdown header.
+	for i := range sketches {
+		sketches[i].Number = i + 1
+		sketches[i].Markdown = renumberSketch(sketches[i].Markdown, i+1)
+	}
 	// Partial success path — log the missing ones via the returned
 	// sketches slice (caller sees len(sketches) < N) but do not fail.
 	// The headless reporter already prints "Architect produced X
 	// sketches" which will naturally reflect any shortfall.
 	return sketches, nil
+}
+
+// sortSketchesDeterministic orders sketches by a stable SHA-256 hash
+// of their markdown body. Pure function; deterministic given the same
+// input slice regardless of the order the LLM produced them in. The
+// hash is truncated to 16 hex chars for comparison — 64 bits of
+// collision space, more than enough for typical N=3..9 sketch
+// counts.
+//
+// Isolated in its own function so unit tests can drive arbitrary
+// permutations of the same sketches and assert the output order is
+// invariant.
+func sortSketchesDeterministic(sketches []Sketch) {
+	sort.SliceStable(sketches, func(i, j int) bool {
+		return sketchSortKey(sketches[i]) < sketchSortKey(sketches[j])
+	})
+}
+
+// sketchSortKey returns the stable hash-based key for a single
+// Sketch. It hashes the Title plus the markdown body with the
+// `## Sketch N:` header stripped — the number in that header is the
+// loop index (emission order), which is exactly what we're trying to
+// make irrelevant. Including it in the hash would defeat the sort:
+// same content emitted in different orders would produce different
+// keys (because the number would differ), and the sort would be
+// stable-but-pointless.
+//
+// Hashing (Title + body-without-header) gives same-content-same-key
+// across runs regardless of emission order — which is the `-sketch N`
+// invariant issue #38 is built around.
+func sketchSortKey(s Sketch) string {
+	body := sketchHeaderRe.ReplaceAllString(s.Markdown, "")
+	input := s.Title + "\n" + body
+	sum := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(sum[:8])
 }
 
 // buildUserMessage assembles the per-run user message the Architect sees

--- a/internal/agents/architect_test.go
+++ b/internal/agents/architect_test.go
@@ -262,12 +262,16 @@ func TestArchitectRunReturnsPartialSuccessOnMidRunFailure(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("want 2 surviving sketches, got %d", len(got))
 	}
-	// Renumbering uses the loop index so gaps collapse to 1..2 in the
-	// returned slice but the sketches themselves carry their original
-	// run-index numbers (1 and 3). That's fine — ParseSketches in the
-	// reporter re-renders the list in order.
-	if got[0].Number != 1 || got[1].Number != 3 {
-		t.Errorf("partial-success numbering: got %d and %d, want 1 and 3", got[0].Number, got[1].Number)
+	// Issue #38 changed this contract: after the stable-hash sort,
+	// sketches get contiguous post-sort numbers (1, 2) reflecting their
+	// ordinal position in the final slice, NOT their original call
+	// indices (which previously would have been 1 and 3 to signal
+	// "call 2 was lost"). The gap-preserving invariant is gone because
+	// the sort reorders independent of call order anyway; contiguous
+	// numbering matches what the user sees via `-sketch N`.
+	if got[0].Number != 1 || got[1].Number != 2 {
+		t.Errorf("partial-success numbering: got %d and %d, want 1 and 2 (post-sort contiguous)",
+			got[0].Number, got[1].Number)
 	}
 }
 
@@ -302,5 +306,153 @@ func TestRenumberSketchRewritesHeaderOnly(t *testing.T) {
 	}
 	if !strings.Contains(got, "body text") {
 		t.Errorf("body text lost: %q", got)
+	}
+}
+
+// TestSortSketchesDeterministic_InvariantUnderPermutation is the
+// regression test issue #38 is built around: given the same set of
+// sketches, the hash-sort must produce the same output order
+// regardless of which input order the LLM happened to emit them in.
+// Exercises every permutation of a 3-sketch set and asserts the
+// resulting sort key sequence is identical each time.
+func TestSortSketchesDeterministic_InvariantUnderPermutation(t *testing.T) {
+	base := []Sketch{
+		{Number: 1, Title: "Alpha approach", Markdown: "## Sketch 1: Alpha approach\n\nSome body text about alpha."},
+		{Number: 2, Title: "Beta approach", Markdown: "## Sketch 2: Beta approach\n\nSome body text about beta."},
+		{Number: 3, Title: "Gamma approach", Markdown: "## Sketch 3: Gamma approach\n\nSome body text about gamma."},
+	}
+
+	// All 6 permutations of 3 elements.
+	perms := [][3]int{
+		{0, 1, 2}, {0, 2, 1}, {1, 0, 2},
+		{1, 2, 0}, {2, 0, 1}, {2, 1, 0},
+	}
+
+	canonicalKeys := []string{"", "", ""}
+	for i, perm := range perms {
+		input := make([]Sketch, 3)
+		for j, idx := range perm {
+			input[j] = base[idx]
+		}
+		sortSketchesDeterministic(input)
+		keys := []string{
+			sketchSortKey(input[0]),
+			sketchSortKey(input[1]),
+			sketchSortKey(input[2]),
+		}
+		if i == 0 {
+			canonicalKeys = keys
+			continue
+		}
+		for j := range keys {
+			if keys[j] != canonicalKeys[j] {
+				t.Errorf("permutation %v slot %d: expected key %q, got %q",
+					perm, j, canonicalKeys[j], keys[j])
+			}
+		}
+	}
+}
+
+// TestSketchSortKeyDependsOnMarkdownNotTitle confirms the sort key is
+// derived from the full markdown body, not just the title — so a
+// title-rename (say, the Architect prompt evolves and titles shift)
+// doesn't silently scramble existing ordering for same-body sketches.
+// Equally: two sketches with different bodies but the same title
+// produce different keys.
+func TestSketchSortKeyDependsOnMarkdownNotTitle(t *testing.T) {
+	a := Sketch{Title: "Same title", Markdown: "body version A"}
+	b := Sketch{Title: "Same title", Markdown: "body version B"}
+	if sketchSortKey(a) == sketchSortKey(b) {
+		t.Errorf("expected different sort keys for different bodies; got %q for both", sketchSortKey(a))
+	}
+}
+
+// TestArchitectRunReturnsDeterministicOrdering is the end-to-end
+// sanity check for issue #38: feed the Architect the same three
+// sketches in two different emission orders; assert both runs produce
+// the same ordinal-to-content mapping after the stable-hash sort.
+//
+// Note: sketches are emitted by the stubbed provider AS IF from
+// independent LLM calls, but because the Architect's system prompt
+// threads prior titles for diversity, the sketch TITLES in the stubbed
+// replies get "renumbered" by renumberSketch(...) after parsing. The
+// assertion compares sketchSortKey() across runs — that's what
+// matters for the `-sketch N` CLI contract.
+func TestArchitectRunReturnsDeterministicOrdering(t *testing.T) {
+	bodyA := singleSketchBody("Alpha approach")
+	bodyB := singleSketchBody("Beta approach")
+	bodyC := singleSketchBody("Gamma approach")
+
+	// Round 1 — stubbed provider emits in order A, B, C.
+	r1 := &sequencedProvider{
+		t:    t,
+		name: "stub-r1",
+		replies: []sequencedReply{
+			{body: bodyA},
+			{body: bodyB},
+			{body: bodyC},
+		},
+	}
+	arch1 := &Architect{Provider: r1, N: 3}
+	sketches1, err := arch1.Run(context.Background(), newArchitectCtx())
+	if err != nil {
+		t.Fatalf("round 1: %v", err)
+	}
+
+	// Round 2 — stubbed provider emits in order C, A, B.
+	r2 := &sequencedProvider{
+		t:    t,
+		name: "stub-r2",
+		replies: []sequencedReply{
+			{body: bodyC},
+			{body: bodyA},
+			{body: bodyB},
+		},
+	}
+	arch2 := &Architect{Provider: r2, N: 3}
+	sketches2, err := arch2.Run(context.Background(), newArchitectCtx())
+	if err != nil {
+		t.Fatalf("round 2: %v", err)
+	}
+
+	if len(sketches1) != 3 || len(sketches2) != 3 {
+		t.Fatalf("expected 3 sketches per round; got %d / %d", len(sketches1), len(sketches2))
+	}
+
+	// Key assertion: after the Architect's internal stable-hash sort,
+	// both rounds produce the same sketchSortKey in each ordinal slot.
+	// That's the `-sketch N` invariant.
+	for i := range sketches1 {
+		k1 := sketchSortKey(sketches1[i])
+		k2 := sketchSortKey(sketches2[i])
+		if k1 != k2 {
+			t.Errorf("slot %d: round 1 key %q != round 2 key %q — ordering is NOT deterministic across emission orders",
+				i, k1, k2)
+		}
+	}
+}
+
+// TestArchitectRunPassesTemperatureZero verifies the Architect
+// encodes deterministic intent in its LLM request even when the
+// claude-cli provider currently ignores it (documented limitation).
+// If the default provider changes, or claude-cli adds temperature
+// support, the deterministic contract is already in place.
+func TestArchitectRunPassesTemperatureZero(t *testing.T) {
+	prov := &sequencedProvider{
+		t:    t,
+		name: "stub",
+		replies: []sequencedReply{
+			{body: singleSketchBody("Only sketch")},
+		},
+	}
+	a := &Architect{Provider: prov, N: 1}
+	if _, err := a.Run(context.Background(), newArchitectCtx()); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if len(prov.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(prov.calls))
+	}
+	if prov.calls[0].Temperature != 0 {
+		t.Errorf("expected Temperature=0 for deterministic Architect output, got %v", prov.calls[0].Temperature)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #38 (refined).

Makes the Architect's N sketches land in the same ordinal slots across runs so \`-sketch N\` reliably picks the same sketch content. Same-content emitted in any order now produces the same sort order.

## Implementation — root-cause fix (Critic's Option D)

Two targeted changes in \`internal/agents/architect.go\`:

1. **Stable-hash sort** after the N sequential LLM calls complete. Sort key is \`sha256(Title + body-with-header-stripped)[:8]\` — truncated hex, 64 bits of collision space. The header (\`## Sketch N:\`) is stripped from the hash input because the loop-index number in that header would otherwise poison the sort (same content emitted in different orders would have different numbers embedded and therefore different hashes). After sorting, sketches get contiguous post-sort numbers (1..N) with \`renumberSketch\` applied once.
2. **Temperature=0 in the \`llm.Request\`** — aspirational intent. The default \`claude-cli\` provider doesn't forward per-call temperature (documented limitation at \`claude_cli.go:73\`), so this is a no-op today. Honored by the \`anthropic\` provider, and automatically activates once claude-cli adds \`--temperature\` support or a user swaps Architect to the anthropic tier. The stable-hash sort is the actual deterministic-ordering guarantee today.

Nothing else — explicitly NOT building the CLI workaround (\`-sketch-matches\` flag) the original issue body proposed and the Critic rejected.

## Load-bearing detail

The Critic's sharp question #1 was load-bearing: *\"does sketch generation use N parallel LLM calls, and if so are the prompts differentiated per-sketch? Temperature=0 with identical prompts would collapse all N sketches to byte-identical output.\"*

Answer from the code (not assumed): the Architect makes **N sequential calls, each with a DIFFERENT system prompt** that threads prior sketch titles as a diversity hint (\`buildSketchSystemPrompt(i, priorTitles)\`). Temperature=0 per-call is safe because the prompts differ per iteration; diversity comes from the prompt variation, not sampling noise. Verified in \`internal/agents/architect.go:124-153\`.

## Breaking-contract change

One existing test updated: \`TestArchitectRunReturnsPartialSuccessOnMidRunFailure\`. Before this PR, a partial-success run (e.g. call 2 failed, calls 1 and 3 succeeded) returned sketches numbered 1 and 3 to signal \"call 2 was lost.\" After this PR, the stable-hash sort reorders sketches by content and reassigns contiguous numbers (1, 2). The gap-preserving invariant is gone; contiguous numbering matches what the user sees via \`-sketch N\`. No external user visible impact (the Number field isn't surfaced outside the Architect's output).

## Test coverage

Four new test cases + one updated:

- \`TestSortSketchesDeterministic_InvariantUnderPermutation\`: all 6 permutations of a 3-sketch set produce identical sort key sequence
- \`TestSketchSortKeyDependsOnMarkdownNotTitle\`: different bodies → different keys (guards against regression where sort collapses distinct sketches)
- \`TestArchitectRunReturnsDeterministicOrdering\`: end-to-end sanity — the Architect emits the same three stubbed sketches in emission orders A-B-C and C-A-B; after the internal sort, both runs produce the same sketchSortKey in each ordinal slot
- \`TestArchitectRunPassesTemperatureZero\`: verifies the Architect encodes deterministic intent in the \`llm.Request\` (aspirational today; activates when the provider honors it)
- \`TestArchitectRunReturnsPartialSuccessOnMidRunFailure\` updated to reflect the new contiguous-numbering contract

## Out of scope

- **Structured output (JSON-mode LLM calls)** — the original body mentioned as a deeper fix; out of scope here.
- **Cross-model determinism** — even with temperature=0, different model versions (sonnet-4-6 vs sonnet-4-7) may produce different content. This fix guarantees same-model-same-input determinism only.
- **claude-cli temperature forwarding** — worth its own issue if we want true determinism via the default provider. The claude-cli comment (\"it doesn't expose per-call overrides in print mode\") may be stale; someone should verify against the current claude CLI version and file a follow-up if \`--temperature\` is now supported.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./...\` — all packages pass, including 4 new + 1 updated Architect test
- [ ] Manual: run \`aidev -headless -auto -n 3 -issue <some-issue> -repo .\` twice against the same issue; confirm architect-output.md sketch ordering is identical across runs (via \`sha256sum\`)

🤖 aidev autonomous run — decision via aidev, implementation + tests + PR via Claude Code.