### PR TITLE
feat: self-update via aidev upgrade + aidev ls

### DIFF
--- a/cmd/aidev/main.go
+++ b/cmd/aidev/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -38,6 +39,7 @@ import (
 	"github.com/aisu-ai/aidev/internal/llm"
 	"github.com/aisu-ai/aidev/internal/orchestrator"
 	"github.com/aisu-ai/aidev/internal/plugin"
+	"github.com/aisu-ai/aidev/internal/release"
 	"github.com/aisu-ai/aidev/internal/repo"
 	"github.com/aisu-ai/aidev/internal/tui"
 	"github.com/aisu-ai/aidev/internal/version"
@@ -159,6 +161,23 @@ func main() {
 		}
 		os.Args = append(os.Args[:1], os.Args[2:]...)
 		runCompletionSubcommand()
+		return
+	}
+	// Intercept the `upgrade` subcommand. Self-update: downloads the
+	// latest (or pinned) release tarball, extracts the binary, and
+	// atomically swaps the on-disk copy. Replaces the manual
+	// `install.sh --version vX.Y.Z --force` step.
+	if len(os.Args) > 1 && os.Args[1] == "upgrade" {
+		os.Args = append(os.Args[:1], os.Args[2:]...)
+		runUpgradeSubcommand()
+		return
+	}
+	// Intercept the `ls` subcommand. Read-only catalog: prints the
+	// installed version + N most recent published releases so the
+	// user can see what's available before running `aidev upgrade`.
+	if len(os.Args) > 1 && (os.Args[1] == "ls" || os.Args[1] == "list") {
+		os.Args = append(os.Args[:1], os.Args[2:]...)
+		runLsSubcommand()
 		return
 	}
 
