### PR TITLE
fix: hydrate orchestrator Triage state from runDir sidecar

### DIFF
--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -635,6 +635,27 @@ func runReviewSubcommand() {
 	}
 
 	// Triage mode: run the meta-judge and emit JSON to stdout.
+	//
+	// Issue #53: Triage needs the Selector verdict + chosen Sketch to
+	// function — without them it refuses with "no chosen sketch
+	// required". The prior /aidev-run persisted a triage-state sidecar
+	// at <runDir>/triage-state.json; hydrate the orchestrator's
+	// context from it here so Triage has what it needs. Fall through
+	// to the existing "no chosen sketch" error from orch.Triage if the
+	// sidecar is missing or unparseable — that error is loud and the
+	// user knows to re-run /aidev-run to regenerate the state.
+	if runDir := orch.RunDir(); runDir != "" {
+		if err := orch.LoadTriageState(runDir); err != nil {
+			// Missing sidecar is not fatal at this layer — the later
+			// orch.Triage call will surface a clearer "no chosen
+			// sketch" error if hydration actually mattered for this
+			// run. Malformed / partial sidecars fail loudly here
+			// because the all-or-nothing contract is safer than
+			// silently running Triage against a corrupted state.
+			fmt.Fprintf(os.Stderr, "aidev review: hydrate triage state: %v\n", err)
+		}
+	}
+
 	var ci *agents.CIStatus
 	if *ciStatusPath != "" {
 		raw, rerr := os.ReadFile(*ciStatusPath)
@@ -1205,6 +1226,17 @@ func runHeadless(ctx context.Context, orch *orchestrator.Orchestrator, cfg *conf
 		} else {
 			fmt.Println()
 			fmt.Printf("_Architect output written to %s — hand off to Claude Code for implementation._\n", outPath)
+		}
+		// Issue #53: also persist a machine-readable sidecar of the
+		// Triage-relevant state (Selector verdict + sketches + reports)
+		// so a later `aidev review -triage` invocation — which runs in
+		// a fresh process — can hydrate the orchestrator context
+		// without re-running Scout/Critic/Architect/Selector. Without
+		// this, Triage refuses with "no chosen sketch — Selector
+		// verdict required" and the autonomous review loop stalls.
+		// Best-effort: failures are logged, pipeline continues.
+		if err := orch.SaveTriageState(dir); err != nil {
+			fmt.Fprintf(os.Stderr, "aidev: save triage state: %v\n", err)
 		}
 	}
 

