### PR TITLE
feat(reviewer,triage): anti-hallucination + Issue-alignment + Boy-Scout mode

### DIFF
--- a/internal/agents/reviewer.go
+++ b/internal/agents/reviewer.go
@@ -80,15 +80,53 @@ func (r *Reviewer) Run(ctx context.Context, c *Context, patch string) (*Review, 
 
 	system := "You are the Reviewer for aidev, a multi-agent coding tool. A " +
 		"diff has just been produced by the Implementer and the user is about " +
-		"to apply it. Your job is a Boy Scout pass on that diff: identify " +
-		"anything that should block merge, anything the author could still " +
-		"improve inside the scope of the change, and anything nearby that " +
-		"deserves a follow-up issue.\n\n" +
+		"to apply it. Your job has TWO parts:\n\n" +
+		"  1. Decide whether the patch actually solves the problem or " +
+		"     delivers the feature described in the GitHub issue.\n" +
+		"  2. Boy Scout pass on the diff itself: identify anything that " +
+		"     should block merge, anything the author could still improve " +
+		"     inside the scope of the change, and anything nearby that " +
+		"     deserves a follow-up issue.\n\n" +
+		"ANTI-HALLUCINATION RULES (these are load-bearing — the human will " +
+		"see your verdict as authoritative):\n\n" +
+		"  - Every Blocker MUST cite a specific file and either a line " +
+		"    number or a verbatim code snippet from the diff. " +
+		"    \"Some function might fail\" without a concrete reproducer is " +
+		"    a Suggestion, not a Blocker.\n" +
+		"  - Before claiming code is missing (validation, error handling, " +
+		"    null checks, etc.), search the patch's surrounding context " +
+		"    AND the unchanged portions of the file shown in the diff. If " +
+		"    the alleged-missing code is visible nearby, the finding is " +
+		"    invalid — do not emit it.\n" +
+		"  - \"Doesn't follow defensive-coding patterns\" is only a " +
+		"    Blocker when (a) the diff introduces a code path that " +
+		"    measurably differs from the established pattern in the same " +
+		"    file, AND (b) you can name the specific established pattern. " +
+		"    Conforming to existing convention is NEVER a blocker.\n" +
+		"  - When uncertain whether a finding is real, downgrade to " +
+		"    Suggestion or omit. False blockers cost the reviewing team " +
+		"    more than missed nits.\n\n" +
 		"Produce EXACTLY these sections in Markdown:\n\n" +
 		"# Review\n\n" +
+		"## Issue alignment\n" +
+		"State EXPLICITLY whether the patch addresses the issue's stated " +
+		"problem or feature. One of:\n\n" +
+		"  - **Solves the issue** — the diff implements what the issue " +
+		"    describes. Briefly say which parts of the issue map to which " +
+		"    parts of the diff.\n" +
+		"  - **Partially solves the issue** — diff covers some of the " +
+		"    stated requirements but not all. List what's missing.\n" +
+		"  - **Does not solve the issue** — diff is unrelated to the " +
+		"    stated problem, OR addresses a different problem than what " +
+		"    the issue describes. Explain the mismatch.\n\n" +
+		"This section is REQUIRED. \"Partially solves\" or \"Does not " +
+		"solve\" automatically makes verdict = changes_requested even if " +
+		"the Blockers list is empty.\n\n" +
 		"## Blockers\n" +
 		"Bullet list. Cite the principle violated and the specific line/file. " +
-		"Be willing to find zero blockers — do not invent them.\n\n" +
+		"Be willing to find zero blockers — do not invent them. " +
+		"Re-read the anti-hallucination rules above before adding each " +
+		"item.\n\n" +
 		"## Suggestions\n" +
 		"Bullet list. Non-blocking improvements the author could still make " +
 		"INSIDE the scope of this diff. Name the file and approximate region.\n\n" +
@@ -103,8 +141,17 @@ func (r *Reviewer) Run(ctx context.Context, c *Context, patch string) (*Review, 
 		"    VERDICT: approve\n" +
 		"or  VERDICT: changes_requested\n" +
 		"or  VERDICT: comment\n\n" +
-		"Do not hedge. If blockers is empty, verdict is approve. Otherwise " +
-		"verdict is changes_requested."
+		"Verdict rules:\n" +
+		"  - Issue-alignment = \"Does not solve the issue\" → " +
+		"    changes_requested (always).\n" +
+		"  - Issue-alignment = \"Partially solves the issue\" → " +
+		"    changes_requested unless the missing pieces are explicitly " +
+		"    out-of-scope per the issue body.\n" +
+		"  - Issue-alignment = \"Solves the issue\" AND blockers empty → " +
+		"    approve.\n" +
+		"  - Issue-alignment = \"Solves the issue\" AND blockers " +
+		"    non-empty → changes_requested.\n" +
+		"  - Do not hedge."
 
 	var principles strings.Builder
 	for _, p := range c.Principles {

--- a/internal/agents/reviewer_test.go
+++ b/internal/agents/reviewer_test.go
@@ -1,10 +1,13 @@
 package agents
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/aisu-ai/aidev/internal/github"
 )
 
 const sampleReview = `# Review
@@ -142,5 +145,79 @@ func TestReviewWriteFollowUpsReturnsEmptyWhenNoFollowUps(t *testing.T) {
 	}
 	if path != "" {
 		t.Errorf("path should be empty when no follow-ups, got %q", path)
+	}
+}
+
+// runReviewer drives Reviewer.Run with a canned LLM reply and returns
+// the prompt that was sent to the LLM. Used to assert the system prompt
+// contains the anti-hallucination + Issue-alignment instructions.
+// Reuses capturingProvider declared in critic_test.go.
+func runReviewer(t *testing.T, reply string) string {
+	t.Helper()
+	prov := &capturingProvider{reply: reply}
+	r := &Reviewer{Provider: prov}
+	c := &Context{
+		Issue: &github.Issue{Owner: "AiSU-AI", Repo: "test", Number: 1, Title: "x", Body: "y"},
+	}
+	if _, err := r.Run(context.Background(), c, "diff --git a/x b/x"); err != nil {
+		t.Fatalf("Reviewer.Run: %v", err)
+	}
+	return prov.req.System
+}
+
+// TestReviewerPromptHasIssueAlignmentSection locks in the explicit
+// "does this patch solve the GH issue?" check. Without this section
+// the Reviewer judges code quality in isolation and approves patches
+// that don't address the issue.
+func TestReviewerPromptHasIssueAlignmentSection(t *testing.T) {
+	system := runReviewer(t, "## Issue alignment\nSolves the issue\n\n## Blockers\n\n## Suggestions\n\n## Follow-up issues\n\n## Verdict\n\nVERDICT: approve\n")
+	want := []string{
+		"## Issue alignment",
+		"Solves the issue",
+		"Partially solves the issue",
+		"Does not solve the issue",
+	}
+	for _, phrase := range want {
+		if !strings.Contains(system, phrase) {
+			t.Errorf("Reviewer system prompt missing %q", phrase)
+		}
+	}
+}
+
+// TestReviewerPromptHasAntiHallucinationRules locks in the rules that
+// stop the Reviewer from inventing blockers (the bug that prompted
+// this whole feature: PR #770 was flagged for missing response.ok
+// validation that was clearly present in the file).
+func TestReviewerPromptHasAntiHallucinationRules(t *testing.T) {
+	system := runReviewer(t, "## Issue alignment\nSolves\n\n## Blockers\n\n## Suggestions\n\n## Follow-up issues\n\n## Verdict\n\nVERDICT: approve\n")
+	wantPhrases := []string{
+		"ANTI-HALLUCINATION",
+		"specific file and either a line",
+		"search the patch's surrounding context",
+		"Conforming to existing convention is NEVER a blocker",
+		"downgrade to",
+	}
+	for _, phrase := range wantPhrases {
+		if !strings.Contains(system, phrase) {
+			t.Errorf("Reviewer system prompt missing anti-hallucination phrase %q", phrase)
+		}
+	}
+}
+
+// TestReviewerPromptVerdictRulesCoverIssueAlignment locks in the
+// verdict-decision rules that connect Issue alignment to the final
+// verdict. Without these the LLM may approve a patch that "Does not
+// solve the issue" because no Blockers were found.
+func TestReviewerPromptVerdictRulesCoverIssueAlignment(t *testing.T) {
+	system := runReviewer(t, "## Issue alignment\nSolves\n\n## Blockers\n\n## Suggestions\n\n## Follow-up issues\n\n## Verdict\n\nVERDICT: approve\n")
+	want := []string{
+		"\"Does not solve the issue\" →",
+		"\"Partially solves the issue\" →",
+		"\"Solves the issue\" AND blockers empty",
+	}
+	for _, phrase := range want {
+		if !strings.Contains(system, phrase) {
+			t.Errorf("Reviewer verdict rules missing %q", phrase)
+		}
 	}
 }

--- a/internal/agents/triage.go
+++ b/internal/agents/triage.go
@@ -144,13 +144,22 @@ func (t *Triage) Run(ctx context.Context, c *Context, in TriageInput) (*TriageVe
 	if in.Review == nil {
 		return nil, errors.New("triage: missing review")
 	}
-	if c.Selector == nil || c.Selector.ChosenNumber == 0 {
-		return nil, errors.New("triage: no chosen sketch — Selector verdict required")
+	// Boy-Scout mode: when a Sketch is not available (e.g. /aidev-review
+	// invoked against a PR that wasn't built via /aidev-run), Triage runs
+	// against an empty Sketch. The rebut action becomes effectively
+	// disabled — the existing citation-coercion below will escalate any
+	// rebut whose sketch_citation doesn't appear in chosenSketch.Markdown,
+	// and an empty Markdown never contains a non-empty citation. The
+	// system prompt is also adapted (see buildTriagePrompt) so the LLM
+	// knows not to attempt rebut in this mode.
+	var chosenSketch Sketch
+	hasSketch := c.Selector != nil && c.Selector.ChosenNumber > 0
+	if hasSketch {
+		if c.Selector.ChosenNumber > len(c.Sketches) {
+			return nil, fmt.Errorf("triage: chosen sketch %d out of range (have %d)", c.Selector.ChosenNumber, len(c.Sketches))
+		}
+		chosenSketch = c.Sketches[c.Selector.ChosenNumber-1]
 	}
-	if c.Selector.ChosenNumber > len(c.Sketches) {
-		return nil, fmt.Errorf("triage: chosen sketch %d out of range (have %d)", c.Selector.ChosenNumber, len(c.Sketches))
-	}
-	chosenSketch := c.Sketches[c.Selector.ChosenNumber-1]
 
 	protected := in.ProtectedPaths
 	if len(protected) == 0 {
@@ -251,9 +260,19 @@ func buildTriagePrompt(c *Context, chosenSketch Sketch, in TriageInput) string {
 	fmt.Fprintf(&b, "## Issue\n\n%s/%s#%d — %s\n\n",
 		c.Issue.Owner, c.Issue.Repo, c.Issue.Number, c.Issue.Title)
 
-	b.WriteString("## Chosen Sketch (you may cite from this verbatim in sketch_citation)\n\n")
-	b.WriteString(chosenSketch.Markdown)
-	b.WriteString("\n\n")
+	if strings.TrimSpace(chosenSketch.Markdown) == "" {
+		// Boy-Scout mode: no Architect Sketch is available. The rebut
+		// action is effectively disabled — any rebut without a verbatim
+		// Sketch citation will be coerced to escalate by the Go-side
+		// safety net. Tell the LLM up-front so it doesn't waste tokens
+		// trying.
+		b.WriteString("## Mode: Boy-Scout review (no Sketch)\n\n")
+		b.WriteString("This PR was not built via /aidev-run, so there is no chosen Architect Sketch to ground rebuttals against. The `rebut` action is UNAVAILABLE in this mode — choose `fix_now`, `defer_to_followup`, or `escalate`. If a finding seems wrong but you cannot fix it via code edit either, escalate to a human.\n\n")
+	} else {
+		b.WriteString("## Chosen Sketch (you may cite from this verbatim in sketch_citation)\n\n")
+		b.WriteString(chosenSketch.Markdown)
+		b.WriteString("\n\n")
+	}
 
 	if c.CriticReport != "" {
 		b.WriteString("## Critic report (background)\n\n")

--- a/internal/agents/triage_test.go
+++ b/internal/agents/triage_test.go
@@ -275,6 +275,78 @@ func TestSketchContainsCitation(t *testing.T) {
 	}
 }
 
+// TestTriageBoyScoutModeNoSketchRunsCleanly locks in the Boy-Scout
+// soft gate: when a PR is reviewed without an Architect Sketch (e.g.
+// `aidev review` was invoked outside the `/aidev-run` flow), Triage
+// must not error — it must run the LLM, parse the verdict, and return
+// fix_now actions normally.
+func TestTriageBoyScoutModeNoSketchRunsCleanly(t *testing.T) {
+	c := &Context{
+		Issue: &github.Issue{Owner: "AiSU-AI", Repo: "Company-Site", Number: 770, Title: "test", Body: ""},
+		// Selector deliberately nil — no Architect Sketch chosen.
+	}
+	llm := `{"actions": [
+		{"id":"f1","source":"reviewer","severity":"blocker","finding":"Missing test for X",
+		 "action":"fix_now","rationale":"Add the missing test","fix_plan":"Add test/x.spec.ts"}
+	]}`
+	in := TriageInput{Review: triageReview("changes_requested", []string{"Missing test"}), Patch: "diff", Round: 1}
+	v := runTriageWithLLM(t, llm, in, c)
+	if v.Convergence != "continue" {
+		t.Errorf("expected convergence=continue, got %q", v.Convergence)
+	}
+	if len(v.Actions) != 1 || v.Actions[0].Action != "fix_now" {
+		t.Errorf("expected one fix_now action preserved, got %+v", v.Actions)
+	}
+	if len(v.CoercionsLog) != 0 {
+		t.Errorf("no coercions expected, got %v", v.CoercionsLog)
+	}
+}
+
+// TestTriageBoyScoutModeRebutCoercedToEscalate locks in the safety net:
+// in Boy-Scout mode the LLM might still attempt rebut, but with no
+// Sketch markdown to cite from, the existing citation coercion must
+// downgrade every rebut to escalate.
+func TestTriageBoyScoutModeRebutCoercedToEscalate(t *testing.T) {
+	c := &Context{
+		Issue: &github.Issue{Owner: "AiSU-AI", Repo: "Company-Site", Number: 770, Title: "test", Body: ""},
+	}
+	llm := `{"actions": [
+		{"id":"f1","source":"reviewer","severity":"blocker",
+		 "finding":"Validation missing","action":"rebut",
+		 "rationale":"Looks valid to me","rebut_text":"The validation is present.",
+		 "sketch_citation":"any text the LLM invented goes here"}
+	]}`
+	in := TriageInput{Review: triageReview("changes_requested", []string{"Validation missing"}), Patch: "diff", Round: 1}
+	v := runTriageWithLLM(t, llm, in, c)
+	if v.Actions[0].Action != "escalate" {
+		t.Errorf("Boy-Scout-mode rebut must coerce to escalate, got %q", v.Actions[0].Action)
+	}
+	if v.Convergence != "escalate" {
+		t.Errorf("expected convergence=escalate, got %q", v.Convergence)
+	}
+	if len(v.CoercionsLog) == 0 {
+		t.Errorf("expected coercion log entry for ungrounded rebut, got %v", v.CoercionsLog)
+	}
+}
+
+// TestTriageBoyScoutModePromptMentionsRebutDisabled verifies the LLM
+// prompt clearly tells the model that rebut is unavailable. Without
+// this, the model will waste tokens crafting rebuts that the Go safety
+// net then escalates anyway.
+func TestTriageBoyScoutModePromptMentionsRebutDisabled(t *testing.T) {
+	c := &Context{
+		Issue: &github.Issue{Owner: "AiSU-AI", Repo: "Company-Site", Number: 770, Title: "test", Body: ""},
+	}
+	in := TriageInput{Review: triageReview("changes_requested", nil), Patch: "diff", Round: 1}
+	prompt := buildTriagePrompt(c, Sketch{}, in)
+	if !strings.Contains(prompt, "Boy-Scout review") {
+		t.Errorf("Boy-Scout-mode prompt should announce the mode, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "`rebut` action is UNAVAILABLE") {
+		t.Errorf("Boy-Scout-mode prompt should tell LLM rebut is unavailable, got:\n%s", prompt)
+	}
+}
+
 func TestIsSecurityCheck(t *testing.T) {
 	yes := []string{"CodeQL", "Snyk", "Dependabot Alerts", "Trivy scan", "Semgrep", "npm audit", "ossf scorecard"}
 	no := []string{"build", "test", "lint", "type-check", "unit-tests"}


### PR DESCRIPTION
## Summary

Three improvements to the Reviewer + Triage agents, motivated by a concrete false-positive in production: PR #770 in Company-Site was flagged for missing \`response.ok\` validation that was clearly present (12 such checks visible in the diff context).

- **Reviewer anti-hallucination rules.** Every Blocker must cite a specific file + line/snippet. Before claiming code is missing, the Reviewer must search the diff's surrounding context. Conforming to existing in-file convention is never a Blocker. \"Doesn't feel safe\" without a concrete reproducer is a Suggestion, not a Blocker.
- **Reviewer Issue-alignment section.** New mandatory section in the output. The Reviewer explicitly classifies the patch as Solves / Partially solves / Does not solve the issue, and the verdict rules now wire Issue-alignment into the final approve/changes_requested decision.
- **Triage Boy-Scout mode.** \`triage: no chosen sketch — Selector verdict required\` is no longer a hard error. When invoked without an Architect Sketch (e.g. \`aidev review\` against a PR not built via \`/aidev-run\`), Triage now runs with rebut effectively disabled — any rebut attempt is escalated by the existing citation-coercion safety net, and the LLM prompt is rewritten to announce the mode and tell the model not to attempt rebut.

## Changes

- \`internal/agents/reviewer.go\` — system prompt rewritten. New \"Issue alignment\" section in output; anti-hallucination rules block; verdict rules now reference Issue-alignment outcomes.
- \`internal/agents/triage.go\` — \`Triage.Run\` no longer errors when \`c.Selector == nil || c.Selector.ChosenNumber == 0\`. \`buildTriagePrompt\` emits a \"Boy-Scout review (no Sketch)\" header in that case, telling the LLM rebut is unavailable.
- \`internal/agents/reviewer_test.go\` — 3 new tests: \`TestReviewerPromptHasIssueAlignmentSection\`, \`TestReviewerPromptHasAntiHallucinationRules\`, \`TestReviewerPromptVerdictRulesCoverIssueAlignment\`.
- \`internal/agents/triage_test.go\` — 3 new tests: \`TestTriageBoyScoutModeNoSketchRunsCleanly\`, \`TestTriageBoyScoutModeRebutCoercedToEscalate\`, \`TestTriageBoyScoutModePromptMentionsRebutDisabled\`.

## Testing

- [x] \`go test ./...\` — all packages pass.
- [x] \`go build ./...\` — clean.
- [ ] Manual end-to-end with a real LLM — out of scope; the prompt assertions are unit-tested via \`capturingProvider\`. Real-LLM behaviour will surface on the next \`/aidev-review\` invocation.

## Risk + rollback

- **Blast radius**: two agents in one package. Other agents (Critic, Selector, Architect, Implementer, Scout, Reporter) are unchanged.
- **Reversibility**: revert is safe. Existing flows (\`/aidev-run\`) still pass a Sketch and exercise the same code paths as before — the Boy-Scout branch only activates when \`Selector == nil\`.
- The anti-hallucination prompt changes only tighten what the Reviewer emits; they do not change the parsing or verdict-extraction logic.

## Follow-ups

- The aidev-review skill docs (\`internal/plugin/files/aidev-review.md\` + copies) could be updated to mention Boy-Scout mode explicitly. The current flow already works because the JSON verdict succeeds; the doc clarification is cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)