### PR TITLE
fix: slash commands fail when invoked without arguments

### DIFF
--- a/internal/plugin/files/aidev-ls.md
+++ b/internal/plugin/files/aidev-ls.md
@@ -6,13 +6,11 @@ allowed-tools: Bash(aidev:*)
 Show the user which aidev version is installed locally plus the most
 recent published releases on GitHub.
 
-With no argument:
+- No argument → list defaults.
+- Numeric argument → treat as `--limit N`.
+- Anything else (e.g. `--all`, `-all`) → pass through as flags.
 
-!`aidev ls`
-
-With a numeric argument (interpreted as a limit):
-
-!`aidev ls --limit "$ARGUMENTS"`
+!`if [ -z "$ARGUMENTS" ]; then aidev ls; elif printf '%s' "$ARGUMENTS" | grep -qE '^[0-9]+$'; then aidev ls --limit "$ARGUMENTS"; else aidev ls $ARGUMENTS; fi`
 
 The legend at the bottom of the output explains the markers:
 

--- a/internal/plugin/files/aidev-upgrade.md
+++ b/internal/plugin/files/aidev-upgrade.md
@@ -6,13 +6,7 @@ allowed-tools: Bash(aidev:*)
 Run aidev's self-update. With no argument, installs the latest published
 release. With a tag argument, pins that version.
 
-If `$ARGUMENTS` is empty:
-
-!`aidev upgrade --yes`
-
-Otherwise:
-
-!`aidev upgrade --version "$ARGUMENTS" --yes`
+!`if [ -z "$ARGUMENTS" ]; then aidev upgrade --yes; else aidev upgrade --version "$ARGUMENTS" --yes; fi`
 
 After the swap completes, the running Claude Code session is still using
 the old binary in memory — but the next `aidev` invocation (any new

--- a/plugin/aidev/commands/aidev-ls.md
+++ b/plugin/aidev/commands/aidev-ls.md
@@ -6,13 +6,11 @@ allowed-tools: Bash(aidev:*)
 Show the user which aidev version is installed locally plus the most
 recent published releases on GitHub.
 
-With no argument:
+- No argument → list defaults.
+- Numeric argument → treat as `--limit N`.
+- Anything else (e.g. `--all`, `-all`) → pass through as flags.
 
-!`aidev ls`
-
-With a numeric argument (interpreted as a limit):
-
-!`aidev ls --limit "$ARGUMENTS"`
+!`if [ -z "$ARGUMENTS" ]; then aidev ls; elif printf '%s' "$ARGUMENTS" | grep -qE '^[0-9]+$'; then aidev ls --limit "$ARGUMENTS"; else aidev ls $ARGUMENTS; fi`
 
 The legend at the bottom of the output explains the markers:
 

--- a/plugin/aidev/commands/aidev-upgrade.md
+++ b/plugin/aidev/commands/aidev-upgrade.md
@@ -6,13 +6,7 @@ allowed-tools: Bash(aidev:*)
 Run aidev's self-update. With no argument, installs the latest published
 release. With a tag argument, pins that version.
 
-If `$ARGUMENTS` is empty:
-
-!`aidev upgrade --yes`
-
-Otherwise:
-
-!`aidev upgrade --version "$ARGUMENTS" --yes`
+!`if [ -z "$ARGUMENTS" ]; then aidev upgrade --yes; else aidev upgrade --version "$ARGUMENTS" --yes; fi`
 
 After the swap completes, the running Claude Code session is still using
 the old binary in memory — but the next `aidev` invocation (any new


### PR DESCRIPTION
## Summary

- `/aidev-ls` and `/aidev-upgrade` shipped in v0.6.0 with two `!` backtick blocks each
- Claude Code's slash-command engine evaluates only the last `!` block, so no-arg invocations always ran the with-arg form
- `/aidev-ls` → `aidev ls --limit ""` → flag parser rejects empty (4× failure in user transcript)
- `/aidev-upgrade` had the same shape

Fix: collapse each command to one conditional `!` block that branches on `$ARGUMENTS`.

`/aidev-ls` now also pass-through-routes non-numeric args (e.g. `-all`, `--all`) instead of coercing them into `--limit`.

## Test plan

- [x] `go test ./...` green across all packages (incl. `internal/plugin` which validates embedded files)
- [x] Patched local `~/.claude/commands/` copies in the live session — `/aidev-ls` (no arg) now produces correct output