@@ -1722,4 +1741,213 @@ func runCompletionSubcommand() {
 func fatal(msg string) {
 	fmt.Fprintf(os.Stderr, "aidev: %s\n", msg)
 	os.Exit(1)
+}
+
+// runUpgradeSubcommand self-updates the running binary by downloading
+// a release tarball, extracting the embedded binary, and atomically
+// swapping the on-disk copy. The running process is unaffected — Unix
+// keeps the open inode alive — but the NEXT `aidev` invocation gets
+// the new version.
+//
+// Flags:
+//
+//	--version <tag>   pin a specific release (default: latest)
+//	--bin     <path>  override the binary path (default: os.Executable())
+//	--yes             skip the confirmation prompt
+func runUpgradeSubcommand() {
+	fs := flag.NewFlagSet("upgrade", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: aidev upgrade [--version <tag>] [--bin <path>] [--yes]\n\n")
+		fmt.Fprintf(os.Stderr, "Download a release tarball and replace the installed binary in place.\n")
+		fmt.Fprintf(os.Stderr, "Default target is the latest release for your platform.\n\n")
+		fs.PrintDefaults()
+	}
+	tag := fs.String("version", "", "specific release tag to install (default: latest)")
+	binOverride := fs.String("bin", "", "override the binary path to replace (default: detected from os.Executable)")
+	yes := fs.Bool("yes", false, "skip the confirmation prompt")
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		fatal(fmt.Sprintf("parse flags: %v", err))
+	}
+
+	// Resolve the binary path. os.Executable returns the path that
+	// invoked this process — usually `/.../.local/bin/aidev`. The user
+	// can override for testing or to upgrade a sibling install.
+	destPath := *binOverride
+	if destPath == "" {
+		exe, err := os.Executable()
+		if err != nil {
+			fatal(fmt.Sprintf("locate current binary: %v (pass --bin <path>)", err))
+		}
+		// Resolve symlinks so we swap the real file, not the link.
+		real, err := filepath.EvalSymlinks(exe)
+		if err == nil {
+			destPath = real
+		} else {
+			destPath = exe
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	rel, err := resolveTargetRelease(ctx, *tag)
+	if err != nil {
+		fatal(err.Error())
+	}
+
+	asset, err := rel.CurrentPlatformAsset()
+	if err != nil {
+		fatal(err.Error())
+	}
+
+	if version.Version == rel.Tag {
+		fmt.Printf("aidev %s is already installed at %s — nothing to do.\n", rel.Tag, destPath)
+		fmt.Printf("Pass --version <other-tag> to switch to a different release.\n")
+		return
+	}
+
+	fmt.Printf("Current : aidev %s\n", version.Version)
+	fmt.Printf("Target  : aidev %s (%s, %s)\n", rel.Tag, asset.Name, humanBytes(asset.Size))
+	fmt.Printf("Binary  : %s\n", destPath)
+
+	if !*yes {
+		fmt.Printf("\nProceed with upgrade? [y/N] ")
+		reader := bufio.NewReader(os.Stdin)
+		line, _ := reader.ReadString('\n')
+		ans := strings.ToLower(strings.TrimSpace(line))
+		if ans != "y" && ans != "yes" {
+			fmt.Println("aborted.")
+			return
+		}
+	}
+
+	fmt.Printf("\nDownloading %s ...\n", asset.Name)
+	tgz, err := release.Download(ctx, asset, nil)
+	if err != nil {
+		fatal(err.Error())
+	}
+	defer os.Remove(tgz)
+
+	fmt.Println("Extracting ...")
+	binSrc, err := release.Extract(tgz)
+	if err != nil {
+		fatal(err.Error())
+	}
+	defer os.RemoveAll(filepath.Dir(binSrc))
+
+	fmt.Printf("Swapping %s ...\n", destPath)
+	if err := release.SwapBinary(binSrc, destPath); err != nil {
+		fatal(err.Error())
+	}
+
+	fmt.Printf("\naidev %s installed at %s\n", rel.Tag, destPath)
+	fmt.Printf("Run `aidev --version` in a NEW shell to confirm.\n")
+}
+
+// resolveTargetRelease picks the release to install. Empty tag → the
+// repo's "Latest" release. Non-empty → that exact tag (404 if missing).
+func resolveTargetRelease(ctx context.Context, tag string) (*release.Release, error) {
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		return release.FetchLatest(ctx, release.DefaultOwner, release.DefaultRepo, nil)
+	}
+	// Tolerate "0.6.0" passed without the v prefix — the release
+	// workflow always tags with v, but humans drop it constantly.
+	if !strings.HasPrefix(tag, "v") {
+		tag = "v" + tag
+	}
+	return release.FetchByTag(ctx, release.DefaultOwner, release.DefaultRepo, tag, nil)
+}
+
+// runLsSubcommand prints the installed version + most recent
+// published releases. Read-only; never modifies the on-disk binary.
+//
+// Flags:
+//
+//	--limit <n>  number of releases to list (default: 10)
+//	--all        include prereleases (default: hide them from the list)
+func runLsSubcommand() {
+	fs := flag.NewFlagSet("ls", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: aidev ls [--limit <n>] [--all]\n\n")
+		fmt.Fprintf(os.Stderr, "Print the installed version + recent published releases.\n\n")
+		fs.PrintDefaults()
+	}
+	limit := fs.Int("limit", 10, "number of releases to show")
+	includeAll := fs.Bool("all", false, "include prereleases in the listing")
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		fatal(fmt.Sprintf("parse flags: %v", err))
+	}
+
+	exe, _ := os.Executable()
+	fmt.Printf("Installed: aidev %s\n", version.Version)
+	if exe != "" {
+		fmt.Printf("Binary   : %s\n", exe)
+	}
+	fmt.Printf("Platform : %s-%s\n\n", runtime.GOOS, runtime.GOARCH)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	releases, err := release.FetchReleases(ctx, release.DefaultOwner, release.DefaultRepo, *limit, nil)
+	if err != nil {
+		fatal(err.Error())
+	}
+
+	if len(releases) == 0 {
+		fmt.Println("No published releases found.")
+		return
+	}
+
+	// Resolve which tag is "Latest" so we can mark it. Falls back to
+	// the newest non-prerelease if the call fails (rate limit, offline).
+	latest, _ := release.FetchLatest(ctx, release.DefaultOwner, release.DefaultRepo, nil)
+	latestTag := ""
+	if latest != nil {
+		latestTag = latest.Tag
+	}
+
+	fmt.Println("Available releases:")
+	shown := 0
+	for _, r := range releases {
+		if r.Prerelease && !*includeAll {
+			continue
+		}
+		marker := "  "
+		switch {
+		case r.Tag == version.Version:
+			marker = "* " // currently installed
+		case r.Tag == latestTag:
+			marker = "→ " // marked Latest on GitHub
+		}
+		tag := r.Tag
+		if r.Prerelease {
+			tag += " (prerelease)"
+		}
+		fmt.Printf("%s%-20s  %s\n", marker, tag, r.PublishedAt.UTC().Format("2006-01-02"))
+		shown++
+	}
+	if shown == 0 {
+		fmt.Println("  (no stable releases — pass --all to include prereleases)")
+	}
+	fmt.Println()
+	fmt.Println("Legend: * installed   → latest")
+	fmt.Println("Upgrade: aidev upgrade [--version <tag>]")
+}
+
+// humanBytes renders a byte count as a short human-readable string.
+// Used only in the upgrade-confirmation UI; exact precision doesn't
+// matter, so we cap at MB.
+func humanBytes(n int64) string {
+	const (
+		KB = 1024
+		MB = 1024 * KB
+	)
+	switch {
+	case n >= MB:
+		return fmt.Sprintf("%.1f MB", float64(n)/float64(MB))
+	case n >= KB:
+		return fmt.Sprintf("%.1f KB", float64(n)/float64(KB))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }

--- a/internal/plugin/files/aidev-ls.md
+++ b/internal/plugin/files/aidev-ls.md
@@ -1,0 +1,23 @@
+---
+description: Show installed aidev version and all available releases
+allowed-tools: Bash(aidev:*)
+---
+
+Show the user which aidev version is installed locally plus the most
+recent published releases on GitHub.
+
+With no argument:
+
+!`aidev ls`
+
+With a numeric argument (interpreted as a limit):
+
+!`aidev ls --limit "$ARGUMENTS"`
+
+The legend at the bottom of the output explains the markers:
+
+- `*` next to a tag means it's the version currently installed.
+- `→` next to a tag means GitHub marks it as the "Latest" release.
+
+If the user wants to switch to a different release, point them at
+`/aidev-upgrade <tag>` (or omit the tag for latest).

--- a/internal/plugin/files/aidev-upgrade.md
+++ b/internal/plugin/files/aidev-upgrade.md
@@ -1,0 +1,24 @@
+---
+description: Upgrade aidev to the latest release (or a specific tag)
+allowed-tools: Bash(aidev:*)
+---
+
+Run aidev's self-update. With no argument, installs the latest published
+release. With a tag argument, pins that version.
+
+If `$ARGUMENTS` is empty:
+
+!`aidev upgrade --yes`
+
+Otherwise:
+
+!`aidev upgrade --version "$ARGUMENTS" --yes`
+
+After the swap completes, the running Claude Code session is still using
+the old binary in memory — but the next `aidev` invocation (any new
+subcommand, `/aidev-run`, `/aidev-review`, etc.) picks up the upgraded
+version. Tell the user the new version is live for future calls.
+
+If the user passed a version that doesn't exist, aidev will surface a
+clear "no release found with tag X" message — relay that verbatim and
+suggest `/aidev-ls` so they can see which tags are available.

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -1,0 +1,366 @@
+// Package release provides aidev's self-update mechanism: fetching
+// release metadata from the GitHub Releases REST API, downloading the
+// platform-specific tarball, and atomically swapping the on-disk binary.
+//
+// The public surface is small enough that `aidev upgrade` and
+// `aidev ls` each compose one or two calls from this package; tests can
+// exercise the API client against an httptest.Server without hitting
+// real network.
+package release
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// DefaultBaseURL is the public GitHub API origin. Tests inject a
+// httptest.Server URL by passing it to FetchReleases / FetchLatest.
+const DefaultBaseURL = "https://api.github.com"
+
+// DefaultOwner / DefaultRepo identify the canonical aidev repo on
+// GitHub. Subcommands pass these through; tests use the same.
+const (
+	DefaultOwner = "AiSU-AI"
+	DefaultRepo  = "aidev"
+)
+
+// Release is the trimmed-down release metadata we surface to callers.
+// We deliberately drop fields like uploader, assets_url, etc. — the
+// caller's mental model is "what tag, what assets, when did it ship".
+type Release struct {
+	Tag         string    `json:"tag_name"`
+	Name        string    `json:"name"`
+	PublishedAt time.Time `json:"published_at"`
+	Draft       bool      `json:"draft"`
+	Prerelease  bool      `json:"prerelease"`
+	Notes       string    `json:"body"`
+	Assets      []Asset   `json:"assets"`
+}
+
+// Asset is one downloadable file attached to a Release.
+type Asset struct {
+	Name        string `json:"name"`
+	DownloadURL string `json:"browser_download_url"`
+	Size        int64  `json:"size"`
+}
+
+// FetchOptions tunes the HTTP client without exposing the raw client
+// to callers. BaseURL exists only to make httptest injection possible.
+type FetchOptions struct {
+	BaseURL string        // defaults to DefaultBaseURL
+	Timeout time.Duration // defaults to 15s
+}
+
+// FetchReleases returns at most `limit` releases for owner/repo,
+// newest first. The GitHub /releases endpoint already orders by
+// created_at desc, so we just respect that order.
+//
+// Drafts are filtered out — they're not installable via tag download.
+// Prereleases ARE returned (some users want to opt into them) but the
+// caller decides what to do with them.
+func FetchReleases(ctx context.Context, owner, repo string, limit int, opts *FetchOptions) ([]Release, error) {
+	base, client := resolveClient(opts)
+	if limit <= 0 {
+		limit = 30
+	}
+	url := fmt.Sprintf("%s/repos/%s/%s/releases?per_page=%d", base, owner, repo, limit)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("release: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "aidev")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("release: GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("release: GET %s -> HTTP %d: %s", url, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var all []Release
+	if err := json.NewDecoder(resp.Body).Decode(&all); err != nil {
+		return nil, fmt.Errorf("release: decode response: %w", err)
+	}
+
+	// Drop drafts. The order from GitHub is newest-first; preserve it.
+	out := make([]Release, 0, len(all))
+	for _, r := range all {
+		if r.Draft {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// FetchLatest returns the release tagged "Latest" on GitHub — NOT
+// simply the newest in time. Maintainers can pin "Latest" to an older
+// tag if a newer one is prerelease-only.
+func FetchLatest(ctx context.Context, owner, repo string, opts *FetchOptions) (*Release, error) {
+	base, client := resolveClient(opts)
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", base, owner, repo)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("release: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "aidev")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("release: GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("release: no latest release published for %s/%s yet", owner, repo)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("release: GET %s -> HTTP %d: %s", url, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var r Release
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, fmt.Errorf("release: decode response: %w", err)
+	}
+	return &r, nil
+}
+
+// FetchByTag returns the release with the given tag, e.g. "v0.5.0".
+func FetchByTag(ctx context.Context, owner, repo, tag string, opts *FetchOptions) (*Release, error) {
+	base, client := resolveClient(opts)
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/tags/%s", base, owner, repo, tag)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("release: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "aidev")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("release: GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("release: no release found with tag %q for %s/%s", tag, owner, repo)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("release: GET %s -> HTTP %d: %s", url, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var r Release
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, fmt.Errorf("release: decode response: %w", err)
+	}
+	return &r, nil
+}
+
+// AssetFor returns the asset matching the given GOOS/GOARCH using the
+// canonical `aidev-<tag>-<goos>-<goarch>.tar.gz` naming convention from
+// .github/workflows/release.yaml. Returns an error when no asset
+// matches — typically because the release workflow hasn't yet
+// published a build for the user's platform.
+func (r *Release) AssetFor(goos, goarch string) (*Asset, error) {
+	want := fmt.Sprintf("aidev-%s-%s-%s.tar.gz", r.Tag, goos, goarch)
+	for i := range r.Assets {
+		if r.Assets[i].Name == want {
+			return &r.Assets[i], nil
+		}
+	}
+	have := make([]string, 0, len(r.Assets))
+	for _, a := range r.Assets {
+		have = append(have, a.Name)
+	}
+	return nil, fmt.Errorf("release: no asset named %q in release %s (have: %s)", want, r.Tag, strings.Join(have, ", "))
+}
+
+// CurrentPlatformAsset is a convenience wrapper for AssetFor using
+// runtime.GOOS/GOARCH — the typical caller path.
+func (r *Release) CurrentPlatformAsset() (*Asset, error) {
+	return r.AssetFor(runtime.GOOS, runtime.GOARCH)
+}
+
+// Download fetches the asset's tarball to a fresh temp file. Returns
+// the path. Caller is responsible for cleanup (and almost always
+// follows with Extract → SwapBinary).
+func Download(ctx context.Context, asset *Asset, opts *FetchOptions) (string, error) {
+	if asset == nil {
+		return "", errors.New("release: nil asset")
+	}
+	_, client := resolveClient(opts)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, asset.DownloadURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("release: build request: %w", err)
+	}
+	req.Header.Set("User-Agent", "aidev")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("release: GET %s: %w", asset.DownloadURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("release: GET %s -> HTTP %d", asset.DownloadURL, resp.StatusCode)
+	}
+
+	tmp, err := os.CreateTemp("", "aidev-asset-*.tar.gz")
+	if err != nil {
+		return "", fmt.Errorf("release: create temp file: %w", err)
+	}
+	defer tmp.Close()
+
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("release: write asset: %w", err)
+	}
+	return tmp.Name(), nil
+}
+
+// Extract unpacks the given tarball into a temp dir and returns the
+// path to the embedded `aidev` binary. The release tarball has shape
+// `aidev-<tag>-<goos>-<goarch>/aidev` per .github/workflows/release.yaml.
+func Extract(tgzPath string) (string, error) {
+	f, err := os.Open(tgzPath)
+	if err != nil {
+		return "", fmt.Errorf("release: open tarball: %w", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return "", fmt.Errorf("release: gzip: %w", err)
+	}
+	defer gz.Close()
+
+	dir, err := os.MkdirTemp("", "aidev-extract-*")
+	if err != nil {
+		return "", fmt.Errorf("release: mkdir temp: %w", err)
+	}
+
+	tr := tar.NewReader(gz)
+	var binPath string
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("release: tar read: %w", err)
+		}
+		// Defense in depth against tar-slip: refuse absolute paths and
+		// any `..` segment. The release tarballs we ship don't use
+		// either, but the OSS world is full of malicious tarballs and
+		// we don't want to be the next vuln.
+		if filepath.IsAbs(hdr.Name) || strings.Contains(hdr.Name, "..") {
+			return "", fmt.Errorf("release: refusing entry with unsafe path %q", hdr.Name)
+		}
+		target := filepath.Join(dir, hdr.Name)
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return "", err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return "", err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&0o777)
+			if err != nil {
+				return "", err
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return "", err
+			}
+			out.Close()
+			if filepath.Base(target) == "aidev" {
+				binPath = target
+			}
+		}
+	}
+	if binPath == "" {
+		return "", fmt.Errorf("release: extracted archive does not contain an `aidev` binary in %s", dir)
+	}
+	return binPath, nil
+}
+
+// SwapBinary atomically replaces destPath with srcPath. On Unix this
+// works even when destPath is the currently-running binary — the OS
+// keeps the open inode alive until the running process exits, and the
+// rename swaps which file the name resolves to.
+//
+// Cross-filesystem renames fail with EXDEV on Linux; fall back to copy+
+// rename within the destination's directory.
+func SwapBinary(srcPath, destPath string) error {
+	// Try a same-dir staged rename first: copy src to a sibling of dest,
+	// then rename. This guarantees same-filesystem semantics regardless
+	// of whether srcPath is in /tmp.
+	stage := destPath + ".aidev-upgrade.tmp"
+	if err := copyFile(srcPath, stage, 0o755); err != nil {
+		return fmt.Errorf("release: stage: %w", err)
+	}
+	if err := os.Rename(stage, destPath); err != nil {
+		// Best-effort cleanup of the stage file before bubbling the
+		// error — leaving it dangling makes the next attempt fail with
+		// a confusing "file exists" message.
+		_ = os.Remove(stage)
+		return fmt.Errorf("release: swap %s -> %s: %w", stage, destPath, err)
+	}
+	return nil
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}
+
+func resolveClient(opts *FetchOptions) (string, *http.Client) {
+	base := DefaultBaseURL
+	timeout := 15 * time.Second
+	if opts != nil {
+		if opts.BaseURL != "" {
+			base = opts.BaseURL
+		}
+		if opts.Timeout > 0 {
+			timeout = opts.Timeout
+		}
+	}
+	return base, &http.Client{Timeout: timeout}
+}

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -1,0 +1,328 @@
+package release
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeServer returns an httptest.Server that responds to the three
+// endpoints we hit: GET /repos/.../releases, /releases/latest,
+// /releases/tags/<tag>. The test passes the server's URL via
+// FetchOptions.BaseURL so no real network is touched.
+func fakeServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	releases := []Release{
+		{
+			Tag:         "v0.5.0",
+			Name:        "v0.5.0",
+			PublishedAt: time.Date(2026, 5, 14, 5, 41, 0, 0, time.UTC),
+			Notes:       "Reviewer + Triage improvements",
+			Assets: []Asset{
+				{Name: "aidev-v0.5.0-darwin-arm64.tar.gz", DownloadURL: "https://example.invalid/v0.5.0/darwin-arm64", Size: 12345},
+				{Name: "aidev-v0.5.0-darwin-amd64.tar.gz", DownloadURL: "https://example.invalid/v0.5.0/darwin-amd64", Size: 12345},
+				{Name: "aidev-v0.5.0-linux-amd64.tar.gz", DownloadURL: "https://example.invalid/v0.5.0/linux-amd64", Size: 12345},
+				{Name: "aidev-v0.5.0-linux-arm64.tar.gz", DownloadURL: "https://example.invalid/v0.5.0/linux-arm64", Size: 12345},
+			},
+		},
+		{
+			Tag:         "v0.4.0",
+			Name:        "v0.4.0",
+			PublishedAt: time.Date(2026, 4, 19, 15, 46, 0, 0, time.UTC),
+			Notes:       "earlier release",
+			Assets: []Asset{
+				{Name: "aidev-v0.4.0-darwin-arm64.tar.gz", DownloadURL: "https://example.invalid/v0.4.0/darwin-arm64", Size: 12345},
+			},
+		},
+		{
+			Tag:         "v0.3.0-beta",
+			Name:        "v0.3.0-beta",
+			PublishedAt: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			Prerelease:  true,
+			Notes:       "early prerelease",
+			Assets:      nil,
+		},
+		{
+			// Draft — must be filtered out by FetchReleases.
+			Tag:         "v0.6.0-draft",
+			Name:        "v0.6.0-draft",
+			PublishedAt: time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC),
+			Draft:       true,
+			Assets:      nil,
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/AiSU-AI/aidev/releases", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(releases)
+	})
+	mux.HandleFunc("/repos/AiSU-AI/aidev/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		// Pretend GitHub considers v0.5.0 the "Latest" tag.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(releases[0])
+	})
+	mux.HandleFunc("/repos/AiSU-AI/aidev/releases/tags/v0.4.0", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(releases[1])
+	})
+	mux.HandleFunc("/repos/AiSU-AI/aidev/releases/tags/v9.9.9", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestFetchReleasesReturnsNonDraftsNewestFirst(t *testing.T) {
+	srv := fakeServer(t)
+	defer srv.Close()
+
+	got, err := FetchReleases(context.Background(), "AiSU-AI", "aidev", 30, &FetchOptions{BaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("FetchReleases: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 releases (drafts filtered), got %d", len(got))
+	}
+	wantOrder := []string{"v0.5.0", "v0.4.0", "v0.3.0-beta"}
+	for i, r := range got {
+		if r.Tag != wantOrder[i] {
+			t.Errorf("release[%d].Tag = %q, want %q", i, r.Tag, wantOrder[i])
+		}
+	}
+	for _, r := range got {
+		if r.Draft {
+			t.Errorf("draft release leaked through: %s", r.Tag)
+		}
+	}
+}
+
+func TestFetchLatestReturnsTaggedLatest(t *testing.T) {
+	srv := fakeServer(t)
+	defer srv.Close()
+
+	r, err := FetchLatest(context.Background(), "AiSU-AI", "aidev", &FetchOptions{BaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("FetchLatest: %v", err)
+	}
+	if r.Tag != "v0.5.0" {
+		t.Errorf("FetchLatest.Tag = %q, want v0.5.0", r.Tag)
+	}
+}
+
+func TestFetchByTagReturnsRequested(t *testing.T) {
+	srv := fakeServer(t)
+	defer srv.Close()
+
+	r, err := FetchByTag(context.Background(), "AiSU-AI", "aidev", "v0.4.0", &FetchOptions{BaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("FetchByTag: %v", err)
+	}
+	if r.Tag != "v0.4.0" {
+		t.Errorf("FetchByTag.Tag = %q, want v0.4.0", r.Tag)
+	}
+}
+
+func TestFetchByTagReturnsClearErrorOnUnknownTag(t *testing.T) {
+	srv := fakeServer(t)
+	defer srv.Close()
+
+	_, err := FetchByTag(context.Background(), "AiSU-AI", "aidev", "v9.9.9", &FetchOptions{BaseURL: srv.URL})
+	if err == nil {
+		t.Fatal("expected error for unknown tag")
+	}
+	if !strings.Contains(err.Error(), "no release found with tag") {
+		t.Errorf("error should mention the missing tag, got: %v", err)
+	}
+}
+
+func TestAssetForMatchesPlatformNamingConvention(t *testing.T) {
+	r := &Release{
+		Tag: "v0.5.0",
+		Assets: []Asset{
+			{Name: "aidev-v0.5.0-darwin-arm64.tar.gz"},
+			{Name: "aidev-v0.5.0-darwin-amd64.tar.gz"},
+			{Name: "aidev-v0.5.0-linux-arm64.tar.gz"},
+			{Name: "aidev-v0.5.0-linux-amd64.tar.gz"},
+		},
+	}
+	cases := []struct {
+		goos, goarch string
+		wantName     string
+	}{
+		{"darwin", "arm64", "aidev-v0.5.0-darwin-arm64.tar.gz"},
+		{"darwin", "amd64", "aidev-v0.5.0-darwin-amd64.tar.gz"},
+		{"linux", "amd64", "aidev-v0.5.0-linux-amd64.tar.gz"},
+		{"linux", "arm64", "aidev-v0.5.0-linux-arm64.tar.gz"},
+	}
+	for _, c := range cases {
+		t.Run(c.goos+"-"+c.goarch, func(t *testing.T) {
+			a, err := r.AssetFor(c.goos, c.goarch)
+			if err != nil {
+				t.Fatalf("AssetFor(%s,%s): %v", c.goos, c.goarch, err)
+			}
+			if a.Name != c.wantName {
+				t.Errorf("got %q, want %q", a.Name, c.wantName)
+			}
+		})
+	}
+}
+
+func TestAssetForReturnsHelpfulErrorWhenPlatformMissing(t *testing.T) {
+	r := &Release{
+		Tag: "v0.5.0",
+		Assets: []Asset{
+			{Name: "aidev-v0.5.0-linux-amd64.tar.gz"},
+		},
+	}
+	_, err := r.AssetFor("windows", "arm64")
+	if err == nil {
+		t.Fatal("expected error for missing platform")
+	}
+	if !strings.Contains(err.Error(), "windows-arm64") {
+		t.Errorf("error should name the missing platform, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "linux-amd64") {
+		t.Errorf("error should list available assets, got: %v", err)
+	}
+}
+
+func TestExtractFindsAidevBinaryInsideExpectedTarShape(t *testing.T) {
+	// Build a tarball matching .github/workflows/release.yaml shape:
+	// aidev-<tag>-<goos>-<goarch>/aidev
+	tgz := buildFakeTarball(t, "aidev-v0.5.0-darwin-arm64", "#!/bin/sh\necho hello\n")
+
+	bin, err := Extract(tgz)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if filepath.Base(bin) != "aidev" {
+		t.Errorf("returned path basename = %q, want aidev", filepath.Base(bin))
+	}
+	data, err := os.ReadFile(bin)
+	if err != nil {
+		t.Fatalf("read extracted bin: %v", err)
+	}
+	if !strings.Contains(string(data), "hello") {
+		t.Errorf("extracted bin contents lost: %q", string(data))
+	}
+	info, err := os.Stat(bin)
+	if err != nil {
+		t.Fatalf("stat extracted bin: %v", err)
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		t.Errorf("extracted bin is not executable: %v", info.Mode())
+	}
+}
+
+func TestExtractRejectsTarSlipPaths(t *testing.T) {
+	tgz := buildFakeTarballRaw(t, []tarEntry{
+		{name: "../escape/aidev", body: "evil"},
+	})
+	_, err := Extract(tgz)
+	if err == nil {
+		t.Fatal("expected error for path traversal")
+	}
+	if !strings.Contains(err.Error(), "unsafe path") {
+		t.Errorf("error should call out the unsafe path, got: %v", err)
+	}
+}
+
+func TestExtractFailsWhenNoAidevBinaryPresent(t *testing.T) {
+	tgz := buildFakeTarballRaw(t, []tarEntry{
+		{name: "aidev-v0.5.0-darwin-arm64/README.md", body: "no binary here"},
+	})
+	_, err := Extract(tgz)
+	if err == nil {
+		t.Fatal("expected error when binary is missing")
+	}
+	if !strings.Contains(err.Error(), "does not contain an `aidev` binary") {
+		t.Errorf("error should explain the missing binary, got: %v", err)
+	}
+}
+
+func TestSwapBinaryReplacesDestAtomically(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "aidev")
+	if err := os.WriteFile(dest, []byte("OLD"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(dir, "aidev-new")
+	if err := os.WriteFile(src, []byte("NEW"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SwapBinary(src, dest); err != nil {
+		t.Fatalf("SwapBinary: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "NEW" {
+		t.Errorf("dest contents = %q, want NEW", string(got))
+	}
+	// The stage file (.aidev-upgrade.tmp) should not be left around
+	// after a successful swap — it gets renamed.
+	if _, err := os.Stat(dest + ".aidev-upgrade.tmp"); !os.IsNotExist(err) {
+		t.Errorf("stage file should not exist after successful swap")
+	}
+}
+
+// ---- test helpers --------------------------------------------------
+
+type tarEntry struct {
+	name string
+	body string
+}
+
+func buildFakeTarball(t *testing.T, dirName, binBody string) string {
+	t.Helper()
+	return buildFakeTarballRaw(t, []tarEntry{
+		{name: dirName + "/", body: ""},
+		{name: dirName + "/aidev", body: binBody},
+	})
+}
+
+func buildFakeTarballRaw(t *testing.T, entries []tarEntry) string {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		hdr := &tar.Header{Name: e.name, Mode: 0o755, Size: int64(len(e.body))}
+		if strings.HasSuffix(e.name, "/") {
+			hdr.Typeflag = tar.TypeDir
+			hdr.Size = 0
+		} else {
+			hdr.Typeflag = tar.TypeReg
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("tar header %q: %v", e.name, err)
+		}
+		if hdr.Typeflag == tar.TypeReg {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatalf("tar body %q: %v", e.name, err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "fake.tar.gz")
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/plugin/aidev/commands/aidev-ls.md
+++ b/plugin/aidev/commands/aidev-ls.md
@@ -1,0 +1,23 @@
+---
+description: Show installed aidev version and all available releases
+allowed-tools: Bash(aidev:*)
+---
+
+Show the user which aidev version is installed locally plus the most
+recent published releases on GitHub.
+
+With no argument:
+
+!`aidev ls`
+
+With a numeric argument (interpreted as a limit):
+
+!`aidev ls --limit "$ARGUMENTS"`
+
+The legend at the bottom of the output explains the markers:
+
+- `*` next to a tag means it's the version currently installed.
+- `→` next to a tag means GitHub marks it as the "Latest" release.
+
+If the user wants to switch to a different release, point them at
+`/aidev-upgrade <tag>` (or omit the tag for latest).

--- a/plugin/aidev/commands/aidev-upgrade.md
+++ b/plugin/aidev/commands/aidev-upgrade.md
@@ -1,0 +1,24 @@
+---
+description: Upgrade aidev to the latest release (or a specific tag)
+allowed-tools: Bash(aidev:*)
+---
+
+Run aidev's self-update. With no argument, installs the latest published
+release. With a tag argument, pins that version.
+
+If `$ARGUMENTS` is empty:
+
+!`aidev upgrade --yes`
+
+Otherwise:
+
+!`aidev upgrade --version "$ARGUMENTS" --yes`
+
+After the swap completes, the running Claude Code session is still using
+the old binary in memory — but the next `aidev` invocation (any new
+subcommand, `/aidev-run`, `/aidev-review`, etc.) picks up the upgraded
+version. Tell the user the new version is live for future calls.
+
+If the user passed a version that doesn't exist, aidev will surface a
+clear "no release found with tag X" message — relay that verbatim and
+suggest `/aidev-ls` so they can see which tags are available.


### PR DESCRIPTION
## Summary

Two new subcommands so users can manage their aidev install without re-running \`install.sh\`:

- \`aidev upgrade [--version <tag>] [--bin <path>] [--yes]\` — downloads the platform-specific release tarball, extracts the embedded binary, and atomically swaps the on-disk copy. Replaces the manual \`install.sh --version vX.Y.Z --force\` step.
- \`aidev ls [--limit <n>] [--all]\` — prints the installed version, the binary path, the platform, and the most recent published releases. \`*\` marks the installed tag; \`→\` marks GitHub's \"Latest\" tag.

Plus matching slash commands so Claude Code can drive both:
- \`/aidev-upgrade [tag]\`
- \`/aidev-ls [limit]\`

Builds cleanly on the existing release-binary infrastructure (the \`v*\` tag → release.yaml workflow → 4 cross-platform tarballs flow that already ships v0.2f..v0.5.0).

## Changes

### \`internal/release/\` (new package)
- \`FetchReleases\` / \`FetchLatest\` / \`FetchByTag\` — thin GitHub Releases REST clients. Drafts filtered out; prereleases preserved (caller decides what to do with them).
- \`Release.AssetFor(goos, goarch)\` — picks the asset matching the workflow's \`aidev-<tag>-<goos>-<goarch>.tar.gz\` naming convention. Returns a helpful \"have: ...\" message when the platform isn't built.
- \`Download\` / \`Extract\` — download to temp + untar. Includes defense against tar-slip (\`..\`, absolute paths).
- \`SwapBinary\` — stage-and-rename inside the destination's directory. Same-filesystem rename → atomic on Unix even when the running binary is being replaced (open inode keeps the old file alive).

### \`cmd/aidev/main.go\`
- New \`upgrade\` and \`ls\` subcommand intercepts in \`main()\`. \`ls\` aliases \`list\`.
- \`runUpgradeSubcommand\` — interactive confirmation by default; \`--yes\` skips. Detects current binary via \`os.Executable\` + \`filepath.EvalSymlinks\` so symlinked installs swap the real file, not the link. Bails fast when the requested tag matches \`version.Version\` (\"nothing to do\").
- \`runLsSubcommand\` — read-only; never touches the binary. Marks the installed tag with \`*\` and the GitHub-marked latest with \`→\`. Hides prereleases by default; \`--all\` includes them.

### Slash commands
- \`internal/plugin/files/aidev-upgrade.md\`, \`internal/plugin/files/aidev-ls.md\` (embedded into the binary via \`//go:embed all:files\`).
- Mirrored to \`plugin/aidev/commands/\` for the plugin-marketplace distribution path.

## Testing

- [x] \`go test ./...\` — all packages pass. New \`internal/release/\` suite is 11 tests covering: fetch endpoints, draft filtering, ordering, asset selection per platform, missing-platform error message, tar-slip rejection, missing-binary error message, atomic swap.
- [x] \`go build ./...\` — clean.
- [x] **End-to-end smoke**: ran \`aidev upgrade --version v0.5.0 --bin /tmp/aidev-upgrade-test --yes\` against the live GitHub release. Downloaded the 3.1 MB darwin-arm64 tarball, extracted, swapped, and the resulting binary at \`/tmp/aidev-upgrade-test --version\` correctly reports \`aidev v0.5.0\`.
- [x] **\`aidev ls\` against live GitHub**: returned \`v0.5.0\` (with \`→\` marker), \`v0.4.0\`, \`v0.3.0\`, \`v0.2f\` in correct order with correct dates.

## Risk + rollback

- **Blast radius**: one new package (\`internal/release\`), two new \`main\` subcommands, two new embedded skill files. No changes to existing agents, orchestrator, or LLM clients.
- **Reversibility**: revert is safe. The two subcommands are pure additions; if reverted, users fall back to the existing \`install.sh --version vX.Y.Z --force\` flow.
- **Self-replacement safety**: \`SwapBinary\` uses stage-and-rename within the dest directory. On Unix this works while the binary is running because the OS keeps the open inode alive. On Windows it would fail with \"file in use\" — we don't ship Windows binaries and the release workflow doesn't build for Windows, so this is moot.
- **Tar-slip**: explicit defense (\`filepath.IsAbs\` + \`..\` substring check). Tested.

## Follow-ups

- The release workflow's actions (\`actions/checkout@v4\`, \`actions/setup-go@v5\`, \`softprops/action-gh-release@v2\`) emitted a Node.js 20 deprecation warning during the v0.5.0 build. Worth a 5-line PR to bump them all before September 2026.
- Self-update doesn't refresh the embedded plugin files (\`~/.claude/commands/aidev-*.md\`) or the config dir — only the binary. \`aidev plugin install --force\` is still the right step after upgrading to a release that changed plugin files. Could be folded into \`aidev upgrade\` later but adds blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)