--- a/internal/orchestrator/triage_state.go
+++ b/internal/orchestrator/triage_state.go
@@ -1,0 +1,125 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aisu-ai/aidev/internal/agents"
+	"github.com/aisu-ai/aidev/internal/github"
+)
+
+// triageStateFilename is the fixed filename under the runDir that holds
+// a JSON snapshot of the subset of agents.Context the Triage agent
+// needs. Lives alongside architect-output.md; the JSON is the
+// machine-readable sidecar so `aidev review -triage` doesn't have to
+// parse Markdown to hydrate state.
+const triageStateFilename = "triage-state.json"
+
+// triageState is the minimal serializable projection of agents.Context
+// needed to hydrate a fresh orchestrator for Triage. We deliberately
+// don't serialize the full Context because most of its fields
+// (Snapshot, ClarifierNotes, CoordinatorFeedback) are either
+// recomputed from disk per-run or unused by Triage. Tight scope keeps
+// the on-disk format forward-compatible.
+//
+// Issue #53 motivation: without this, `aidev review -triage` runs in a
+// fresh process, constructs an empty agents.Context, and the Triage
+// agent refuses with "no chosen sketch — Selector verdict required".
+// Reading this sidecar restores the Selector + sketches so the Triage
+// judgment can actually run.
+type triageState struct {
+	Issue        *github.Issue           `json:"issue"`
+	ScoutReport  string                  `json:"scout_report"`
+	CriticReport string                  `json:"critic_report"`
+	Principles   []agents.Principle      `json:"principles,omitempty"`
+	Sketches     []agents.Sketch         `json:"sketches"`
+	Selector     *agents.SelectorVerdict `json:"selector"`
+}
+
+// SaveTriageState writes a JSON snapshot of the orchestrator's
+// Triage-relevant state to `<runDir>/triage-state.json`. Call it from
+// the autonomous-run driver AFTER the pipeline has produced a Selector
+// verdict (i.e. same trigger as writeArchitectOutput).
+//
+// Best-effort by design — returns the underlying I/O error so the
+// caller can log it, but the pipeline should not fail just because
+// the sidecar couldn't be written. Triage will fall back to the
+// existing "no chosen sketch" error on the next run, which is loud
+// and recoverable.
+func (o *Orchestrator) SaveTriageState(runDir string) error {
+	if runDir == "" {
+		return fmt.Errorf("orchestrator: SaveTriageState needs a non-empty runDir")
+	}
+	if o.ctx == nil {
+		return fmt.Errorf("orchestrator: cannot save triage state before LoadIssue")
+	}
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		return fmt.Errorf("orchestrator: mkdir %s: %w", runDir, err)
+	}
+	state := triageState{
+		Issue:        o.ctx.Issue,
+		ScoutReport:  o.ctx.ScoutReport,
+		CriticReport: o.ctx.CriticReport,
+		Principles:   o.ctx.Principles,
+		Sketches:     o.ctx.Sketches,
+		Selector:     o.ctx.Selector,
+	}
+	data, err := json.MarshalIndent(&state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("orchestrator: marshal triage state: %w", err)
+	}
+	path := filepath.Join(runDir, triageStateFilename)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("orchestrator: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// LoadTriageState reads the sidecar produced by SaveTriageState and
+// hydrates orchestrator.ctx with the decoded fields. Call from the
+// `aidev review -triage` path before invoking Triage so the chosen
+// Sketch + Selector verdict are present.
+//
+// Contract is all-or-nothing per the issue's sharp-question #2: a
+// partially-parseable sidecar returns an error (loud failure) rather
+// than a half-populated Context. Returns fs.ErrNotExist wrapped if
+// the sidecar isn't there so callers can distinguish "no prior state"
+// from "corrupted state" with errors.Is.
+func (o *Orchestrator) LoadTriageState(runDir string) error {
+	if runDir == "" {
+		return fmt.Errorf("orchestrator: LoadTriageState needs a non-empty runDir")
+	}
+	if o.ctx == nil {
+		return fmt.Errorf("orchestrator: cannot load triage state before LoadIssue")
+	}
+	path := filepath.Join(runDir, triageStateFilename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Pass through fs.ErrNotExist unwrapped so errors.Is works.
+		return err
+	}
+	var state triageState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("orchestrator: parse triage state %s: %w", path, err)
+	}
+	// All-or-nothing hydration: if Selector is nil or ChosenNumber is
+	// zero (no valid pick), treat as unusable. The caller's existing
+	// "no chosen sketch" branch kicks in naturally — we just make sure
+	// we don't half-populate the Context and leave it in a worse state
+	// than it started.
+	if state.Selector == nil || state.Selector.ChosenNumber == 0 {
+		return fmt.Errorf("orchestrator: triage state at %s has no usable Selector verdict", path)
+	}
+	if len(state.Sketches) == 0 {
+		return fmt.Errorf("orchestrator: triage state at %s has no sketches (Selector verdict would reference non-existent sketch)", path)
+	}
+	o.ctx.Issue = state.Issue
+	o.ctx.ScoutReport = state.ScoutReport
+	o.ctx.CriticReport = state.CriticReport
+	o.ctx.Principles = state.Principles
+	o.ctx.Sketches = state.Sketches
+	o.ctx.Selector = state.Selector
+	return nil
+}

