### PR TITLE
feat: add cloud-only profile for users without Ollama

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -20,7 +20,7 @@
 #
 # ---
 #
-# Shipped profiles (this PR ships four):
+# Shipped profiles (this PR ships five):
 #
 #   default    Local Ollama for the agents (Implementer/Reviewer
 #              with native tool use, Critic/Architect on Claude
@@ -28,6 +28,13 @@
 #              the Coordinator monitoring every agent transition.
 #              Recommended for users with both local hardware and
 #              a Claude Code subscription.
+#
+#   cloud-only No local Ollama required. Every agent routes through
+#              Claude Code (claude-cli). Best for users without
+#              Ollama installed, or CI/sandboxed environments
+#              where local model hosting isn't feasible. The
+#              recommended profile for the `aidev init` onboarding
+#              when Ollama is absent.
 #
 #   offline    Fully offline. Every role on a local Ollama model.
 #              Zero cloud calls. Use when air-gapped, on a plane,
@@ -111,6 +118,57 @@ profiles:
         provider: ollama
         model: qwen2.5-coder:14b
         endpoint: http://localhost:11434
+        max_tokens: 8192
+        temperature: 0.2
+      cloud_large:
+        provider: claude-cli
+        model: ""
+        max_tokens: 8192
+        temperature: 0.3
+      oversight:
+        provider: claude-cli
+        model: ""
+        max_tokens: 8192
+        temperature: 0.3
+    routing:
+      scout: small
+      tester: small
+      implementer: medium
+      reviewer: medium
+      critic: cloud_large
+      architect: cloud_large
+      charter: cloud_large
+      coordinator: oversight
+
+  cloud-only:
+    description: |
+      No local Ollama required. Every agent routes through Claude
+      Code (claude-cli). Best for users without Ollama installed,
+      or CI/sandboxed environments where local model hosting
+      isn't feasible. This is the recommended profile for
+      `aidev init` onboarding when Ollama isn't present.
+
+      Cost vs. `default`: marginal. The expensive roles
+      (critic, architect, coordinator) were already cloud-routed
+      in default; cloud-only just redirects the cheap local roles
+      (scout, tester, implementer, reviewer) to the same cloud
+      tier. Scout and Tester are short prompts; Implementer and
+      Reviewer loops can be chattier but still bounded.
+
+      Note: the Implementer loses native tool use (read_file,
+      glob, grep, list_dir) when routed through claude-cli, per
+      the comment at the top of this file. The legacy picker +
+      NEED_FILES path still works; it's just slower on multi-file
+      changes than the tool-use path.
+    tiers:
+      small:
+        provider: claude-cli
+        model: ""
+        max_tokens: 2048
+        temperature: 0.2
+      medium:
+        provider: claude-cli
+        model: ""
         max_tokens: 8192
         temperature: 0.2
       cloud_large:

--- a/internal/installpkg/files/models.yaml
+++ b/internal/installpkg/files/models.yaml
@@ -20,7 +20,7 @@
 #
 # ---
 #
-# Shipped profiles (this PR ships four):
+# Shipped profiles (this PR ships five):
 #
 #   default    Local Ollama for the agents (Implementer/Reviewer
 #              with native tool use, Critic/Architect on Claude
@@ -28,6 +28,13 @@
 #              the Coordinator monitoring every agent transition.
 #              Recommended for users with both local hardware and
 #              a Claude Code subscription.
+#
+#   cloud-only No local Ollama required. Every agent routes through
+#              Claude Code (claude-cli). Best for users without
+#              Ollama installed, or CI/sandboxed environments
+#              where local model hosting isn't feasible. The
+#              recommended profile for the `aidev init` onboarding
+#              when Ollama is absent.
 #
 #   offline    Fully offline. Every role on a local Ollama model.
 #              Zero cloud calls. Use when air-gapped, on a plane,
@@ -111,6 +118,57 @@ profiles:
         provider: ollama
         model: qwen2.5-coder:14b
         endpoint: http://localhost:11434
+        max_tokens: 8192
+        temperature: 0.2
+      cloud_large:
+        provider: claude-cli
+        model: ""
+        max_tokens: 8192
+        temperature: 0.3
+      oversight:
+        provider: claude-cli
+        model: ""
+        max_tokens: 8192
+        temperature: 0.3
+    routing:
+      scout: small
+      tester: small
+      implementer: medium
+      reviewer: medium
+      critic: cloud_large
+      architect: cloud_large
+      charter: cloud_large
+      coordinator: oversight
+
+  cloud-only:
+    description: |
+      No local Ollama required. Every agent routes through Claude
+      Code (claude-cli). Best for users without Ollama installed,
+      or CI/sandboxed environments where local model hosting
+      isn't feasible. This is the recommended profile for
+      `aidev init` onboarding when Ollama isn't present.
+
+      Cost vs. `default`: marginal. The expensive roles
+      (critic, architect, coordinator) were already cloud-routed
+      in default; cloud-only just redirects the cheap local roles
+      (scout, tester, implementer, reviewer) to the same cloud
+      tier. Scout and Tester are short prompts; Implementer and
+      Reviewer loops can be chattier but still bounded.
+
+      Note: the Implementer loses native tool use (read_file,
+      glob, grep, list_dir) when routed through claude-cli, per
+      the comment at the top of this file. The legacy picker +
+      NEED_FILES path still works; it's just slower on multi-file
+      changes than the tool-use path.
+    tiers:
+      small:
+        provider: claude-cli
+        model: ""
+        max_tokens: 2048
+        temperature: 0.2
+      medium:
+        provider: claude-cli
+        model: ""
         max_tokens: 8192
         temperature: 0.2
       cloud_large:

--- a/internal/installpkg/installpkg_test.go
+++ b/internal/installpkg/installpkg_test.go
@@ -3,7 +3,10 @@ package installpkg
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // TestInstallConfigShipsExpectedFiles is the install-time
@@ -49,3 +52,71 @@ func TestInstallConfigShipsExpectedFiles(t *testing.T) {
 		t.Errorf("InstallConfig wrote unexpected files: %v — v0.5 ships only models.yaml + principles.yaml. Remove stragglers from internal/installpkg/files/.", unexpected)
 	}
 }
+
+// TestCloudOnlyProfileHasNoOllamaRoutes verifies the shipped
+// cloud-only profile routes every tier through a non-ollama
+// provider. This is the load-bearing contract of the profile
+// (issue #56) — a user without Ollama installed must be able to
+// `aidev config use-profile cloud-only` and have everything work.
+// Any regression that reintroduces an ollama-backed tier to this
+// profile breaks that promise.
+func TestCloudOnlyProfileHasNoOllamaRoutes(t *testing.T) {
+	dir := t.TempDir()
+	if _, _, err := InstallConfig(dir, true); err != nil {
+		t.Fatalf("InstallConfig: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "models.yaml"))
+	if err != nil {
+		t.Fatalf("read models.yaml: %v", err)
+	}
+
+	// Minimal decode — we only need tier providers from one profile
+	// to enforce the no-ollama invariant. Full config parsing lives
+	// in internal/config.
+	type tier struct {
+		Provider string `yaml:"provider"`
+	}
+	type profile struct {
+		Description string          `yaml:"description"`
+		Tiers       map[string]tier `yaml:"tiers"`
+		Routing     map[string]string `yaml:"routing"`
+	}
+	type root struct {
+		Profiles map[string]profile `yaml:"profiles"`
+	}
+	var r root
+	if err := yaml.Unmarshal(raw, &r); err != nil {
+		t.Fatalf("unmarshal models.yaml: %v", err)
+	}
+	p, ok := r.Profiles["cloud-only"]
+	if !ok {
+		available := make([]string, 0, len(r.Profiles))
+		for name := range r.Profiles {
+			available = append(available, name)
+		}
+		t.Fatalf("cloud-only profile not present in shipped models.yaml — did you forget to add it?\nAvailable: %v", available)
+	}
+	if len(p.Tiers) == 0 {
+		t.Fatal("cloud-only profile has no tiers")
+	}
+	for name, tr := range p.Tiers {
+		if tr.Provider == "ollama" {
+			t.Errorf("cloud-only tier %q routes to provider=ollama — breaks the no-Ollama promise", name)
+		}
+	}
+	// Every routed role must point at a tier that exists in the
+	// profile — guards against a typo like `routing: critic: claud_large`
+	// after a rename.
+	for role, tierName := range p.Routing {
+		if _, ok := p.Tiers[tierName]; !ok {
+			t.Errorf("cloud-only role %q → tier %q does not exist in profile.Tiers", role, tierName)
+		}
+	}
+	// Sanity: description should mention \"no Ollama\" or \"claude\"
+	// so anyone reading the file understands the profile's purpose.
+	low := strings.ToLower(p.Description)
+	if !strings.Contains(low, "ollama") && !strings.Contains(low, "claude") {
+		t.Errorf("cloud-only description should explain the no-Ollama / claude-cli tradeoff; got: %q", p.Description)
+	}
+}
+


### PR DESCRIPTION
## Summary

Closes #56. Adds a \`cloud-only\` profile to \`config/models.yaml\` (and its embedded mirror) so users without Ollama installed can use aidev out of the box. Every tier routes to \`claude-cli\`; no local model hosting required. Prerequisite for #57 (the \`aidev init\` onboarding subcommand which needs a no-Ollama profile to emit).

## Changes

- **MODIFY** \`config/models.yaml\` + \`internal/installpkg/files/models.yaml\` — new \`cloud-only\` profile with 4 tiers (\`small\`, \`medium\`, \`cloud_large\`, \`oversight\`), all \`provider: claude-cli\`, same role→tier routing shape as the existing \`default\` profile. Updated the shipped-profiles comment header from \"four\" to \"five\".
- **ADD** \`TestCloudOnlyProfileHasNoOllamaRoutes\` in \`internal/installpkg/installpkg_test.go\` — reads the embedded \`models.yaml\`, decodes the \`cloud-only\` profile, asserts (a) profile exists, (b) no tier routes to \`provider: ollama\`, (c) every role→tier pointer resolves to an existing tier, (d) description mentions the claude-cli / no-Ollama tradeoff.

## Cost considerations

Marginal vs. the \`default\` profile. The expensive roles (critic, architect, coordinator) were already cloud-routed in default; cloud-only just redirects the *cheap* local roles (scout, tester, implementer, reviewer) to the same cloud tier. Scout and Tester are short prompts; Implementer's NEED_FILES loop can be chattier, but it's bounded. Users explicitly picking this profile are accepting the tradeoff.

## Implementation note — Implementer tool use

The comment at the top of \`models.yaml\` flags that \`provider: claude-cli\` does not currently support native tool use — Implementer and Reviewer fall back to the legacy picker + NEED_FILES path. The \`cloud-only\` profile's description section acknowledges this explicitly so users aren't surprised by the slower multi-file-change behaviour compared to the Ollama-backed \`default\`.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./...\` — all packages pass, new \`TestCloudOnlyProfileHasNoOllamaRoutes\` green
- [ ] Manual end-to-end (post-merge): on a fresh machine with no Ollama installed, \`aidev config profile use cloud-only && aidev doctor\` should pass cleanly because no tier routes to ollama (the ollama-binary/daemon/models checks skip).

🤖 aidev — decision via Claude Code session, implementation + tests + PR.