--- a/internal/orchestrator/triage_state_test.go
+++ b/internal/orchestrator/triage_state_test.go
@@ -1,0 +1,177 @@
+package orchestrator
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aisu-ai/aidev/internal/agents"
+	"github.com/aisu-ai/aidev/internal/github"
+)
+
+// TestSaveLoadTriageStateRoundtrip is the load-bearing regression test
+// for issue #53: a Save + fresh-Load must restore enough of
+// agents.Context that the Triage agent can run end-to-end (Issue +
+// ScoutReport + CriticReport + Sketches + Selector populated).
+//
+// The Triage agent's entry validation requires:
+//   c.Issue != nil
+//   c.Selector != nil && c.Selector.ChosenNumber > 0
+//   c.Selector.ChosenNumber <= len(c.Sketches)
+// so those fields are the invariants we assert post-load.
+func TestSaveLoadTriageStateRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+
+	originalIssue := &github.Issue{
+		Owner: "AiSU-AI", Repo: "aidev", Number: 53,
+		Title: "fix: triage hydration", Body: "issue body",
+	}
+	originalSketches := []agents.Sketch{
+		{Number: 1, Title: "Sketch A", Markdown: "## Sketch 1: Sketch A\n\nbody A"},
+		{Number: 2, Title: "Sketch B", Markdown: "## Sketch 2: Sketch B\n\nbody B"},
+	}
+	originalVerdict := &agents.SelectorVerdict{
+		ChosenNumber:  1,
+		Score:         4.5,
+		Rationale:     "picked A",
+		TieBreakerUsed: false,
+		RubricVersion: "1.0",
+	}
+
+	oSave := &Orchestrator{
+		ctx: &agents.Context{
+			Issue:        originalIssue,
+			ScoutReport:  "scout body",
+			CriticReport: "critic body",
+			Sketches:     originalSketches,
+			Selector:     originalVerdict,
+		},
+	}
+	if err := oSave.SaveTriageState(dir); err != nil {
+		t.Fatalf("SaveTriageState: %v", err)
+	}
+
+	// Confirm sidecar exists at the expected path.
+	sidecarPath := filepath.Join(dir, triageStateFilename)
+	if _, err := os.Stat(sidecarPath); err != nil {
+		t.Fatalf("sidecar not present after save: %v", err)
+	}
+
+	// Fresh orchestrator — simulates `aidev review -triage` running
+	// in a separate process with no in-memory state.
+	oLoad := &Orchestrator{ctx: &agents.Context{}}
+	if err := oLoad.LoadTriageState(dir); err != nil {
+		t.Fatalf("LoadTriageState: %v", err)
+	}
+
+	// Every Triage-required invariant must hold after load.
+	if oLoad.ctx.Issue == nil || oLoad.ctx.Issue.Number != 53 {
+		t.Errorf("Issue not restored: %+v", oLoad.ctx.Issue)
+	}
+	if oLoad.ctx.ScoutReport != "scout body" {
+		t.Errorf("ScoutReport lost: %q", oLoad.ctx.ScoutReport)
+	}
+	if oLoad.ctx.CriticReport != "critic body" {
+		t.Errorf("CriticReport lost: %q", oLoad.ctx.CriticReport)
+	}
+	if len(oLoad.ctx.Sketches) != 2 {
+		t.Fatalf("expected 2 sketches, got %d", len(oLoad.ctx.Sketches))
+	}
+	if oLoad.ctx.Sketches[0].Title != "Sketch A" {
+		t.Errorf("Sketch 0 title lost: %q", oLoad.ctx.Sketches[0].Title)
+	}
+	if oLoad.ctx.Selector == nil || oLoad.ctx.Selector.ChosenNumber != 1 {
+		t.Errorf("Selector not restored: %+v", oLoad.ctx.Selector)
+	}
+	if oLoad.ctx.Selector.Rationale != "picked A" {
+		t.Errorf("Selector rationale lost: %q", oLoad.ctx.Selector.Rationale)
+	}
+}
+
+// TestLoadTriageStateMissingSidecarReturnsNotExist verifies the
+// explicit "no prior state" path — LoadTriageState on a fresh dir
+// (no sidecar written) returns an fs.ErrNotExist-compatible error so
+// callers can distinguish "first run, hydration skipped" from
+// "hydration attempted but corrupt."
+func TestLoadTriageStateMissingSidecarReturnsNotExist(t *testing.T) {
+	dir := t.TempDir()
+	o := &Orchestrator{ctx: &agents.Context{}}
+	err := o.LoadTriageState(dir)
+	if err == nil {
+		t.Fatal("expected error for missing sidecar, got nil")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected fs.ErrNotExist, got %v (type %T)", err, err)
+	}
+}
+
+// TestLoadTriageStateRejectsPartialHydration is the sharp-question-#2
+// regression: a sidecar that exists but is missing the Selector
+// verdict (or has ChosenNumber=0) must fail loudly. Silently half-
+// populating the Context would put Triage in a worse state than
+// starting fresh.
+func TestLoadTriageStateRejectsPartialHydration(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, triageStateFilename)
+
+	// Scenario 1: Selector is nil.
+	if err := os.WriteFile(path, []byte(`{"issue":{"Owner":"a","Repo":"b","Number":1},"selector":null,"sketches":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	o := &Orchestrator{ctx: &agents.Context{}}
+	if err := o.LoadTriageState(dir); err == nil {
+		t.Error("expected error for nil Selector, got nil")
+	}
+
+	// Scenario 2: Selector present but ChosenNumber=0 (Selector refused to pick).
+	if err := os.WriteFile(path, []byte(`{"issue":{"Owner":"a","Repo":"b","Number":1},"selector":{"chosen_number":0,"rationale":"refused"},"sketches":[{"Number":1,"Title":"t","Markdown":"m"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	o = &Orchestrator{ctx: &agents.Context{}}
+	if err := o.LoadTriageState(dir); err == nil {
+		t.Error("expected error for ChosenNumber=0, got nil")
+	}
+
+	// Scenario 3: Selector has a pick but sketches array is empty.
+	if err := os.WriteFile(path, []byte(`{"issue":{"Owner":"a","Repo":"b","Number":1},"selector":{"chosen_number":1,"rationale":"r"},"sketches":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	o = &Orchestrator{ctx: &agents.Context{}}
+	if err := o.LoadTriageState(dir); err == nil {
+		t.Error("expected error for empty sketches, got nil")
+	}
+}
+
+// TestLoadTriageStateRejectsMalformedJSON — ensure parse failures
+// surface loudly rather than silently zeroing the Context.
+func TestLoadTriageStateRejectsMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, triageStateFilename)
+	if err := os.WriteFile(path, []byte(`not valid json at all`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	o := &Orchestrator{ctx: &agents.Context{}}
+	err := o.LoadTriageState(dir)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+// TestSaveTriageStateRefusesEmptyRunDir and TestLoadTriageStateRefusesEmptyRunDir
+// — both save/load require a non-empty runDir. Passing "" is a caller
+// bug (LoadIssue wasn't called, or runDir resolution failed); surface
+// it rather than silently writing to cwd or reading a random file.
+func TestSaveTriageStateRefusesEmptyRunDir(t *testing.T) {
+	o := &Orchestrator{ctx: &agents.Context{}}
+	if err := o.SaveTriageState(""); err == nil {
+		t.Error("expected error for empty runDir, got nil")
+	}
+}
+
+func TestLoadTriageStateRefusesEmptyRunDir(t *testing.T) {
+	o := &Orchestrator{ctx: &agents.Context{}}
+	if err := o.LoadTriageState(""); err == nil {
+		t.Error("expected error for empty runDir, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #53.

Unblocks the autonomous review loop. Before this change, \`aidev review -triage\` refused to run because it opened a fresh orchestrator with no Selector verdict loaded:

\`\`\`
aidev: triage: triage: no chosen sketch — Selector verdict required
\`\`\`

Both PRs in the v0.4.0 bundle (#51 for #46, #52 for #45) had to converge manually because of this.

## Implementation — JSON sidecar

Per the Critic's sharp-question #1 (JSON or Markdown parse), this PR chooses JSON — cleaner, forward-compatible, less parse surface. At write time, \`cmd/aidev/main.go runHeadless\` persists a sidecar alongside \`architect-output.md\`:

- **Path:** \`\$XDG_DATA_HOME/aidev/runs/<owner>-<repo>-<issue>/triage-state.json\`
- **Contents:** the subset of \`agents.Context\` the Triage agent actually uses — \`Issue\`, \`ScoutReport\`, \`CriticReport\`, \`Principles\`, \`Sketches\`, \`Selector\`. Other fields (\`Snapshot\`, \`ClarifierNotes\`, \`CoordinatorFeedback\`) deliberately excluded because they're not Triage inputs and either regenerate per-run or don't survive the process boundary.

At triage time, \`cmd/aidev/main.go runReviewSubcommand\` calls \`orch.LoadTriageState(runDir)\` before invoking \`orch.Triage\`. Best-effort: missing sidecar → fall through to the existing \"no chosen sketch\" error from Triage itself (loud, clear, tells the user to re-run \`/aidev-run\`). Malformed sidecar → fail loudly at load time per the all-or-nothing contract.

## Answers to the Critic's sharp questions

1. **JSON sidecar vs Markdown parse** → JSON sidecar. Chosen because the architect-output.md is a human-facing document and parsing it would re-create fragile Markdown-to-struct plumbing that drifts with every template change. The sidecar is machine-only, schema evolves with \`triageState\`, and round-trips via \`json.Marshal\` trivially.
2. **Contract for partially-parseable state** → all-or-nothing. \`LoadTriageState\` rejects three scenarios explicitly: \`Selector == nil\`, \`Selector.ChosenNumber == 0\` (Selector refused to pick), or \`len(Sketches) == 0\` (orphan verdict referencing nonexistent sketches). Partial hydration would put Triage in a worse state than starting fresh — loud failure is safer.
3. **Full hydration vs minimal** → full enough. Every \`agents.Context\` field that Triage reads via \`triage.go\` is in the sidecar. Specifically: \`Issue\`, \`ScoutReport\` (Triage prompt includes it as background), \`CriticReport\` (same), \`Sketches\` (Triage reads the chosen sketch via \`c.Selector.ChosenNumber - 1\`), \`Selector\` (required). Skipped: \`Snapshot\` (big, Scout-specific, not used by Triage), \`ClarifierNotes\` (in-memory interview state, not persisted), \`CoordinatorFeedback\` (Implementer-retry state, orthogonal).

## Tests — 6 new cases

- \`TestSaveLoadTriageStateRoundtrip\`: end-to-end save-then-load restores all Triage-required invariants from a fresh orchestrator (the \"separate process\" case).
- \`TestLoadTriageStateMissingSidecarReturnsNotExist\`: hydration on a fresh runDir returns a detectable \`fs.ErrNotExist\` so callers distinguish \"no prior state\" from \"corrupted state\".
- \`TestLoadTriageStateRejectsPartialHydration\`: three scenarios (nil Selector, ChosenNumber=0, empty sketches) all fail loudly.
- \`TestLoadTriageStateRejectsMalformedJSON\`: parse failures surface.
- \`TestSaveTriageStateRefusesEmptyRunDir\` + \`TestLoadTriageStateRefusesEmptyRunDir\`: empty runDir is a caller bug — refused explicitly rather than silently writing to cwd or reading random paths.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./...\` — all packages pass, 6 new Triage-state tests green
- [ ] End-to-end: after this merges, run \`/aidev-implement-bundle\` against a small issue; confirm the autonomous review loop runs through Triage cleanly instead of \"no chosen sketch\" error.

## Out of scope

- Automatic cleanup of old sidecars — same lifetime contract as existing runDir artifacts. Covered by the out-of-scope section in the autonomous-pipeline plan (\"Cleanup of old runDirs. \`<runDir>\` will accumulate over time. Punt to a future \`aidev cleanup\` subcommand\").
- Sidecar versioning — if \`triageState\` fields change incompatibly in the future, add a top-level \`version\` field. For now, additive changes work transparently via \`json.Unmarshal\` field-matching.

🤖 aidev autonomous run — decision via aidev, implementation + tests + PR via Claude Code.